### PR TITLE
Fix flaky CI test: seed RNG and strengthen add_remove_edge assertion

### DIFF
--- a/tests/test_graph_model.py
+++ b/tests/test_graph_model.py
@@ -21,13 +21,12 @@ def test_calculate_spectrum_sorted_nonnegative():
 
 
 def test_add_remove_edge_changes_edge_count():
-    gm = GraphModel(n=12, d=1, sigma=0.0, er_p=0.1)
-    before = np.sum(np.triu(gm.graph))
-    for _ in range(10):
+    gm = GraphModel(n=12, d=1, sigma=0.0, er_p=0.1, seed=42)
+    counts = {int(np.sum(np.triu(gm.graph)))}
+    for _ in range(200):
         gm.add_remove_edge()
-    after = np.sum(np.triu(gm.graph))
-    # Probabilistic, but across 10 steps should change at least sometimes
-    assert before != after or np.sum(gm.graph) in [0, gm.graph.size]
+        counts.add(int(np.sum(np.triu(gm.graph))))
+    assert len(counts) > 1, "Edge count never changed across 200 steps"
 
 
 def test_convergence_checks_do_not_crash():


### PR DESCRIPTION
## Summary

- `test_add_remove_edge_changes_edge_count` was failing on Python 3.11 in CI after the merge of #15
- Root cause: no RNG seed + only 10 MCMC steps + weak before/after comparison — by chance, edges added and removed cancelled out, leaving the upper-triangle count unchanged

## Changes

- Add `seed=42` to `GraphModel` instantiation so the test is deterministic
- Increase from 10 to 200 steps and track whether the edge count ever changes (not just before vs. after)

## Test plan

- [x] `pytest tests/test_graph_model.py::test_add_remove_edge_changes_edge_count` passes locally on Python 3.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)