### PR TITLE
Expand core-method + API unit test coverage (92 → 211 tests)

### DIFF
--- a/tests/test_degrees_counts_deeper.py
+++ b/tests/test_degrees_counts_deeper.py
@@ -1,0 +1,81 @@
+"""Edge-case coverage for degree-counting primitives."""
+import numpy as np
+
+from logit_graph.degrees_counts import degree_vertex, get_sum_degrees
+
+
+def _adj(n, edges):
+    g = np.zeros((n, n), dtype=int)
+    for i, j in edges:
+        g[i, j] = g[j, i] = 1
+    return g
+
+
+def test_degree_vertex_isolated_returns_zero_at_all_depths():
+    # vertex 2 is isolated; the other edge is (0,1)
+    adj = _adj(3, [(0, 1)])
+    for d in range(5):
+        assert degree_vertex(adj, 2, d=d) == [0.0]
+
+
+def test_get_sum_degrees_isolated_vertex_is_zero():
+    adj = _adj(3, [(0, 1)])
+    for d in range(4):
+        assert get_sum_degrees(adj, 2, d=d) == 0.0
+
+
+def test_degree_vertex_complete_graph_all_degrees_equal():
+    n = 5
+    adj = (np.ones((n, n), dtype=int) - np.eye(n, dtype=int))
+    for v in range(n):
+        # d=0 returns [deg(v)]
+        assert degree_vertex(adj, v, d=0) == [float(n - 1)]
+        # d=1 returns deg(v) + degs of n-1 neighbors → list of length n
+        d1 = degree_vertex(adj, v, d=1)
+        assert len(d1) == n
+        assert all(x == float(n - 1) for x in d1)
+
+
+def test_get_sum_degrees_complete_graph_d1():
+    n = 4
+    adj = (np.ones((n, n), dtype=int) - np.eye(n, dtype=int))
+    # Each node deg n-1; d=1 ball covers all n nodes → sum = n*(n-1)
+    assert get_sum_degrees(adj, 0, d=1) == float(n * (n - 1))
+
+
+def test_degree_vertex_path_d0_equals_individual_degree():
+    # Path 0-1-2-3-4: degrees 1,2,2,2,1
+    adj = _adj(5, [(0, 1), (1, 2), (2, 3), (3, 4)])
+    expected = [1, 2, 2, 2, 1]
+    for v, deg in enumerate(expected):
+        assert degree_vertex(adj, v, d=0) == [float(deg)]
+
+
+def test_degree_vertex_cycle_d1_and_d2():
+    # 4-cycle: every degree 2
+    adj = _adj(4, [(0, 1), (1, 2), (2, 3), (3, 0)])
+    # d=1 from vertex 0: includes vertex 0 + 2 neighbors (1, 3)
+    d1 = degree_vertex(adj, 0, d=1)
+    assert sorted(d1) == [2.0, 2.0, 2.0]
+    # d=2: reaches all 4 nodes (vertex 2 via either side)
+    d2 = degree_vertex(adj, 0, d=2)
+    assert sorted(d2) == [2.0, 2.0, 2.0, 2.0]
+
+
+def test_degree_vertex_disconnected_components_stops_at_boundary():
+    # Two disjoint triangles
+    adj = _adj(6, [(0, 1), (1, 2), (0, 2), (3, 4), (4, 5), (3, 5)])
+    # BFS from vertex 0 cannot reach the other triangle even at large d
+    result = degree_vertex(adj, 0, d=10)
+    assert sorted(result) == [2.0, 2.0, 2.0]
+
+
+def test_get_sum_degrees_matches_sum_of_degree_vertex_random_graph():
+    rng = np.random.default_rng(42)
+    n = 12
+    upper = rng.random((n, n)) < 0.25
+    upper = np.triu(upper, k=1)
+    adj = (upper | upper.T).astype(int)
+    for v in range(n):
+        for d in range(4):
+            assert get_sum_degrees(adj, v, d) == float(sum(degree_vertex(adj, v, d)))

--- a/tests/test_gic_core.py
+++ b/tests/test_gic_core.py
@@ -1,0 +1,122 @@
+"""Tests for the Graph Information Criterion (cross-family model selection)."""
+import math
+
+import networkx as nx
+import numpy as np
+import pytest
+
+from logit_graph.gic import GraphInformationCriterion
+
+
+def _er(n, p, seed):
+    return nx.erdos_renyi_graph(n, p, seed=seed)
+
+
+# -------------------------------------------------------------------
+# compute_spectral_density
+# -------------------------------------------------------------------
+
+def test_spectral_density_returns_50_bins_in_0_2():
+    g = _er(30, 0.2, seed=0)
+    gic = GraphInformationCriterion(g, model="ER", p=0.2)
+    hist, edges = gic.compute_spectral_density(g)
+    assert hist.shape == (50,)
+    assert edges.shape == (51,)
+    # Bin edges span [0, 2] (range of normalized Laplacian eigenvalues)
+    assert math.isclose(edges[0], 0.0)
+    assert math.isclose(edges[-1], 2.0)
+
+
+def test_spectral_density_is_normalized():
+    g = _er(40, 0.25, seed=1)
+    gic = GraphInformationCriterion(g, model="ER", p=0.25)
+    hist, edges = gic.compute_spectral_density(g)
+    bin_width = edges[1] - edges[0]
+    # density=True ⇒ integrates to 1 over the bin range
+    assert math.isclose(hist.sum() * bin_width, 1.0, abs_tol=1e-9)
+
+
+# -------------------------------------------------------------------
+# calculate_spectral_distance — KL vs same graph is near zero
+# -------------------------------------------------------------------
+
+def test_kl_distance_to_self_near_zero():
+    g = _er(40, 0.2, seed=2)
+    gic = GraphInformationCriterion(g, model="ER", p=0.2)
+    own_density, _ = gic.compute_spectral_density(g)
+    d = gic.calculate_spectral_distance(model_den=own_density)
+    assert d < 1e-8
+
+
+def test_kl_distance_to_very_different_graph_is_large():
+    # Sparse ER vs dense complete-ish graph
+    g_sparse = _er(40, 0.05, seed=3)
+    g_dense = _er(40, 0.9, seed=4)
+    gic = GraphInformationCriterion(g_sparse, model="ER", p=0.05)
+    dense_density, _ = gic.compute_spectral_density(g_dense)
+    sparse_density, _ = gic.compute_spectral_density(g_sparse)
+    d_diff = gic.calculate_spectral_distance(model_den=dense_density)
+    d_same = gic.calculate_spectral_distance(model_den=sparse_density)
+    assert d_diff > d_same
+
+
+# -------------------------------------------------------------------
+# Distance metrics: KL, L1, L2 all non-negative
+# -------------------------------------------------------------------
+
+@pytest.mark.parametrize("dist", ["KL", "L1", "L2"])
+def test_distance_metrics_non_negative(dist):
+    g = _er(30, 0.2, seed=5)
+    gic = GraphInformationCriterion(g, model="ER", p=0.2, dist=dist)
+    hist, _ = gic.compute_spectral_density(g)
+    d = gic.calculate_spectral_distance(model_den=hist)
+    assert d >= 0.0
+
+
+def test_unsupported_distance_raises():
+    g = _er(20, 0.2, seed=6)
+    gic = GraphInformationCriterion(g, model="ER", p=0.2, dist="cosine")
+    with pytest.raises(ValueError):
+        gic.calculate_spectral_distance(model_den=np.ones(50) / 50)
+
+
+# -------------------------------------------------------------------
+# calculate_gic — formula and penalty
+# -------------------------------------------------------------------
+
+def test_gic_equals_two_dist_plus_two_n_params():
+    g = _er(30, 0.2, seed=7)
+    gic = GraphInformationCriterion(g, model="ER", p=0.2)
+    own_density, _ = gic.compute_spectral_density(g)
+    dist = gic.calculate_spectral_distance(model_den=own_density)
+    gic_val = gic.calculate_gic(model_den=own_density)
+    # ER has 1 parameter (the edge probability)
+    assert math.isclose(gic_val, 2.0 * dist + 2.0 * 1)
+
+
+def test_gic_explicit_n_params_overrides_default():
+    g = _er(30, 0.2, seed=8)
+    gic = GraphInformationCriterion(g, model="ER", p=0.2)
+    own_density, _ = gic.compute_spectral_density(g)
+    gic_1 = gic.calculate_gic(model_den=own_density, n_params=1)
+    gic_3 = gic.calculate_gic(model_den=own_density, n_params=3)
+    # Difference is 2 * (3 - 1) = 4
+    assert math.isclose(gic_3 - gic_1, 4.0)
+
+
+# -------------------------------------------------------------------
+# generate_model_graph dispatch
+# -------------------------------------------------------------------
+
+def test_generate_model_graph_er():
+    g = _er(20, 0.3, seed=9)
+    gic = GraphInformationCriterion(g, model="ER", p=0.3)
+    out = gic.generate_model_graph()
+    assert out.number_of_nodes() == 20
+
+
+def test_generate_model_graph_unknown_model_raises():
+    g = _er(15, 0.2, seed=10)
+    gic = GraphInformationCriterion(g, model=123, p=0.2)  # invalid type
+    with pytest.raises(ValueError):
+        gic.generate_model_graph()

--- a/tests/test_graph_model_deeper.py
+++ b/tests/test_graph_model_deeper.py
@@ -1,0 +1,136 @@
+"""Deeper coverage of the GraphModel generator + utility methods.
+
+Existing tests/test_graph_model.py covers smoke + convergence integration.
+This file targets the constructor, edge probability, spectrum, and core
+invariants of generated graphs.
+"""
+import math
+
+import numpy as np
+import networkx as nx
+import pytest
+
+from logit_graph.graph import GraphModel
+
+
+# -------------------------------------------------------------------
+# Construction & init
+# -------------------------------------------------------------------
+
+def test_default_init_creates_er_graph_at_er_p():
+    n, er_p = 80, 0.1
+    m = GraphModel(n=n, d=0, sigma=-2.0, er_p=er_p, seed=42)
+    # Initial graph density is close to er_p
+    density = m.graph.sum() / (n * (n - 1))
+    assert abs(density - er_p) < 0.05
+    assert m.graph.shape == (n, n)
+
+
+def test_init_with_explicit_init_graph_uses_it():
+    n = 10
+    G = nx.path_graph(n)  # path → n-1 edges
+    m = GraphModel(n=n, d=1, sigma=-2.0, init_graph=G, seed=0)
+    assert int(m.graph.sum() / 2) == n - 1
+
+
+def test_init_creates_symmetric_no_self_loops():
+    m = GraphModel(n=30, d=1, sigma=-2.0, er_p=0.15, seed=1)
+    np.testing.assert_array_equal(m.graph, m.graph.T)
+    assert np.all(np.diag(m.graph) == 0)
+
+
+def test_default_feature_mode_is_incremental():
+    m = GraphModel(n=10, d=1, sigma=-2.0, seed=0)
+    assert m.feature_mode == "incremental"
+
+
+def test_default_alpha_beta_layer2():
+    m = GraphModel(n=10, d=1, sigma=-2.0, seed=0)
+    assert m.alpha == 1
+    assert m.beta == 1
+    assert m.layer2 is True
+
+
+def test_seed_determinism_initial_graph():
+    m1 = GraphModel(n=30, d=1, sigma=-2.0, er_p=0.2, seed=99)
+    m2 = GraphModel(n=30, d=1, sigma=-2.0, er_p=0.2, seed=99)
+    np.testing.assert_array_equal(m1.graph, m2.graph)
+
+
+def test_different_seeds_produce_different_graphs():
+    m1 = GraphModel(n=30, d=1, sigma=-2.0, er_p=0.2, seed=1)
+    m2 = GraphModel(n=30, d=1, sigma=-2.0, er_p=0.2, seed=2)
+    assert not np.array_equal(m1.graph, m2.graph)
+
+
+# -------------------------------------------------------------------
+# logistic_regression / edge probability
+# -------------------------------------------------------------------
+
+def test_logistic_regression_returns_expit():
+    m = GraphModel(n=5, d=0, sigma=-1.0, seed=0)
+    # The method just calls expit on its argument
+    from scipy.special import expit
+    for x in (-5.0, -1.0, 0.0, 1.0, 5.0):
+        assert math.isclose(m.logistic_regression(x), float(expit(x)))
+
+
+def test_logistic_regression_is_in_unit_interval():
+    m = GraphModel(n=5, d=0, sigma=-1.0, seed=0)
+    for x in (-100.0, -1.0, 0.0, 1.0, 100.0):
+        p = m.logistic_regression(x)
+        assert 0.0 <= p <= 1.0
+
+
+# -------------------------------------------------------------------
+# generate_empty_graph / generate_small_er_graph
+# -------------------------------------------------------------------
+
+def test_generate_empty_graph_has_no_edges():
+    m = GraphModel(n=10, d=0, sigma=-2.0, seed=0)
+    G = m.generate_empty_graph(15)
+    assert G.shape == (15, 15)
+    assert G.sum() == 0
+
+
+def test_generate_small_er_graph_density_close_to_p():
+    m = GraphModel(n=10, d=0, sigma=-2.0, er_p=0.05, seed=42)
+    # Generate a larger ER directly via the instance method
+    G = m.generate_small_er_graph(80, p=0.3)
+    density = G.sum() / (80 * 79)
+    assert abs(density - 0.3) < 0.06
+    # Symmetric, no self-loops
+    np.testing.assert_array_equal(G, G.T)
+    assert np.all(np.diag(G) == 0)
+
+
+# -------------------------------------------------------------------
+# calculate_spectrum
+# -------------------------------------------------------------------
+
+def test_calculate_spectrum_sorted_and_non_negative():
+    rng = np.random.default_rng(0)
+    n = 12
+    upper = rng.random((n, n)) < 0.3
+    upper = np.triu(upper, k=1)
+    adj = (upper | upper.T).astype(float)
+    eig = GraphModel.calculate_spectrum(adj)
+    assert eig.shape == (n,)
+    assert np.all(np.diff(eig) >= -1e-12)  # sorted ascending
+    # Laplacian eigenvalues are non-negative (allow tiny FP noise)
+    assert np.all(eig >= -1e-9)
+
+
+def test_calculate_spectrum_zero_eigenvalue_for_connected_or_disconnected():
+    # Any undirected graph's Laplacian has 0 as an eigenvalue with
+    # multiplicity = number of connected components.
+    n = 8
+    # Two disconnected triangles + 2 isolated → 4 components
+    edges = [(0, 1), (1, 2), (0, 2), (3, 4), (4, 5), (3, 5)]
+    adj = np.zeros((n, n), dtype=float)
+    for i, j in edges:
+        adj[i, j] = adj[j, i] = 1.0
+    eig = GraphModel.calculate_spectrum(adj)
+    # 4 components → 4 zero eigenvalues
+    near_zero = np.sum(np.abs(eig) < 1e-9)
+    assert near_zero == 4

--- a/tests/test_lg_features_core.py
+++ b/tests/test_lg_features_core.py
@@ -1,0 +1,183 @@
+"""Correctness tests for the lg_features primitives (Python paths only)."""
+import math
+
+import numpy as np
+import networkx as nx
+import pytest
+
+from logit_graph.lg_features import (
+    ALPHA_GWESP_DEFAULT,
+    build_pair_dataset,
+    common_dhop_count,
+    incremental_h,
+    pair_feature,
+    pair_feature_layer2,
+    precompute_vertex_sums,
+    recommended_iterations,
+    sum_degree,
+)
+
+
+def _adj(n, edges):
+    g = np.zeros((n, n), dtype=float)
+    for i, j in edges:
+        g[i, j] = g[j, i] = 1.0
+    return g
+
+
+# -------------------------------------------------------------------
+# recommended_iterations
+# -------------------------------------------------------------------
+
+def test_recommended_iterations_floor_when_small_n():
+    # For very small n the 20_000 floor wins over 5*n*(n-1)
+    assert recommended_iterations(10) == 20_000
+
+
+def test_recommended_iterations_scales_quadratically_for_large_n():
+    assert recommended_iterations(100) == 5 * 100 * 99
+    assert recommended_iterations(500) == 5 * 500 * 499
+
+
+def test_recommended_iterations_cap_clips_below_floor():
+    # If user caps at 5_000, result is 5_000 (cap takes precedence over the 20k floor)
+    assert recommended_iterations(100, cap=5_000) == 5_000
+
+
+def test_recommended_iterations_cap_above_formula_returns_formula():
+    assert recommended_iterations(100, cap=10_000_000) == 5 * 100 * 99
+
+
+# -------------------------------------------------------------------
+# common_dhop_count
+# -------------------------------------------------------------------
+
+def test_common_dhop_count_d0_is_zero():
+    adj = _adj(3, [(0, 1), (1, 2), (0, 2)])
+    assert common_dhop_count(adj, 0, 1, d=0) == 0
+
+
+def test_common_dhop_count_triangle_d1():
+    # Triangle 0-1-2: (0,1) share neighbor 2
+    adj = _adj(3, [(0, 1), (1, 2), (0, 2)])
+    assert common_dhop_count(adj, 0, 1, d=1) == 1
+
+
+def test_common_dhop_count_no_shared_neighbors():
+    # Two disjoint edges → (0,2) share no neighbor
+    adj = _adj(4, [(0, 1), (2, 3)])
+    assert common_dhop_count(adj, 0, 2, d=1) == 0
+
+
+# -------------------------------------------------------------------
+# incremental_h
+# -------------------------------------------------------------------
+
+def test_incremental_h_d0_returns_zero():
+    adj = _adj(3, [(0, 1), (1, 2)])
+    assert incremental_h(adj, 0, 1, d=0) == 0.0
+
+
+def test_incremental_h_d1_matches_gwesp_formula():
+    # Triangle: (0,1) have 1 common neighbor; check GWESP closed-form
+    adj = _adj(3, [(0, 1), (1, 2), (0, 2)])
+    alpha = ALPHA_GWESP_DEFAULT
+    c = 1
+    expected = alpha * (1.0 - (1.0 - 1.0 / alpha) ** c)
+    assert math.isclose(incremental_h(adj, 0, 1, d=1), expected)
+
+
+def test_incremental_h_no_common_neighbor_is_zero():
+    adj = _adj(4, [(0, 1), (2, 3)])
+    assert incremental_h(adj, 0, 2, d=1) == 0.0
+
+
+# -------------------------------------------------------------------
+# pair_feature modes
+# -------------------------------------------------------------------
+
+def test_pair_feature_paper_raw_sums_d_hop_degrees():
+    # Path 0-1-2: vertex 0 has d=1 ball {0,1}; degrees 1+2=3.
+    # vertex 2 has d=1 ball {2,1}; degrees 1+2=3.
+    adj = _adj(3, [(0, 1), (1, 2)])
+    assert pair_feature(adj, 0, 2, d=1, mode="paper_raw") == 6.0
+
+
+def test_pair_feature_bounded_is_log1p_of_sums():
+    adj = _adj(3, [(0, 1), (1, 2)])
+    f = pair_feature(adj, 0, 2, d=1, mode="bounded")
+    assert math.isclose(f, 2 * math.log(4.0))
+
+
+def test_pair_feature_common_dhop_log_form():
+    # Triangle: common neighbor count = 1; mode returns log(1 + 1)
+    adj = _adj(3, [(0, 1), (1, 2), (0, 2)])
+    assert math.isclose(
+        pair_feature(adj, 0, 1, d=1, mode="common_dhop"),
+        math.log(2.0),
+    )
+
+
+def test_pair_feature_unknown_mode_raises():
+    adj = _adj(3, [(0, 1)])
+    with pytest.raises(ValueError):
+        pair_feature(adj, 0, 1, d=1, mode="bogus")
+
+
+# -------------------------------------------------------------------
+# pair_feature_layer2
+# -------------------------------------------------------------------
+
+def test_pair_feature_layer2_drops_edge_when_present():
+    # Triangle; remove edge (0,1) → degrees of 0 and 1 drop
+    adj = _adj(3, [(0, 1), (1, 2), (0, 2)])
+    f_full = pair_feature(adj, 0, 1, d=1, mode="paper_raw")
+    f_l2 = pair_feature_layer2(adj, 0, 1, d=1, mode="paper_raw")
+    assert f_l2 < f_full
+
+
+def test_pair_feature_layer2_unchanged_when_edge_absent():
+    # No edge (0,2)
+    adj = _adj(3, [(0, 1), (1, 2)])
+    f_full = pair_feature(adj, 0, 2, d=1, mode="paper_raw")
+    f_l2 = pair_feature_layer2(adj, 0, 2, d=1, mode="paper_raw")
+    assert math.isclose(f_full, f_l2)
+
+
+# -------------------------------------------------------------------
+# precompute_vertex_sums
+# -------------------------------------------------------------------
+
+def test_precompute_vertex_sums_matches_per_vertex_calls():
+    rng = np.random.default_rng(0)
+    n = 8
+    upper = rng.random((n, n)) < 0.3
+    upper = np.triu(upper, k=1)
+    adj = (upper | upper.T).astype(float)
+    for d in [1, 2]:
+        sums = precompute_vertex_sums(adj, d)
+        for v in range(n):
+            assert math.isclose(sums[v], sum_degree(adj, v, d))
+
+
+# -------------------------------------------------------------------
+# build_pair_dataset
+# -------------------------------------------------------------------
+
+def test_build_pair_dataset_shapes_and_label_invariant():
+    adj = nx.to_numpy_array(nx.erdos_renyi_graph(10, 0.3, seed=1))
+    offsets, labels = build_pair_dataset(adj, d=1, mode="bounded", layer2=True)
+    # n choose 2 = 45 pairs
+    assert offsets.shape == (45,)
+    assert labels.shape == (45,)
+    # Labels are binary and their sum equals the edge count
+    assert set(np.unique(labels).tolist()).issubset({0, 1})
+    assert int(labels.sum()) == int(adj.sum() / 2)
+
+
+def test_build_pair_dataset_deterministic():
+    adj = nx.to_numpy_array(nx.erdos_renyi_graph(10, 0.3, seed=42))
+    o1, l1 = build_pair_dataset(adj, d=1, mode="bounded", layer2=True)
+    o2, l2 = build_pair_dataset(adj, d=1, mode="bounded", layer2=True)
+    np.testing.assert_array_equal(o1, o2)
+    np.testing.assert_array_equal(l1, l2)

--- a/tests/test_logit_estimator_api.py
+++ b/tests/test_logit_estimator_api.py
@@ -1,0 +1,134 @@
+"""API coverage for LogitRegEstimator (the public estimator class)."""
+import math
+
+import numpy as np
+import networkx as nx
+import pytest
+
+from logit_graph.logit_estimator import LogitRegEstimator
+
+
+def _er(n, p, seed):
+    return nx.to_numpy_array(nx.erdos_renyi_graph(n, p, seed=seed))
+
+
+# -------------------------------------------------------------------
+# Construction
+# -------------------------------------------------------------------
+
+def test_accepts_numpy_adjacency():
+    adj = _er(20, 0.2, seed=0)
+    est = LogitRegEstimator(adj, d=1)
+    assert est.n == 20
+    assert est.adj is adj
+
+
+def test_accepts_networkx_graph():
+    G = nx.erdos_renyi_graph(15, 0.2, seed=1)
+    est = LogitRegEstimator(G, d=1)
+    assert est.n == 15
+    assert isinstance(est.adj, np.ndarray)
+    assert est.adj.shape == (15, 15)
+
+
+def test_invalid_graph_type_raises():
+    with pytest.raises(ValueError):
+        LogitRegEstimator("not a graph", d=1)
+
+
+def test_default_feature_mode_is_incremental():
+    est = LogitRegEstimator(_er(10, 0.3, seed=2), d=1)
+    assert est.feature_mode == "incremental"
+
+
+# -------------------------------------------------------------------
+# get_features_labels
+# -------------------------------------------------------------------
+
+def test_get_features_labels_shapes():
+    adj = _er(12, 0.25, seed=3)
+    est = LogitRegEstimator(adj, d=1, feature_mode="bounded")
+    features, labels = est.get_features_labels()
+    # n*(n-1)/2 = 66 pairs
+    assert features.shape == (66, 2)  # statsmodels adds constant column
+    assert len(labels) == 66
+
+
+def test_get_features_labels_label_count_matches_edges():
+    adj = _er(10, 0.4, seed=4)
+    est = LogitRegEstimator(adj, d=1, feature_mode="bounded")
+    _, labels = est.get_features_labels()
+    assert sum(labels) == int(adj.sum() / 2)
+
+
+# -------------------------------------------------------------------
+# compute_aic — return shape and basic correctness
+# -------------------------------------------------------------------
+
+def test_compute_aic_returns_finite_with_expected_keys():
+    adj = _er(20, 0.2, seed=5)
+    est = LogitRegEstimator(adj, d=1)
+    stats = est.compute_aic()
+    # Keys returned by aic_from_offset_fit + d_est, n_obs
+    for key in ("aic", "ll", "k", "sigma_hat", "d_est", "n_obs"):
+        assert key in stats
+    assert math.isfinite(stats["aic"])
+    assert math.isfinite(stats["sigma_hat"])
+    assert stats["k"] == 1.0
+    assert stats["n_obs"] == 20 * 19 / 2
+
+
+def test_compute_aic_d_est_override_changes_d():
+    adj = _er(20, 0.2, seed=6)
+    est = LogitRegEstimator(adj, d=1)
+    s1 = est.compute_aic(d_est=1)
+    s2 = est.compute_aic(d_est=2)
+    assert s1["d_est"] == 1.0
+    assert s2["d_est"] == 2.0
+
+
+def test_compute_aic_extra_penalty_increases_aic():
+    adj = _er(20, 0.2, seed=7)
+    est = LogitRegEstimator(adj, d=1)
+    no_pen = est.compute_aic(extra_penalty=0.0)
+    with_pen = est.compute_aic(extra_penalty=5.0)
+    assert with_pen["aic"] == no_pen["aic"] + 5.0
+    # Penalty does not affect sigma_hat or ll
+    assert with_pen["sigma_hat"] == no_pen["sigma_hat"]
+    assert with_pen["ll"] == no_pen["ll"]
+
+
+# -------------------------------------------------------------------
+# select_d
+# -------------------------------------------------------------------
+
+def test_select_d_returns_d_in_candidates():
+    adj = _er(25, 0.15, seed=8)
+    est = LogitRegEstimator(adj, d=1)
+    best, stats = est.select_d(d_candidates=[0, 1, 2])
+    assert best in (0, 1, 2)
+    assert set(stats.keys()) == {0, 1, 2}
+
+
+def test_select_d_picks_argmin_aic():
+    adj = _er(25, 0.15, seed=9)
+    est = LogitRegEstimator(adj, d=1)
+    best, stats = est.select_d(d_candidates=[0, 1, 2, 3])
+    chosen_aic = stats[best]["aic"]
+    for d, s in stats.items():
+        assert chosen_aic <= s["aic"]
+
+
+# -------------------------------------------------------------------
+# Sigma recovery on synthetic ER (sigma ≡ logit(density) when d=0)
+# -------------------------------------------------------------------
+
+def test_sigma_hat_close_to_logit_density_on_ER_with_d0():
+    n, p = 100, 0.10
+    adj = _er(n, p, seed=10)
+    est = LogitRegEstimator(adj, d=0)
+    stats = est.compute_aic(d_est=0)
+    # For d=0 the feature mode contributes nothing → sigma_hat ≈ logit(empirical density)
+    emp_density = adj.sum() / (n * (n - 1))
+    expected = math.log(emp_density / (1 - emp_density))
+    assert abs(stats["sigma_hat"] - expected) < 0.05

--- a/tests/test_model_selection_core.py
+++ b/tests/test_model_selection_core.py
@@ -1,0 +1,146 @@
+"""Coverage for the three model-selection classes."""
+import io
+import contextlib
+
+import networkx as nx
+import pytest
+
+from logit_graph.model_selection import (
+    GraphModelSelection,
+    ModelSelectorSpectrum,
+    RandomGraphModelSelector,
+)
+
+
+def _er(n, p, seed):
+    return nx.erdos_renyi_graph(n, p, seed=seed)
+
+
+def _silent(fn, *args, **kwargs):
+    """Run fn with stdout suppressed (the selectors print verbose progress)."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        return fn(*args, **kwargs)
+
+
+# -------------------------------------------------------------------
+# RandomGraphModelSelector
+# -------------------------------------------------------------------
+
+def test_random_selector_fit_returns_best_model_in_candidates():
+    real = _er(30, 0.2, seed=0)
+    lg = _er(30, 0.2, seed=1)  # stand-in for an LG graph
+    sel = RandomGraphModelSelector(real, lg)
+    best, scores = _silent(sel.fit)
+    assert best in {"ER", "WS", "BA", "LG"}
+    assert set(scores.keys()).issubset({"ER", "WS", "BA", "LG"})
+    # scores are floats, lower is better
+    for v in scores.values():
+        assert isinstance(v, float)
+
+
+def test_random_selector_evaluate_model_returns_float():
+    real = _er(20, 0.2, seed=0)
+    sel = RandomGraphModelSelector(real, _er(20, 0.2, seed=1))
+    score = _silent(sel.evaluate_model, _er(20, 0.2, seed=2))
+    assert isinstance(score, float)
+    assert score >= 0.0  # All components (ks, |Δclust|, |Δaspl|) are non-negative
+
+
+def test_random_selector_score_smaller_for_similar_graphs():
+    real = _er(30, 0.2, seed=0)
+    # Same-distribution graph should score lower than a very different one
+    similar = _er(30, 0.2, seed=5)
+    different = _er(30, 0.6, seed=6)  # much denser
+    sel = RandomGraphModelSelector(real, similar)
+    s_sim = _silent(sel.evaluate_model, similar)
+    s_diff = _silent(sel.evaluate_model, different)
+    assert s_sim < s_diff
+
+
+# -------------------------------------------------------------------
+# ModelSelectorSpectrum
+# -------------------------------------------------------------------
+
+def test_spectrum_selector_kl_to_self_is_zero():
+    real = _er(25, 0.2, seed=0)
+    sel = ModelSelectorSpectrum(real, _er(25, 0.2, seed=1))
+    sp = sel.graph_spectrum(real)
+    kl = sel.kl_divergence(sp, sp)
+    assert abs(kl) < 1e-9
+
+
+def test_spectrum_selector_kl_non_negative_between_different_graphs():
+    real = _er(25, 0.2, seed=0)
+    sel = ModelSelectorSpectrum(real, _er(25, 0.2, seed=1))
+    s1 = sel.graph_spectrum(_er(25, 0.2, seed=2))
+    s2 = sel.graph_spectrum(_er(25, 0.5, seed=3))
+    assert sel.kl_divergence(s1, s2) >= 0.0
+
+
+def test_spectrum_model_penalty_known_models():
+    sel = ModelSelectorSpectrum(_er(10, 0.2, seed=0), _er(10, 0.2, seed=1))
+    assert sel.model_penalty("ER") == 1
+    assert sel.model_penalty("WS") == 2
+    assert sel.model_penalty("BA") == 1
+    assert sel.model_penalty("LG") == 3
+    assert sel.model_penalty("UNKNOWN") == 0
+
+
+def test_spectrum_selector_fit_returns_best_model():
+    real = _er(25, 0.2, seed=0)
+    sel = ModelSelectorSpectrum(real, _er(25, 0.2, seed=1))
+    best, scores = _silent(sel.fit)
+    assert best in scores
+    assert set(scores.keys()).issubset({"ER", "WS", "BA", "LG"})
+
+
+# -------------------------------------------------------------------
+# GraphModelSelection (high-level avg-spectrum / avg-GIC selectors)
+# -------------------------------------------------------------------
+
+def _make_selection(n=20, seed=0):
+    G = _er(n, 0.2, seed=seed)
+    return GraphModelSelection(
+        graph=G,
+        log_graphs=[G],
+        log_params=[0.1],
+        models=["ER", "BA"],
+        parameters=[{"lo": 0.05, "hi": 0.3}, {"lo": 1, "hi": 3}],
+        n_runs=2,
+        grid_points=3,
+    )
+
+
+def test_graph_model_selection_avg_spectrum_returns_estimates_per_model():
+    sel = _make_selection()
+    out = _silent(sel.select_model_avg_spectrum)
+    assert "model" in out and "estimates" in out
+    assert out["model"] in {"ER", "BA"}
+    assert len(out["estimates"]) == 2
+
+
+def test_graph_model_selection_validate_input_models_length_matches_parameters():
+    sel = _make_selection()
+    # Construction completes without error if lengths match
+    sel.validate_input()
+
+
+def test_graph_model_selection_model_function_returns_callable_for_known_model():
+    sel = _make_selection()
+    fn = sel.model_function("ER")
+    assert callable(fn)
+
+
+def test_graph_model_selection_seed_offset_advances_state():
+    sel = _make_selection(seed=42)
+    # Two distinct seed offsets should be allowed without error
+    sel._run_seed(0)
+    sel._run_seed(1)
+    # Just smoke — internal state is reset per call
+
+
+def test_graph_model_selection_unknown_model_raises():
+    sel = _make_selection()
+    with pytest.raises(ValueError):
+        sel.model_function("DEFINITELY_NOT_A_MODEL")

--- a/tests/test_offset_logit_core.py
+++ b/tests/test_offset_logit_core.py
@@ -1,0 +1,147 @@
+"""Edge cases + regression coverage for the offset-logit MLE."""
+import math
+
+import numpy as np
+import statsmodels.api as sm
+
+from logit_graph.offset_logit import (
+    aic_from_offset_fit,
+    fit_offset_logit_fast,
+    fit_offset_logit_numba,
+)
+
+
+def _make_offsets_labels(n, sigma_true, offset_mean, offset_std, seed=0):
+    """Synthetic (offsets, labels) for logit(p) = sigma + offset."""
+    rng = np.random.default_rng(seed)
+    offsets = rng.normal(offset_mean, offset_std, size=n)
+    logits = sigma_true + offsets
+    p = 1.0 / (1.0 + np.exp(-logits))
+    labels = (rng.random(n) < p).astype(np.int8)
+    return offsets.astype(np.float64), labels
+
+
+# -------------------------------------------------------------------
+# Empty / degenerate inputs
+# -------------------------------------------------------------------
+
+def test_fit_empty_returns_zeros():
+    off = np.zeros(0, dtype=np.float64)
+    lab = np.zeros(0, dtype=np.int8)
+    sigma, ll = fit_offset_logit_numba(off, lab)
+    assert sigma == 0.0
+    assert ll == 0.0
+
+
+def test_fit_all_negatives_pushes_sigma_very_negative():
+    n = 100
+    off = np.zeros(n, dtype=np.float64)
+    lab = np.zeros(n, dtype=np.int8)
+    sigma, _ = fit_offset_logit_numba(off, lab)
+    # All zeros → p_hat clamped to 1e-15 → sigma very negative
+    assert sigma < -30.0
+
+
+def test_fit_all_positives_pushes_sigma_very_positive():
+    n = 100
+    off = np.zeros(n, dtype=np.float64)
+    lab = np.ones(n, dtype=np.int8)
+    sigma, _ = fit_offset_logit_numba(off, lab)
+    assert sigma > 30.0
+
+
+def test_fit_zero_offsets_recovers_empirical_density_logit():
+    # All offsets 0 → MLE collapses to sigma_hat = logit(empirical density)
+    n = 200
+    off = np.zeros(n, dtype=np.float64)
+    lab = np.zeros(n, dtype=np.int8)
+    lab[:50] = 1  # 25% positive
+    sigma, _ = fit_offset_logit_numba(off, lab)
+    assert math.isclose(sigma, math.log(0.25 / 0.75), abs_tol=1e-6)
+
+
+# -------------------------------------------------------------------
+# Regression: large mean offset used to cause Newton oscillation
+# -------------------------------------------------------------------
+
+def _score_at(sigma, offsets, labels):
+    """Score function: sum_i (y_i - p_i) where p_i = expit(sigma + offset_i)."""
+    linpred = sigma + offsets
+    # Use stable expit
+    p = np.where(linpred >= 0,
+                 1.0 / (1.0 + np.exp(-linpred)),
+                 np.exp(linpred) / (1.0 + np.exp(linpred)))
+    return float(np.sum(labels - p))
+
+
+def test_fit_large_positive_mean_offset_converges_to_score_zero():
+    """Pre-fix, sigma init = logit(p_hat) ≈ -3 with offsets ~ 4.5 caused
+    Newton to overshoot, clamp to ±10, then oscillate without finding the
+    MLE. The fix initializes sigma = logit(p_hat) - mean(offsets).
+
+    We don't compare to statsmodels here because the regime (most p_i near 1)
+    makes statsmodels' Hessian singular. Instead we verify the score
+    sum_i(y_i - p_i) is near zero at the returned sigma.
+    """
+    off, lab = _make_offsets_labels(
+        n=500, sigma_true=-3.0, offset_mean=4.5, offset_std=0.5, seed=42,
+    )
+    sigma, ll = fit_offset_logit_numba(off, lab)
+    assert math.isfinite(sigma) and math.isfinite(ll)
+    # MLE first-order condition for logistic: sum(y - p) = 0
+    assert abs(_score_at(sigma, off, lab)) < 1e-4
+
+
+def test_fit_large_negative_mean_offset_converges_to_score_zero():
+    off, lab = _make_offsets_labels(
+        n=500, sigma_true=-2.0, offset_mean=-3.5, offset_std=0.4, seed=7,
+    )
+    sigma, ll = fit_offset_logit_numba(off, lab)
+    assert math.isfinite(sigma) and math.isfinite(ll)
+    assert abs(_score_at(sigma, off, lab)) < 1e-4
+
+
+def test_fit_moderate_offsets_matches_statsmodels():
+    """Sanity check against statsmodels for a well-conditioned case."""
+    off, lab = _make_offsets_labels(
+        n=300, sigma_true=-1.5, offset_mean=0.5, offset_std=1.0, seed=3,
+    )
+    sigma, _ = fit_offset_logit_numba(off, lab)
+    result = sm.Logit(lab, np.ones((len(lab), 1)), offset=off).fit(disp=False)
+    sm_sigma = float(result.params[0])
+    assert abs(sigma - sm_sigma) < 0.05
+
+
+# -------------------------------------------------------------------
+# Wrappers and AIC helpers
+# -------------------------------------------------------------------
+
+def test_fit_offset_logit_fast_accepts_lists_and_equals_numba():
+    off, lab = _make_offsets_labels(
+        n=200, sigma_true=-2.5, offset_mean=1.0, offset_std=1.0, seed=1,
+    )
+    s_fast, ll_fast = fit_offset_logit_fast(off.tolist(), lab.tolist())
+    s_num, ll_num = fit_offset_logit_numba(off, lab)
+    assert s_fast == s_num
+    assert ll_fast == ll_num
+
+
+def test_aic_from_offset_fit_formula_no_penalty():
+    res = aic_from_offset_fit(sigma_hat=-3.0, log_likelihood=-100.0, k=1.0)
+    assert res["aic"] == 200.0 + 2.0  # -2*ll + 2*k
+    assert res["ll"] == -100.0
+    assert res["k"] == 1.0
+    assert res["sigma_hat"] == -3.0
+
+
+def test_aic_extra_penalty_added():
+    res_no = aic_from_offset_fit(-3.0, -100.0, extra_penalty=0.0)
+    res_yes = aic_from_offset_fit(-3.0, -100.0, extra_penalty=4.5)
+    assert math.isclose(res_yes["aic"] - res_no["aic"], 4.5)
+
+
+def test_aic_different_k_changes_penalty_term():
+    res_k1 = aic_from_offset_fit(-3.0, -50.0, k=1.0)
+    res_k3 = aic_from_offset_fit(-3.0, -50.0, k=3.0)
+    # difference is 2*(3 - 1) = 4
+    assert math.isclose(res_k3["aic"] - res_k1["aic"], 4.0)

--- a/tests/test_param_estimator.py
+++ b/tests/test_param_estimator.py
@@ -1,0 +1,108 @@
+"""Coverage for GraphParameterEstimator.
+
+Note: the module has a known constructor-ordering bug (``get_search_interval``
+is called before ``is_multi_param`` is assigned) which crashes whenever an
+explicit ``interval=`` is passed for a single-parameter model. We test only
+the code paths that do not trigger it; per CLAUDE.md §3, we don't refactor
+unrelated bugs.
+"""
+import math
+
+import networkx as nx
+import pytest
+
+from logit_graph.param_estimator import GraphParameterEstimator
+
+
+def _er(n, p, seed):
+    return nx.erdos_renyi_graph(n, p, seed=seed)
+
+
+# -------------------------------------------------------------------
+# get_model_function — pure dispatch
+# -------------------------------------------------------------------
+
+@pytest.mark.parametrize("model", ["ER", "GRG", "KR", "WS", "BA"])
+def test_get_model_function_returns_callable(model):
+    # Construct with WS (multi-param) avoids the interval-branch bug
+    G = _er(15, 0.3, seed=0)
+    est = GraphParameterEstimator(G, model="WS")  # default interval path
+    fn = est.get_model_function(model)
+    assert callable(fn)
+
+
+def test_get_model_function_unknown_raises():
+    G = _er(15, 0.3, seed=0)
+    est = GraphParameterEstimator(G, model="WS")
+    with pytest.raises(ValueError):
+        est.get_model_function("DEFINITELY_NOT_A_MODEL")
+
+
+# -------------------------------------------------------------------
+# Construction (default interval branches that don't touch is_multi_param)
+# -------------------------------------------------------------------
+
+def test_construct_er_default_interval_succeeds():
+    G = _er(15, 0.3, seed=0)
+    est = GraphParameterEstimator(G, model="ER")
+    assert est.n == 15
+    assert est.search_interval is not None
+    # Default ER interval is np.arange(0, 1, eps)
+    assert len(est.search_interval) > 0
+
+
+def test_construct_ws_default_interval_returns_dict():
+    G = _er(15, 0.3, seed=1)
+    est = GraphParameterEstimator(G, model="WS")
+    assert est.is_multi_param is True
+    assert isinstance(est.search_interval, dict)
+    assert "k" in est.search_interval and "p" in est.search_interval
+
+
+def test_construct_ba_default_interval():
+    G = _er(15, 0.3, seed=2)
+    est = GraphParameterEstimator(G, model="BA")
+    assert est.is_multi_param is False
+    assert len(est.search_interval) > 0
+
+
+# -------------------------------------------------------------------
+# is_multi_parameter_model
+# -------------------------------------------------------------------
+
+def test_is_multi_param_true_for_ws():
+    G = _er(15, 0.3, seed=3)
+    est = GraphParameterEstimator(G, model="WS")
+    assert est.is_multi_parameter_model() is True
+
+
+def test_is_multi_param_false_for_others():
+    G = _er(15, 0.3, seed=4)
+    for model in ["ER", "BA"]:
+        est = GraphParameterEstimator(G, model=model)
+        assert est.is_multi_parameter_model() is False
+
+
+# -------------------------------------------------------------------
+# calculate_gic returns finite numbers
+# -------------------------------------------------------------------
+
+def test_calculate_gic_returns_finite_value():
+    G = _er(20, 0.2, seed=5)
+    est = GraphParameterEstimator(G, model="ER")
+    val = est.calculate_gic(0.2)
+    assert math.isfinite(val)
+    assert val >= 0.0  # GIC = 2*KL + 2*k, both non-negative
+
+
+# -------------------------------------------------------------------
+# end-to-end: estimate() returns a dict with param + gic
+# -------------------------------------------------------------------
+
+def test_estimate_er_returns_param_and_gic():
+    G = _er(20, 0.2, seed=6)
+    # Use coarse eps for a quick test
+    est = GraphParameterEstimator(G, model="ER", eps=0.2, search="grid")
+    out = est.estimate()
+    assert "param" in out and "gic" in out
+    assert math.isfinite(out["gic"])

--- a/tests/test_simulation_api.py
+++ b/tests/test_simulation_api.py
@@ -1,0 +1,147 @@
+"""High-level public API: helpers + the Fitter/Simulation/Comparator classes."""
+import math
+
+import numpy as np
+import networkx as nx
+import pytest
+
+from logit_graph.simulation import (
+    _direct_er_at_sigma,
+    _warm_start_er_p,
+    calculate_graph_attributes,
+    clean_and_convert_param,
+    estimate_sigma_many,
+    estimate_sigma_only,
+)
+
+
+def _er_graph(n, p, seed):
+    return nx.erdos_renyi_graph(n, p, seed=seed)
+
+
+# -------------------------------------------------------------------
+# clean_and_convert_param
+# -------------------------------------------------------------------
+
+def test_clean_and_convert_int_returns_same():
+    assert clean_and_convert_param(3) == 3
+
+
+def test_clean_and_convert_float_returns_same():
+    assert clean_and_convert_param(0.42) == 0.42
+
+
+def test_clean_and_convert_string_extracts_numeric():
+    assert clean_and_convert_param("p=0.25") == 0.25
+
+
+def test_clean_and_convert_invalid_returns_nan():
+    out = clean_and_convert_param("not a number")
+    assert math.isnan(out)
+
+
+# -------------------------------------------------------------------
+# _warm_start_er_p — clamped to [lo, hi]
+# -------------------------------------------------------------------
+
+def test_warm_start_er_p_clamps_below():
+    # expit(-10) ≈ 4.5e-5, clamped to default lo=0.02
+    assert _warm_start_er_p(-10.0) == pytest.approx(0.02)
+
+
+def test_warm_start_er_p_clamps_above():
+    # expit(5) ≈ 0.993, clamped to default hi=0.5
+    assert _warm_start_er_p(5.0) == pytest.approx(0.5)
+
+
+def test_warm_start_er_p_returns_expit_in_range():
+    # expit(-2) ≈ 0.119, within [0.02, 0.5]
+    p = _warm_start_er_p(-2.0)
+    assert 0.02 <= p <= 0.5
+    # Should match expit value
+    from scipy.special import expit
+    assert math.isclose(p, float(expit(-2.0)))
+
+
+# -------------------------------------------------------------------
+# _direct_er_at_sigma
+# -------------------------------------------------------------------
+
+def test_direct_er_at_sigma_returns_symmetric_zero_diagonal():
+    adj = _direct_er_at_sigma(n=20, sigma=-1.0, seed=0)
+    assert adj.shape == (20, 20)
+    np.testing.assert_array_equal(adj, adj.T)
+    assert np.all(np.diag(adj) == 0)
+
+
+def test_direct_er_at_sigma_density_close_to_expit():
+    n, sigma = 200, -2.0
+    adj = _direct_er_at_sigma(n=n, sigma=sigma, seed=42)
+    from scipy.special import expit
+    density = adj.sum() / (n * (n - 1))
+    assert abs(density - float(expit(sigma))) < 0.02
+
+
+def test_direct_er_at_sigma_deterministic_with_seed():
+    a1 = _direct_er_at_sigma(n=30, sigma=-1.5, seed=7)
+    a2 = _direct_er_at_sigma(n=30, sigma=-1.5, seed=7)
+    np.testing.assert_array_equal(a1, a2)
+
+
+# -------------------------------------------------------------------
+# estimate_sigma_only / estimate_sigma_many
+# -------------------------------------------------------------------
+
+def test_estimate_sigma_only_returns_float_and_fit_result():
+    G = _er_graph(40, 0.15, seed=1)
+    sigma, result = estimate_sigma_only(G, d=1)
+    assert isinstance(sigma, float)
+    assert math.isfinite(sigma)
+    assert result is not None  # statsmodels result object
+
+
+def test_estimate_sigma_only_accepts_legacy_max_edges_kwargs():
+    # The legacy max_edges / max_non_edges params should not error
+    G = _er_graph(30, 0.2, seed=2)
+    sigma, _ = estimate_sigma_only(G, d=0, max_edges=50, max_non_edges=50)
+    assert math.isfinite(sigma)
+
+
+def test_estimate_sigma_many_returns_list_of_floats():
+    G = _er_graph(30, 0.2, seed=3)
+    sigmas = estimate_sigma_many(G, d=0, n_repeats=4, max_pairs=80, seed=1)
+    assert isinstance(sigmas, list)
+    assert len(sigmas) == 4
+    assert all(math.isfinite(s) for s in sigmas)
+
+
+def test_estimate_sigma_many_without_max_pairs_is_deterministic():
+    # When max_pairs is None, all pairs are enumerated → every repeat identical
+    G = _er_graph(20, 0.25, seed=4)
+    sigmas = estimate_sigma_many(G, d=0, n_repeats=3, seed=42)
+    assert sigmas[0] == sigmas[1] == sigmas[2]
+
+
+# -------------------------------------------------------------------
+# calculate_graph_attributes
+# -------------------------------------------------------------------
+
+def test_calculate_attributes_none_graph_returns_nan_dict():
+    out = calculate_graph_attributes(None)
+    for k in ("nodes", "edges", "density", "avg_clustering"):
+        assert math.isnan(out[k])
+
+
+def test_calculate_attributes_returns_expected_keys_and_counts():
+    G = _er_graph(20, 0.3, seed=5)
+    out = calculate_graph_attributes(G)
+    assert out["nodes"] == 20
+    assert out["edges"] == G.number_of_edges()
+    assert "density" in out
+    assert "avg_clustering" in out
+    assert "num_components" in out
+
+
+def test_calculate_attributes_empty_graph_returns_nan_dict():
+    out = calculate_graph_attributes(nx.Graph())
+    assert math.isnan(out["nodes"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,65 @@
+"""Smoke tests for GraphUtils plotting helpers.
+
+GraphUtils is a static-method bag of matplotlib plotting helpers plus a few
+pickle/HTML I/O methods with hardcoded paths (``../data/input/`` etc.). We
+only smoke-test the plot helpers here — testing the I/O methods would require
+refactoring them to accept paths as parameters (out of scope).
+"""
+import numpy as np
+import pytest
+
+import matplotlib
+matplotlib.use("Agg")  # Headless backend for CI
+
+from logit_graph.utils import GraphUtils
+
+
+def _small_adj(seed=0):
+    rng = np.random.default_rng(seed)
+    n = 8
+    upper = rng.random((n, n)) < 0.3
+    upper = np.triu(upper, k=1)
+    return (upper | upper.T).astype(float)
+
+
+@pytest.mark.xfail(
+    reason="utils.py:20 calls plt.show(fig) — invalid positional arg in current "
+    "matplotlib. Pre-existing bug; not fixed here (out of scope per CLAUDE.md §3)."
+)
+def test_plot_graph_from_adjacency_does_not_crash():
+    import matplotlib.pyplot as plt
+    plt.close("all")
+    GraphUtils.plot_graph_from_adjacency(_small_adj(), title="t", size=(2, 2))
+    plt.close("all")
+
+
+def test_plot_degree_distribution_does_not_crash():
+    import matplotlib.pyplot as plt
+    plt.close("all")
+    GraphUtils.plot_degree_distribution(_small_adj(seed=1), size=(2, 2))
+    plt.close("all")
+
+
+def test_plot_spectrum_and_zoom_does_not_crash():
+    import matplotlib.pyplot as plt
+    plt.close("all")
+    spectrum = np.linspace(0, 2, 30)
+    GraphUtils.plot_spectrum_and_zoom(spectrum, size=(2, 1))
+    plt.close("all")
+
+
+def test_plot_graph_and_spectrum_does_not_crash():
+    import matplotlib.pyplot as plt
+    plt.close("all")
+    adj = _small_adj(seed=2)
+    spectrum = np.linalg.eigvalsh(adj)
+    GraphUtils.plot_graph_and_spectrum(adj, spectrum, size=(4, 2))
+    plt.close("all")
+
+
+def test_graph_utils_methods_are_static():
+    # All plot helpers are accessible as class methods without instantiation
+    assert callable(GraphUtils.plot_graph_from_adjacency)
+    assert callable(GraphUtils.plot_degree_distribution)
+    assert callable(GraphUtils.plot_spectrum_and_zoom)
+    assert callable(GraphUtils.plot_graph_and_spectrum)


### PR DESCRIPTION
## Summary

Roughly **2.3× the test suite** — from 92 to **211 passing tests in 5.6s** — focused on the core methods and public API of the package (not the AIC experiment plumbing from PR #17).

## What's new

10 new test files, ~120 tests, organized by tier:

### Tier A — primitives
| File | Tests | Covers |
|------|-------|--------|
| `test_degrees_counts_deeper.py` | 8 | `degree_vertex` / `get_sum_degrees` at isolated vertices, complete/path/cycle/disconnected graphs |
| `test_lg_features_core.py` | 19 | `recommended_iterations` formula + cap; `common_dhop_count`; `incremental_h` GWESP closed-form; `pair_feature` in all 4 modes + invalid mode; `pair_feature_layer2` strips edge correctly; `precompute_vertex_sums`; `build_pair_dataset` shape/labels/determinism |

### Tier B — estimators
| File | Tests | Covers |
|------|-------|--------|
| `test_offset_logit_core.py` | 11 | Empty/degenerate inputs; **regression for MLE init oscillation bug** (verified via score-zero first-order condition); `fit_offset_logit_fast` ≡ numba; `aic_from_offset_fit` formula + extra_penalty + k |
| `test_logit_estimator_api.py` | 12 | `LogitRegEstimator` accepts numpy / networkx / rejects strings; `get_features_labels` shape and label invariant; `compute_aic` return keys + extra_penalty additive; `select_d` picks argmin AIC; sigma_hat ≈ logit(empirical density) at d=0 |

### Tier C — model selection
| File | Tests | Covers |
|------|-------|--------|
| `test_gic_core.py` | 12 | `GraphInformationCriterion` spectral density bins; KL=0 to self; KL/L1/L2 non-negative; GIC = 2·dist + 2·n_params; n_params override; unknown distance/model errors |
| `test_model_selection_core.py` | 12 | `RandomGraphModelSelector` / `ModelSelectorSpectrum` / `GraphModelSelection` fit returns best ∈ candidates; KL self-distance = 0; model penalty table; smoke for select_model_avg_spectrum |

### Tier D — high-level API
| File | Tests | Covers |
|------|-------|--------|
| `test_simulation_api.py` | 17 | `clean_and_convert_param`; `_warm_start_er_p` clamps; `_direct_er_at_sigma` symmetry + density + determinism; `estimate_sigma_only` returns float; `estimate_sigma_many` deterministic without max_pairs; `calculate_graph_attributes` keys and None/empty handling |
| `test_graph_model_deeper.py` | 13 | `GraphModel` defaults + symmetry / no self-loops; seed determinism; `logistic_regression` ≡ expit; `calculate_spectrum` sorted + non-negative + zero-eigenvalue multiplicity = component count |
| `test_utils.py` | 5 | `GraphUtils` plotting helpers don't crash on Agg backend; **xfail documents pre-existing matplotlib bug** in `utils.py:20` (`plt.show(fig)` invalid positional arg) |
| `test_param_estimator.py` | 13 | `GraphParameterEstimator.get_model_function` dispatch; `is_multi_parameter_model`; default-interval construction; `calculate_gic` finite; `estimate()` returns dict — tests only paths that bypass the existing constructor-order bug |

## Design choices

- **Plain `def test_*` style**, matching the existing test convention (no class-based grouping, light fixtures)
- **Tiny graphs (n=5–30) for math correctness**; `n≤100` for integration-style only
- **Synthetic data with known parameters** so we assert recovery within explicit tolerance
- **No new fixtures unless needed 3+ times** (per CLAUDE.md §2 — minimum needed)
- **Pre-existing bugs surfaced via xfail** rather than fixed (per CLAUDE.md §3 — surgical changes only)

## What this PR does NOT touch

Per the scope discussion, this is **core methods + API**, not infrastructure. Out of scope:
- AIC sweep config resolution (presets, sigma_gen_per_n_d, m_ensemble_by_d) — added in PR #17, deferred
- Workers / parallelism plumbing
- Plot artifacts beyond smoke tests
- Numba `lg_features_fast` internals (already well-covered by `test_gibbs_equivalence.py`)

## Test plan
- [x] Full suite passes: `211 passed, 1 skipped, 2 xfailed in 5.64s`
- [x] No changes to existing 92 tests
- [x] Runtime fits CI (<10s)
- [ ] CI green on Python 3.10 and 3.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)