### PR TITLE
Pin CI to uv.lock + immutable action SHAs (supply-chain hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,13 @@
 name: CI
 
+# Supply-chain hygiene:
+#   - All actions are pinned to a full 40-char commit SHA (mutable tags
+#     can be rewritten upstream). Update SHAs by running
+#     `gh api repos/<org>/<repo>/git/refs/tags/<tag> --jq .object.sha`.
+#   - Dependencies are installed from uv.lock with --frozen, which
+#     verifies every package against the sha256 hashes stored in the
+#     lockfile and refuses to update the lock at install time.
+
 on:
   push:
     branches: [ main ]
@@ -16,20 +24,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        # actions/checkout v4.3.1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        # actions/setup-python v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install package and test dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .
+      - name: Install uv (pinned)
+        # astral-sh/setup-uv v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+
+      - name: Install dependencies from frozen lockfile
+        # --frozen: refuse to update uv.lock; install must match exactly.
+        # Hashes from the lockfile are enforced automatically.
+        run: uv sync --frozen --all-extras
 
       - name: Run tests
-        run: |
-          pytest -q
-
-
+        run: uv run pytest -q

--- a/uv.lock
+++ b/uv.lock
@@ -1628,7 +1628,7 @@ wheels = [
 
 [[package]]
 name = "logit-graph"
-version = "0.1.1"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "imageio" },


### PR DESCRIPTION
## What changed

### `.github/workflows/ci.yml`

**Action pinning.** All three GitHub Actions used by CI are now pinned to a full 40-char commit SHA instead of a mutable tag:

| Action | Was | Now (SHA) | Tag |
|--------|-----|-----------|-----|
| `actions/checkout` | `@v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/setup-python` | `@v5` | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5.6.0 |
| `astral-sh/setup-uv` | *(was absent)* | `08807647e7069bb48b6ef5acd8ec9567f424441b` | v8.1.0 |

Tags are mutable — an attacker with push access to `actions/checkout` could re-point `v4` to a malicious commit and our workflow would pick it up silently. Pinning to immutable SHAs forecloses that.

**Install path.** CI was running `pip install -e .`, which resolves the dependency tree fresh from PyPI on every run — vulnerable to typosquats, dependency-confusion, or upstream tampering between commit and CI run.

New flow:
```yaml
uses: astral-sh/setup-uv@<sha>
- run: uv sync --frozen --all-extras
- run: uv run pytest -q
```

`uv sync --frozen` installs only what's in `uv.lock` and verifies every package against the sha256 hashes already baked into the lockfile (2744 entries). It also *refuses* to update the lockfile during install — so any drift between PR code and the lock is a hard CI failure.

### `uv.lock`

The workspace package version drifted from `0.1.1` to `0.1.4` in `pyproject.toml` without re-locking. Refreshed to keep `uv sync --frozen` green.

## How to update pinned SHAs

When you want to upgrade an action:
```bash
gh api repos/<org>/<repo>/git/refs/tags/<tag> --jq .object.sha
```
Replace the SHA in the workflow + update the comment line to the new tag.

A Dependabot config could automate this — happy to add `.github/dependabot.yml` as a follow-up if useful (not in this PR per scope).

## Test plan

- [x] Local: `uv sync --frozen --all-extras` succeeds with current lockfile (exit 0)
- [x] Local: `uv run pytest` → 212 passed, 2 xfailed in 7.45s
- [ ] CI: Python 3.10 + 3.11 jobs pass on this PR