### PR TITLE
Ignore .claude/ local Claude Code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ __pycache__/
 .DS_Store
 *.DS_Store
 
+# Claude Code local settings
+.claude/
+
 # R
 *.RData
 */.RData


### PR DESCRIPTION
## Summary
- Adds `.claude/` to `.gitignore` so local Claude Code settings (e.g. `settings.json`) do not appear in `git status` and cannot be committed accidentally.

## Test plan
- [x] `git status` no longer lists `.claude/` as an untracked file after this lands.