### PR TITLE
GIC ranking of LG vs ER/WS/BA on full MUSAE Facebook + SNAP ego networks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,15 @@ convergence-diagnostics-quick:  ## Quick smoke (n=200, 50k iter, ~1 min)
 	LG_CONV_QUICK=1 \
 		$(UV) run python notebooks/refactors/run_convergence_diagnostics.py
 
+gic-facebook-ego:  ## Rank LG vs ER/WS/BA on the 10 SNAP Facebook ego networks (~30-60s)
+	LG_FBEGO_USE_CACHE=1 \
+		$(UV) run python notebooks/refactors/run_facebook_ego_gic.py
+
+gic-facebook-ego-quick:  ## Smoke run on small SNAP Facebook ego networks (~15s)
+	LG_FBEGO_QUICK=1 \
+	LG_FBEGO_USE_CACHE=0 \
+		$(UV) run python notebooks/refactors/run_facebook_ego_gic.py
+
 gic-facebook:  ## Rank LG vs ER/WS/BA by GIC on full MUSAE Facebook page-page graph (~2-3 min)
 	LG_FB_USE_CACHE=1 \
 		$(UV) run python notebooks/refactors/run_facebook_gic.py

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,15 @@ convergence-diagnostics-quick:  ## Quick smoke (n=200, 50k iter, ~1 min)
 	LG_CONV_QUICK=1 \
 		$(UV) run python notebooks/refactors/run_convergence_diagnostics.py
 
+gic-facebook:  ## Rank LG vs ER/WS/BA by GIC on full MUSAE Facebook page-page graph (~2-3 min)
+	LG_FB_USE_CACHE=1 \
+		$(UV) run python notebooks/refactors/run_facebook_gic.py
+
+gic-facebook-quick:  ## Smoke run on MUSAE Facebook (~30-60s, fewer MCMC iters)
+	LG_FB_QUICK=1 \
+	LG_FB_USE_CACHE=0 \
+		$(UV) run python notebooks/refactors/run_facebook_gic.py
+
 gic-arxiv:  ## Rank LG vs ER/WS/BA by GIC on full cit-HepTh citation network (~3-5 min)
 	LG_ARXIV_USE_CACHE=1 \
 		$(UV) run python notebooks/refactors/run_arxiv_gic.py

--- a/notebooks/refactors/run_facebook_ego_gic.py
+++ b/notebooks/refactors/run_facebook_ego_gic.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Fit LG + ER/WS/BA on every SNAP Facebook ego network and rank them by GIC.
+
+For each ``data/misc/facebook/*.edges`` ego graph (10 networks, n from 52
+to 1034) fits the Logit-Graph model (AIC d̂ + offset-logit σ̂) and the
+three classical baselines, scores each by spectral GIC against the real
+graph, and ranks them.
+
+Same pipeline as ``run_gplus_gic.py`` (PR #24) — KPM spectral density +
+parallel worker processes via platform_fit_utils. Outputs per-graph
+reports under ``notebooks/refactors/runs/facebook_ego/{graph}/`` and an
+aggregate leaderboard plot.
+
+Env-var overrides:
+  LG_FBEGO_MAX_NODES   cap on |V|        (default None — keep all 10)
+  LG_FBEGO_MIN_NODES   floor on |V|      (default 30)
+  LG_FBEGO_LG_ITER     LG MCMC cap       (default 2000)
+  LG_FBEGO_GRID_POINTS baseline grid     (default 3)
+  LG_FBEGO_N_RUNS      baseline reps     (default 1)
+  LG_FBEGO_USE_CACHE   reload finished networks (default 1)
+  LG_FBEGO_WORKERS     parallel processes (default cpu-1)
+  LG_FBEGO_QUICK       smoke (MAX_NODES=500, fewer iter)
+
+  make gic-facebook-ego        full (~30-60s on the 10 ego networks)
+  make gic-facebook-ego-quick  smoke (~15s)
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import traceback
+import warnings
+from pathlib import Path
+from typing import Optional
+
+
+def _get_int(env: str, default: int) -> int:
+    raw = os.environ.get(env)
+    return int(raw) if raw is not None else default
+
+
+def _get_optional_int(env: str, default: Optional[int]) -> Optional[int]:
+    raw = os.environ.get(env)
+    if raw is None:
+        return default
+    if raw.lower() in ("none", "", "null"):
+        return None
+    return int(raw)
+
+
+def _fmt_secs(s: float) -> str:
+    if s < 60:
+        return f"{s:5.1f}s"
+    m, rem = divmod(s, 60)
+    return f"{int(m):2d}m{int(rem):02d}s"
+
+
+def _peek_size(edge_path: Path) -> int:
+    nodes = set()
+    with open(edge_path, "r", encoding="utf-8") as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) >= 2:
+                nodes.add(parts[0])
+                nodes.add(parts[1])
+    return len(nodes)
+
+
+def _fast_discover(cfg):
+    """Same file-size pre-filter + token-count peek used by the gplus driver.
+
+    The SNAP facebook directory only has ~10 .edges files (plus .circles /
+    .feat etc. that we ignore), so byte filtering is barely needed — but
+    keeping the same shape as run_gplus_gic.py for consistency.
+    """
+    paths = sorted(cfg.data_root.glob(cfg.glob_pattern))
+    paths = [p for p in paths if p.suffix == ".edges" and p.is_file()]
+    if cfg.max_nodes is not None:
+        max_bytes = 100 * cfg.max_nodes * cfg.max_nodes
+    else:
+        max_bytes = None
+    sizes: dict[str, int] = {}
+    kept: list[tuple[Path, int]] = []
+    for p in paths:
+        if max_bytes is not None and p.stat().st_size > max_bytes:
+            continue
+        try:
+            n = _peek_size(p)
+        except OSError:
+            continue
+        if n < cfg.min_nodes or n == 0:
+            continue
+        if cfg.max_nodes is not None and n > cfg.max_nodes:
+            continue
+        sizes[p.stem] = n
+        kept.append((p, n))
+    kept.sort(key=lambda x: x[1])
+    return [p for p, _ in kept], sizes
+
+
+def main() -> None:
+    sys.stdout.reconfigure(line_buffering=True)
+    for v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+        os.environ.setdefault(v, "1")
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+    _here = Path(__file__).resolve().parent
+    _repo_root = _here.parents[1]
+    _src = _repo_root / "src"
+    if str(_src) not in sys.path:
+        sys.path.insert(0, str(_src))
+    if str(_here) not in sys.path:
+        sys.path.insert(0, str(_here))
+
+    import platform_fit_utils as pfu  # noqa: E402
+    from platform_fit_utils import (  # noqa: E402
+        PlatformConfig,
+        fit_one_network,
+        load_cached_result,
+        plot_aggregate_summary,
+        setup_platform_logging,
+        summarize_aggregates,
+    )
+    import pandas as pd  # noqa: E402
+
+    quick = os.environ.get("LG_FBEGO_QUICK", "0") == "1"
+    max_nodes_default = 500 if quick else None  # 10 ego nets, biggest n=1034
+    lg_iter_default = 800 if quick else 2000
+
+    max_nodes = _get_optional_int("LG_FBEGO_MAX_NODES", max_nodes_default)
+    min_nodes = _get_int("LG_FBEGO_MIN_NODES", 30)
+    lg_iter_cap = _get_int("LG_FBEGO_LG_ITER", lg_iter_default)
+    grid_points = _get_int("LG_FBEGO_GRID_POINTS", 3)
+    n_runs = _get_int("LG_FBEGO_N_RUNS", 1)
+    use_cache = os.environ.get("LG_FBEGO_USE_CACHE", "1") == "1"
+    workers = _get_int("LG_FBEGO_WORKERS", max(1, (os.cpu_count() or 2) - 1))
+
+    _original_lg_max = pfu.lg_max_iterations
+
+    def _capped(n: int) -> int:
+        return min(_original_lg_max(n), lg_iter_cap)
+
+    pfu.lg_max_iterations = _capped
+
+    cfg = PlatformConfig(
+        platform="facebook_ego",
+        glob_pattern="misc/facebook/*.edges",
+        min_nodes=min_nodes,
+        max_nodes=max_nodes,
+        other_model_n_runs=n_runs,
+        other_model_grid_points=grid_points,
+        use_cache=use_cache,
+        display_plots=False,
+        data_root=_repo_root / "data",
+        run_dir=_here / "runs",
+    )
+
+    print(
+        f"SNAP Facebook ego networks GIC ranking  min_nodes={min_nodes}  "
+        f"max_nodes={max_nodes}  lg_iter≤{lg_iter_cap}  grid_points={grid_points}  "
+        f"n_runs={n_runs}  cache={use_cache}  workers={workers}  quick={quick}"
+    )
+
+    graph_files, sizes_by_stem = _fast_discover(cfg)
+    if not graph_files:
+        print("No ego networks matched the size window; nothing to do.")
+        return
+    sizes = [(stem, sizes_by_stem[stem]) for stem in (p.stem for p in graph_files)]
+    avg_n = sum(n for _, n in sizes) / len(sizes)
+    print(
+        f"\nDiscovered {len(graph_files)} ego networks  "
+        f"|V|: min={min(n for _, n in sizes)}  max={max(n for _, n in sizes)}  "
+        f"mean={avg_n:.0f}"
+    )
+
+    pending = []
+    cached_count = 0
+    for p in graph_files:
+        net_dir = cfg.run_dir / p.stem
+        if use_cache and load_cached_result(net_dir, p.stem) is not None:
+            cached_count += 1
+        else:
+            pending.append(p)
+    print(f"Cache: {cached_count}/{len(graph_files)} hits, {len(pending)} fits pending\n")
+
+    logger = setup_platform_logging(cfg.run_dir)
+    logger.info(
+        "=== facebook_ego GIC sweep  (%d networks, %d cached, %d to fit) ===",
+        len(graph_files), cached_count, len(pending),
+    )
+
+    summary_rows = []
+    fit_meta_rows = []
+    failures = []
+    t_start = time.perf_counter()
+
+    pending_with_idx: list[tuple[int, Path]] = []
+    for i, edge_path in enumerate(graph_files, start=1):
+        graph_name = edge_path.stem
+        net_dir = cfg.run_dir / graph_name
+        if use_cache:
+            cached = load_cached_result(net_dir, graph_name)
+            if cached is not None:
+                n_v = cached["meta"].get("n_nodes")
+                print(
+                    f"[{i:3d}/{len(graph_files)}] {graph_name}  CACHE  "
+                    f"n={n_v}  best={cached['meta'].get('best_model')}  "
+                    f"GIC={cached['meta'].get('best_gic', float('nan')):.3f}"
+                )
+                summary_rows.append(cached["summary"])
+                fit_meta_rows.append({**cached["meta"], "cached": True})
+                continue
+        pending_with_idx.append((i, edge_path))
+
+    if pending_with_idx:
+        worker_count = max(1, min(workers, len(pending_with_idx)))
+        print(
+            f"Launching {worker_count} worker(s) for {len(pending_with_idx)} fresh fits ...\n"
+        )
+        if worker_count == 1:
+            results_iter = [
+                _fit_worker((str(p), _cfg_to_dict(cfg), lg_iter_cap, i, len(graph_files)))
+                for i, p in pending_with_idx
+            ]
+        else:
+            from concurrent.futures import ProcessPoolExecutor, as_completed
+            tasks = [
+                (str(p), _cfg_to_dict(cfg), lg_iter_cap, i, len(graph_files))
+                for i, p in pending_with_idx
+            ]
+            results_iter = []
+            with ProcessPoolExecutor(max_workers=worker_count) as pool:
+                futures = {pool.submit(_fit_worker, t): t for t in tasks}
+                for fut in as_completed(futures):
+                    results_iter.append(fut.result())
+
+        fits_done = 0
+        for status, name, payload in results_iter:
+            fits_done += 1
+            elapsed = time.perf_counter() - t_start
+            if status == "err":
+                print(f"  [{fits_done}/{len(pending_with_idx)}] {name}  FAILED  {payload}")
+                failures.append({"graph": name, "error": payload})
+                continue
+            meta = payload["meta"]
+            print(
+                f"  [{fits_done}/{len(pending_with_idx)}] {name}  DONE  "
+                f"n={meta.get('n_nodes')}  best={meta['best_model']}  "
+                f"GIC={meta['best_gic']:.3f}  σ̂={meta.get('sigma_hat', 0):+.3f}  "
+                f"d̂={meta.get('d_hat')}  in {_fmt_secs(meta.get('elapsed_s', 0))}  "
+                f"| wall {_fmt_secs(elapsed)}"
+            )
+            summary_rows.append(payload["summary"])
+            fit_meta_rows.append(meta)
+
+    total_elapsed = time.perf_counter() - t_start
+    print(
+        f"\nFit phase complete in {_fmt_secs(total_elapsed)} "
+        f"({len(pending_with_idx) - len(failures)} fresh fits, "
+        f"{cached_count} cache hits, {len(failures)} failures)"
+    )
+
+    if not summary_rows:
+        print("No networks were processed.")
+        return
+
+    summary_all = pd.concat(summary_rows, ignore_index=True)
+    fit_meta = pd.DataFrame(fit_meta_rows)
+    summary_all.to_csv(cfg.run_dir / "summary_all.csv", index=False)
+    fit_meta.to_csv(cfg.run_dir / "fit_meta_all.csv", index=False)
+    if failures:
+        pd.DataFrame(failures).to_csv(cfg.run_dir / "failures.csv", index=False)
+
+    gic_pivot, rank_pivot, mean_rank = summarize_aggregates(summary_all, cfg.run_dir)
+    plot_aggregate_summary(fit_meta, mean_rank, cfg.run_dir, cfg.platform, display=False)
+
+    print("\nMean GIC rank (lower = better fit):")
+    print(mean_rank.to_string())
+
+    print("\nPer-graph best model (by GIC):")
+    cols = ["graph", "n_nodes", "n_edges", "d_hat", "sigma_hat", "best_model", "best_gic"]
+    cols = [c for c in cols if c in fit_meta.columns]
+    print(fit_meta[cols].sort_values("n_nodes").to_string(index=False))
+
+    print(f"\nArtifacts in: {cfg.run_dir}")
+
+
+def _cfg_to_dict(cfg) -> dict:
+    return {
+        "platform": cfg.platform,
+        "glob_pattern": cfg.glob_pattern,
+        "min_nodes": cfg.min_nodes,
+        "max_nodes": cfg.max_nodes,
+        "d_candidates": list(cfg.d_candidates),
+        "seed": cfg.seed,
+        "other_model_n_runs": cfg.other_model_n_runs,
+        "other_model_grid_points": cfg.other_model_grid_points,
+        "display_plots": cfg.display_plots,
+        "use_cache": cfg.use_cache,
+        "data_root": str(cfg.data_root),
+        "run_dir_parent": str(cfg.run_dir.parent),
+    }
+
+
+def _fit_worker(args):
+    edge_path_str, cfg_dict, lg_iter_cap, i, total = args
+    import sys as _sys
+    import os as _os
+    from pathlib import Path as _Path
+
+    for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+        _os.environ.setdefault(_v, "1")
+
+    _here = _Path(__file__).resolve().parent
+    _repo_root = _here.parents[1]
+    for _p in (str(_repo_root / "src"), str(_here)):
+        if _p not in _sys.path:
+            _sys.path.insert(0, _p)
+
+    import platform_fit_utils as pfu
+    from platform_fit_utils import PlatformConfig, fit_one_network, setup_platform_logging
+
+    cfg_kwargs = dict(cfg_dict)
+    run_dir_parent = cfg_kwargs.pop("run_dir_parent")
+    cfg_kwargs["data_root"] = _Path(cfg_kwargs["data_root"])
+    cfg_kwargs["run_dir"] = _Path(run_dir_parent)
+    cfg = PlatformConfig(**cfg_kwargs)
+
+    _orig_lg_max = pfu.lg_max_iterations
+    pfu.lg_max_iterations = lambda n: min(_orig_lg_max(n), lg_iter_cap)
+
+    edge_path = _Path(edge_path_str)
+    logger = setup_platform_logging(cfg.run_dir, name=f"worker_{_os.getpid()}")
+    try:
+        result = fit_one_network(edge_path, cfg, logger, i, total)
+        return ("ok", edge_path.stem, {"meta": result["meta"], "summary": result["summary"]})
+    except Exception as exc:
+        import traceback as _tb
+        return ("err", edge_path.stem, f"{exc}\n{_tb.format_exc()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/notebooks/refactors/run_facebook_gic.py
+++ b/notebooks/refactors/run_facebook_gic.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Fit LG + ER/WS/BA on the FULL MUSAE Facebook page-page network and rank by GIC.
+
+Mirrors ``run_arxiv_gic.py`` but on the page-page Facebook graph shipped
+in ``data/facebook_large/musae_facebook_edges.csv`` (n≈22,470, m≈171k).
+No node subsampling — whole graph fitted via:
+  - KPM spectral density on the sparse normalised Laplacian
+  - sampled logistic regression for σ, β (~50k edges + 50k non-edges)
+  - dense LG MCMC at d=0 (one adjacency in RAM, ~4 GB)
+  - sparse baseline generation + KPM scoring
+
+Env-var overrides:
+  LG_FB_DATA          path to musae_facebook_edges.csv
+  LG_FB_MAX_ITER      LG MCMC iterations         (default 50_000)
+  LG_FB_CHECK         spectral check interval    (default 5_000)
+  LG_FB_WARM_UP       iters before patience      (default 10_000)
+  LG_FB_PATIENCE      no-improvement checks      (default 100)
+  LG_FB_SAMPLE_EDGES  σ/β estimation sample      (default 50_000)
+  LG_FB_KPM_MOMENTS   Chebyshev moments          (default 150)
+  LG_FB_KPM_PROBES    random probes              (default 40)
+  LG_FB_USE_CACHE     reuse cached results       (default 1)
+  LG_FB_SEED          RNG seed                   (default 42)
+  LG_FB_QUICK         smoke (MAX_ITER=10k, fewer KPM moments)
+
+  make gic-facebook        full preset (~2-3 min)
+  make gic-facebook-quick  smoke (~30-60s)
+"""
+from __future__ import annotations
+
+import gc
+import json
+import os
+import pickle
+import sys
+import time
+import warnings
+from pathlib import Path
+
+
+def _get_int(env: str, default: int) -> int:
+    raw = os.environ.get(env)
+    return int(raw) if raw is not None else default
+
+
+def _fmt(s: float) -> str:
+    if s < 60:
+        return f"{s:5.1f}s"
+    m, rem = divmod(s, 60)
+    return f"{int(m):2d}m{int(rem):02d}s"
+
+
+def _sparse_normalised_laplacian(G_or_adj):
+    import networkx as nx
+    import numpy as np
+    import scipy.sparse as sp
+
+    if isinstance(G_or_adj, nx.Graph):
+        A = nx.adjacency_matrix(G_or_adj).astype(np.float64)
+    elif isinstance(G_or_adj, np.ndarray):
+        A = sp.csr_matrix(G_or_adj)
+    else:
+        A = sp.csr_matrix(G_or_adj)
+    n = A.shape[0]
+    deg = np.asarray(A.sum(axis=1)).ravel()
+    deg_inv_sqrt = np.where(deg > 0, 1.0 / np.sqrt(deg), 0.0)
+    D_inv_sqrt = sp.diags(deg_inv_sqrt)
+    return sp.eye(n, format="csr") - (D_inv_sqrt @ A @ D_inv_sqrt)
+
+
+def main() -> None:
+    sys.stdout.reconfigure(line_buffering=True)
+    for v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+        os.environ.setdefault(v, "1")
+    warnings.filterwarnings("ignore")
+
+    _here = Path(__file__).resolve().parent
+    _repo_root = _here.parents[1]
+    _src = _repo_root / "src"
+    if str(_src) not in sys.path:
+        sys.path.insert(0, str(_src))
+
+    import numpy as np
+    import networkx as nx
+    import pandas as pd
+    import statsmodels.api as sm
+    from logit_graph.gic import kpm_spectral_density
+    from logit_graph.graph import GraphModel
+
+    quick = os.environ.get("LG_FB_QUICK", "0") == "1"
+    data_path = Path(os.environ.get(
+        "LG_FB_DATA",
+        str(_repo_root / "data" / "facebook_large" / "musae_facebook_edges.csv"),
+    ))
+    max_iter = _get_int("LG_FB_MAX_ITER", 10_000 if quick else 50_000)
+    check_interval = _get_int("LG_FB_CHECK", 1_000 if quick else 5_000)
+    warm_up = _get_int("LG_FB_WARM_UP", 2_000 if quick else 10_000)
+    patience = _get_int("LG_FB_PATIENCE", 30 if quick else 100)
+    sample_edges = _get_int("LG_FB_SAMPLE_EDGES", 20_000 if quick else 50_000)
+    kpm_moments = _get_int("LG_FB_KPM_MOMENTS", 80 if quick else 150)
+    kpm_probes = _get_int("LG_FB_KPM_PROBES", 20 if quick else 40)
+    seed = _get_int("LG_FB_SEED", 42)
+    use_cache = os.environ.get("LG_FB_USE_CACHE", "1") == "1"
+
+    out_dir = _here / "runs" / "facebook"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = out_dir / "facebook_full_results.pkl"
+
+    print(
+        f"MUSAE Facebook full-graph GIC ranking  "
+        f"max_iter={max_iter:,}  check={check_interval:,}  patience={patience}  "
+        f"sample_edges={sample_edges:,}  kpm_moments={kpm_moments}  "
+        f"kpm_probes={kpm_probes}  quick={quick}"
+    )
+
+    cfg_sig = json.dumps(
+        [max_iter, check_interval, sample_edges, kpm_moments, kpm_probes, seed],
+        sort_keys=True,
+    )
+    if use_cache and cache_path.is_file():
+        with open(cache_path, "rb") as f:
+            cached = pickle.load(f)
+        if cached.get("config_signature") == cfg_sig:
+            print(f"\nCache hit at {cache_path}; reprinting summary.")
+            _print_summary(cached["summary_df"], cached["n"], cached["m"])
+            return
+        print("Cache present but config changed; recomputing.")
+
+    # 1. Load + GCC
+    print(f"\n=== 1. Load full graph from {data_path}")
+    t0 = time.perf_counter()
+    df = pd.read_csv(data_path)
+    G_full = nx.from_pandas_edgelist(df, source=df.columns[0], target=df.columns[1])
+    G_full.remove_edges_from(nx.selfloop_edges(G_full))
+    gcc_nodes = max(nx.connected_components(G_full), key=len)
+    G_gcc = nx.convert_node_labels_to_integers(G_full.subgraph(gcc_nodes).copy())
+    n = G_gcc.number_of_nodes()
+    m = G_gcc.number_of_edges()
+    del df, G_full
+    gc.collect()
+    print(f"  GCC: n={n:,}  m={m:,}  density={nx.density(G_gcc):.6f}  "
+          f"[{_fmt(time.perf_counter() - t0)}]")
+
+    # 2. KPM density of the real graph
+    print(f"\n=== 2. KPM spectral density of real graph")
+    t0 = time.perf_counter()
+    L_real = _sparse_normalised_laplacian(G_gcc)
+    real_density, _ = kpm_spectral_density(
+        L_real, n_bins=50, n_moments=kpm_moments,
+        n_probes=kpm_probes, seed=seed,
+    )
+    print(f"  KPM done in {_fmt(time.perf_counter() - t0)}")
+
+    # 3. LG σ, β by sampled logistic regression
+    print(f"\n=== 3. Estimate LG σ, β  "
+          f"({sample_edges:,} edges + {sample_edges:,} non-edges)")
+    t0 = time.perf_counter()
+    rng = np.random.default_rng(seed)
+    degree_dict = dict(G_gcc.degree())
+    sum_degrees = np.array([degree_dict.get(v, 0) for v in range(n)], dtype=np.float64)
+
+    edges_all = list(G_gcc.edges())
+    n_sample = min(sample_edges, len(edges_all))
+    edge_idx = rng.choice(len(edges_all), size=n_sample, replace=False)
+    edge_pairs = [edges_all[i] for i in edge_idx]
+    edge_set = set((min(a, b), max(a, b)) for a, b in edges_all)
+    non_edge_pairs = []
+    while len(non_edge_pairs) < n_sample:
+        i = int(rng.integers(0, n))
+        j = int(rng.integers(0, n))
+        if i == j:
+            continue
+        pair = (min(i, j), max(i, j))
+        if pair not in edge_set:
+            non_edge_pairs.append(pair)
+    pairs = edge_pairs + non_edge_pairs
+    labels = [1] * len(edge_pairs) + [0] * len(non_edge_pairs)
+    feats = np.array([sum_degrees[i] + sum_degrees[j] for i, j in pairs]).reshape(-1, 1)
+    features = sm.add_constant(feats)
+    result = sm.Logit(labels, features).fit_regularized(method="l1", alpha=0, disp=False)
+    sigma = float(result.params[0])
+    beta = float(result.params[1])
+    d_lg = 0
+    print(f"  σ={sigma:+.4f}  β={beta:+.4f}  d={d_lg}  "
+          f"[{_fmt(time.perf_counter() - t0)}]")
+
+    # 4. LG MCMC fit
+    print(f"\n=== 4. LG MCMC fit  (max_iter={max_iter:,}, check every {check_interval:,})")
+    er_seed_p = 1.25 * (nx.density(G_gcc) / 2)
+    gm = GraphModel(n=n, d=d_lg, sigma=sigma, beta=beta, er_p=er_seed_p, seed=seed)
+    print(f"  Initial: edges={gm._edge_count:,}  dense adj={gm.graph.nbytes / 1e9:.2f} GB")
+    best_graph = gm.graph.copy()
+    best_diff = float("inf")
+    best_iter = 0
+    no_improve = 0
+    t_start = time.perf_counter()
+
+    for i in range(max_iter):
+        gm.add_remove_edge()
+        if i > 0 and i % check_interval == 0:
+            L_cur = _sparse_normalised_laplacian(gm.graph)
+            cur_density, _ = kpm_spectral_density(
+                L_cur, n_bins=50, n_moments=kpm_moments,
+                n_probes=kpm_probes, seed=seed + i,
+            )
+            diff = float(np.linalg.norm(cur_density - real_density))
+            if diff < best_diff:
+                best_diff = diff
+                best_graph = gm.graph.copy()
+                best_iter = i
+                no_improve = 0
+            elif i >= warm_up:
+                no_improve += 1
+            print(
+                f"  iter {i:>7,}/{max_iter:,}  L2={diff:.4f}  best={best_diff:.4f}  "
+                f"edges={gm._edge_count:,}/{m:,}  pat={no_improve}/{patience}  "
+                f"wall={_fmt(time.perf_counter() - t_start)}"
+            )
+            if i >= warm_up and no_improve >= patience:
+                print(f"  converged (no improvement for {patience} checks)")
+                break
+
+    print(f"  LG fit done in {_fmt(time.perf_counter() - t_start)}  "
+          f"best_iter={best_iter:,}  best_L2={best_diff:.4f}")
+
+    # 5. GIC for LG + ER / WS / BA
+    print(f"\n=== 5. GIC for LG + ER / WS / BA")
+    results: dict[str, dict] = {}
+    real_density_val = nx.density(G_gcc)
+    real_avg_deg = 2 * m / n
+    eps = 1e-10
+
+    def _gic(p):
+        from scipy.stats import entropy as _entropy
+        return 0.5 * (_entropy(real_density + eps, p + eps)
+                      + _entropy(p + eps, real_density + eps))
+
+    t0 = time.perf_counter()
+    L_lg = _sparse_normalised_laplacian(best_graph)
+    lg_density, _ = kpm_spectral_density(
+        L_lg, n_bins=50, n_moments=kpm_moments,
+        n_probes=kpm_probes, seed=seed + 99_991,
+    )
+    lg_gic = float(_gic(lg_density))
+    results["LG"] = {"gic": lg_gic, "param": f"σ={sigma:.3f},β={beta:.3f},d={d_lg}",
+                     "n": n, "m": int(best_graph.sum() // 2)}
+    print(f"  LG  GIC={lg_gic:.4f}  ({_fmt(time.perf_counter() - t0)})")
+    del gm
+    gc.collect()
+
+    baselines = [
+        ("ER", "Erdos-Renyi",
+         lambda: nx.erdos_renyi_graph(n, real_density_val, seed=seed)),
+        ("WS", "Watts-Strogatz",
+         lambda: nx.watts_strogatz_graph(n, max(2, int(round(real_avg_deg))), 0.1, seed=seed)),
+        ("BA", "Barabasi-Albert",
+         lambda: nx.barabasi_albert_graph(n, max(1, int(round(real_avg_deg / 2))), seed=seed)),
+    ]
+    for name, label, gen in baselines:
+        t0 = time.perf_counter()
+        G_m = gen()
+        L_m = _sparse_normalised_laplacian(G_m)
+        m_density, _ = kpm_spectral_density(
+            L_m, n_bins=50, n_moments=kpm_moments,
+            n_probes=kpm_probes, seed=seed + hash(name) % 1000,
+        )
+        gic_val = float(_gic(m_density))
+        results[name] = {"gic": gic_val, "param": label,
+                         "n": G_m.number_of_nodes(), "m": G_m.number_of_edges()}
+        print(f"  {name:<2s}  GIC={gic_val:.4f}  ({_fmt(time.perf_counter() - t0)})")
+        del G_m, L_m
+        gc.collect()
+
+    # 6. Summary + cache
+    summary_rows = [{"model": "Original", "gic": float("nan"), "param": "N/A",
+                     "nodes": n, "edges": m, "density": real_density_val}]
+    for name, data in results.items():
+        summary_rows.append({
+            "model": name, "gic": data["gic"], "param": data["param"],
+            "nodes": data["n"], "edges": data["m"],
+            "density": 2 * data["m"] / (data["n"] * (data["n"] - 1))
+            if data["n"] > 1 else 0,
+        })
+    summary_df = pd.DataFrame(summary_rows)
+    _print_summary(summary_df, n, m)
+
+    summary_df.to_csv(out_dir / "summary.csv", index=False)
+    with open(cache_path, "wb") as f:
+        pickle.dump({
+            "summary_df": summary_df,
+            "n": n, "m": m,
+            "lg_params": {"sigma": sigma, "beta": beta, "d": d_lg,
+                          "best_iter": best_iter, "best_L2": best_diff},
+            "config_signature": cfg_sig,
+        }, f)
+    print(f"\nArtifacts: {out_dir}")
+
+
+def _print_summary(summary_df, n, m):
+    print(f"\n=== Summary  (MUSAE Facebook GCC: n={n:,}, m={m:,}) ===\n")
+    print(summary_df.to_string(index=False))
+    models_only = summary_df[summary_df["model"] != "Original"].sort_values("gic")
+    print("\nRanking by GIC (lower = better):")
+    medals = ["🥇", "🥈", "🥉", "4️⃣"]
+    for rank, (_, row) in enumerate(models_only.iterrows(), 1):
+        m_str = medals[rank - 1] if rank <= 4 else f"{rank}."
+        print(f"  {m_str} {row['model']:>3s}  GIC = {row['gic']:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Covers **both** Facebook datasets in the repo:

### 1. MUSAE single large graph (`gic-facebook` / `gic-facebook-quick`)
- `notebooks/refactors/run_facebook_gic.py` — structural port of `run_arxiv_gic.py` (PR #27) to the MUSAE Facebook page-page network shipped in `data/facebook_large/musae_facebook_edges.csv` (n≈22,470, m≈171k).
- Full-graph approach: KPM spectral density on the sparse normalised Laplacian, sampled logistic regression for σ/β, single dense LG MCMC at d=0, sparse ER/WS/BA baselines.

### 2. SNAP ego networks (`gic-facebook-ego` / `gic-facebook-ego-quick`)
- `notebooks/refactors/run_facebook_ego_gic.py` — port of the gplus driver (PR #24) to the 10 SNAP Facebook ego networks in `data/misc/facebook/*.edges`. Per-graph fits + parallel workers + aggregate leaderboard plot.

Four Makefile targets:
| Target | What it does | Wall |
|---|---|---|
| `make gic-facebook` | MUSAE full graph, MAX_ITER=50k | ~1-2 min |
| `make gic-facebook-quick` | MUSAE smoke | ~1 min |
| `make gic-facebook-ego` | All 10 ego nets, parallel | ~1:30 |
| `make gic-facebook-ego-quick` | Small-ego smoke | ~15s |

## Results

### MUSAE page-page (n=22,470, m=170,823)
| Rank | Model | GIC |
|---|---|---|
| 🥇 | **LG** | **0.454** |
| 🥈 | WS | 0.514 |
| 🥉 | ER | 0.602 |
| 4️⃣ | BA | 0.633 |

### SNAP ego networks (10 nets, n=40 to 1034)
| Rank | Model | Mean rank | Wins |
|---|---|---|---|
| 🥇 | **LG** | **1.70** | 6/10 |
| 🥈 | BA | 2.20 | 2/10 |
| 🥉 | ER | 2.80 | 1/10 |
| 4️⃣ | WS | 3.30 | 1/10 |

LG dominates both datasets — strongest on MUSAE (decisive lead) and most of the ego networks.

## Test plan
- [x] `make gic-facebook-quick` ~57s, ranking matches above shape
- [x] `make gic-facebook` ~1:15
- [x] `make gic-facebook-ego-quick` ~10s
- [x] `make gic-facebook-ego` ~1:36
- [x] Artifacts land in `notebooks/refactors/runs/facebook/` and `notebooks/refactors/runs/facebook_ego/`