### PR TITLE
Add SBM (Louvain-fit) baseline across every real-data driver

### DIFF
--- a/notebooks/refactors/platform_fit_utils.py
+++ b/notebooks/refactors/platform_fit_utils.py
@@ -388,7 +388,7 @@ def fit_one_network(
         other_model_n_runs=cfg.other_model_n_runs,
         dist_type="KL",
         verbose=True,
-        other_models=["ER", "WS", "BA"],
+        other_models=["ER", "WS", "BA", "SBM"],
         other_model_grid_points=cfg.other_model_grid_points,
         random_state=cfg.seed,
     ).compare(original_graph=G_real, graph_filepath=graph_name)

--- a/notebooks/refactors/run_arxiv_gic.py
+++ b/notebooks/refactors/run_arxiv_gic.py
@@ -244,6 +244,7 @@ def main() -> None:
     del gm
     gc.collect()
 
+    from logit_graph.sbm import generate_sbm_from_real
     baselines = [
         ("ER", "Erdos-Renyi",
          lambda: nx.erdos_renyi_graph(n, real_density_val, seed=seed)),
@@ -251,6 +252,8 @@ def main() -> None:
          lambda: nx.watts_strogatz_graph(n, max(2, int(round(real_avg_deg))), 0.1, seed=seed)),
         ("BA", "Barabasi-Albert",
          lambda: nx.barabasi_albert_graph(n, max(1, int(round(real_avg_deg / 2))), seed=seed)),
+        ("SBM", "Louvain SBM",
+         lambda: generate_sbm_from_real(G_gcc, seed=seed)[0]),
     ]
     for name, label, gen in baselines:
         t0 = time.perf_counter()

--- a/notebooks/refactors/run_facebook_gic.py
+++ b/notebooks/refactors/run_facebook_gic.py
@@ -235,6 +235,7 @@ def main() -> None:
     del gm
     gc.collect()
 
+    from logit_graph.sbm import generate_sbm_from_real
     baselines = [
         ("ER", "Erdos-Renyi",
          lambda: nx.erdos_renyi_graph(n, real_density_val, seed=seed)),
@@ -242,6 +243,8 @@ def main() -> None:
          lambda: nx.watts_strogatz_graph(n, max(2, int(round(real_avg_deg))), 0.1, seed=seed)),
         ("BA", "Barabasi-Albert",
          lambda: nx.barabasi_albert_graph(n, max(1, int(round(real_avg_deg / 2))), seed=seed)),
+        ("SBM", "Louvain SBM",
+         lambda: generate_sbm_from_real(G_gcc, seed=seed)[0]),
     ]
     for name, label, gen in baselines:
         t0 = time.perf_counter()

--- a/notebooks/refactors/run_twitch_gic.py
+++ b/notebooks/refactors/run_twitch_gic.py
@@ -219,6 +219,7 @@ def fit_country(country: str, edge_path: Path, *, max_iter: int, check_interval:
                       "n": n, "m": best_lg["edges"], "d": best_lg["d"]}}
     gc.collect()
 
+    from logit_graph.sbm import generate_sbm_from_real
     baselines = [
         ("ER", "Erdos-Renyi",
          lambda: nx.erdos_renyi_graph(n, real_density_val, seed=seed)),
@@ -226,6 +227,8 @@ def fit_country(country: str, edge_path: Path, *, max_iter: int, check_interval:
          lambda: nx.watts_strogatz_graph(n, max(2, int(round(real_avg_deg))), 0.1, seed=seed)),
         ("BA", "Barabasi-Albert",
          lambda: nx.barabasi_albert_graph(n, max(1, int(round(real_avg_deg / 2))), seed=seed)),
+        ("SBM", "Louvain SBM",
+         lambda: generate_sbm_from_real(G_gcc, seed=seed)[0]),
     ]
     for name, label, gen in baselines:
         G_m = gen()

--- a/src/logit_graph/gic.py
+++ b/src/logit_graph/gic.py
@@ -16,6 +16,10 @@ _MODEL_N_PARAMS: dict[str, int] = {
     "GRG": 1,
     "KR": 1,
     "LG": 1,
+    # SBM has k(k+1)/2 block probabilities; the exact count is graph-
+    # dependent. ``_get_n_params`` returns 1 as a safe default and callers
+    # that care about the real count read it from ``sbm.fit_sbm_from_graph``.
+    "SBM": 1,
 }
 
 # Switch to KPM (Kernel Polynomial Method) approximation of the normalized
@@ -138,6 +142,11 @@ class GraphInformationCriterion:
             elif self.model == "BA":
                 m = max(1, int(self.parameter))  # Ensure m is at least 1
                 return nx.barabasi_albert_graph(self.n, m)
+            elif self.model == "SBM":
+                from .sbm import generate_sbm_from_real
+
+                G_sbm, _ = generate_sbm_from_real(self.graph)
+                return G_sbm
             elif self.model == "LG":
                 if isinstance(self.log_graph, tuple):
                     return self.log_graph[0]

--- a/src/logit_graph/model_selection.py
+++ b/src/logit_graph/model_selection.py
@@ -182,6 +182,13 @@ class GraphModelSelection:
             return nx.watts_strogatz_graph(n, k, float(params), seed=seed)
         if model == "BA":
             return nx.barabasi_albert_graph(n, int(params), seed=seed)
+        if model == "SBM":
+            # SBM has no scalar grid parameter — Louvain on the observed
+            # graph fixes the block structure; ``params`` is ignored.
+            from .sbm import generate_sbm_from_real
+
+            G_sbm, _ = generate_sbm_from_real(self.graph, seed=seed)
+            return G_sbm
         raise ValueError(f"Unknown model: {model}")
 
     def validate_input(self):
@@ -212,6 +219,15 @@ class GraphModelSelection:
             return ws_wrapper
         elif model_name == "BA":
             return lambda n, m: nx.barabasi_albert_graph(n, int(m))
+        elif model_name == "SBM":
+            # Closure over self.graph: SBM is fit on the observed graph
+            # (Louvain communities) rather than parameterised by n alone.
+            from .sbm import generate_sbm_from_real
+
+            def sbm_wrapper(n, _params):
+                G_sbm, _ = generate_sbm_from_real(self.graph, seed=None)
+                return G_sbm
+            return sbm_wrapper
         elif model_name == "LG":
             pass
         else:
@@ -263,6 +279,23 @@ class GraphModelSelection:
         results = []
         for idx, model in enumerate(self.models):
             print(f'Testing the selected model for {model}')
+            if model == "SBM":
+                # No scalar grid — Louvain on the observed graph fixes the
+                # block structure. Average across ``n_runs`` re-samples.
+                grid_offset = idx * 1000
+                avg_spectrum = self.calculate_average_spectrum(
+                    model, None, seed_offset=grid_offset,
+                )
+                real_spectrum, _ = gic.GraphInformationCriterion(
+                    self.graph, model,
+                ).compute_spectral_density(self.graph)
+                distance = float(np.linalg.norm(real_spectrum - avg_spectrum))
+                current_gic = gic.GraphInformationCriterion(
+                    graph=self.graph, model=model, p=None,
+                ).calculate_gic(model_den=avg_spectrum)
+                print(f'{model} gic: {current_gic}')
+                results.append((model, "Louvain-fit", distance, current_gic))
+                continue
             if model == "LG":
                 avg_spectrum = self.calculate_average_spectrum(model, None)
                 params = self.log_params
@@ -399,6 +432,13 @@ class GraphModelSelection:
         results = []
         for idx, model in enumerate(self.models):
             print(f'Testing the selected model for {model}')
+            if model == "SBM":
+                # No grid — Louvain on the observed graph fixes blocks.
+                avg_gic = self.calculate_average_gic(model, None)
+                result = {'param': 'Louvain-fit', 'gic': avg_gic}
+                print(f'{model} result:', result)
+                results.append((model, result['param'], result['gic']))
+                continue
             if model == "LG":
                 avg_gic = self.calculate_average_gic(model, None)
                 params = self.log_params

--- a/src/logit_graph/sbm.py
+++ b/src/logit_graph/sbm.py
@@ -1,0 +1,86 @@
+"""Stochastic Block Model baseline fitted to an observed graph.
+
+Single source of truth used by both the production codepath
+(``model_selection._generate_graph`` and
+``simulation.GraphModelComparator._fit_other_models``) and the
+single-graph driver scripts in ``notebooks/refactors/``.
+
+The fit follows the recipe in ``notebooks/more_baselines/02_new_baselines_facebook.ipynb``
+and the corresponding twitch notebook:
+
+  1. Detect communities on ``G_real`` with Louvain.
+  2. Treat the communities as SBM blocks; compute the per-block-pair edge
+     probability ``p_ij = actual_edges_between_blocks / possible_pairs``
+     (within-block uses ``len(B)·(len(B)-1)/2`` possible pairs).
+  3. Generate an SBM sample with ``nx.stochastic_block_model``.
+
+The model has ``k·(k+1)/2`` free probability parameters where ``k`` is the
+number of Louvain communities; this is reported as ``n_params`` for the
+caller's AIC bookkeeping. The current pipeline scores SBM by spectral
+GIC like the other baselines, so the parameter count is informational.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import networkx as nx
+import numpy as np
+
+
+def fit_sbm_from_graph(
+    G_real: nx.Graph,
+    seed: Optional[int] = None,
+) -> tuple[list[int], np.ndarray, list[list[int]]]:
+    """Louvain communities + per-block-pair edge probabilities.
+
+    Returns ``(sizes, p_matrix, comm_nodes)`` where:
+      - ``sizes`` is the list of community sizes in detection order;
+      - ``p_matrix`` is a ``k × k`` symmetric matrix of within / between
+        block edge probabilities;
+      - ``comm_nodes`` is the list of node-index lists per community
+        (sorted within each community), useful if the caller needs to
+        recover the partition.
+    """
+    comms = list(nx.community.louvain_communities(G_real, seed=seed))
+    sizes = [len(c) for c in comms]
+    k = len(comms)
+
+    comm_nodes = [sorted(c) for c in comms]
+    p_matrix = np.zeros((k, k))
+    for ci in range(k):
+        for cj in range(ci, k):
+            ni, nj = comm_nodes[ci], comm_nodes[cj]
+            if ci == cj:
+                possible = len(ni) * (len(ni) - 1) / 2
+                actual = sum(
+                    1 for u in ni for v in ni
+                    if u < v and G_real.has_edge(u, v)
+                )
+            else:
+                possible = len(ni) * len(nj)
+                actual = sum(
+                    1 for u in ni for v in nj if G_real.has_edge(u, v)
+                )
+            p = actual / possible if possible > 0 else 0.0
+            p_matrix[ci, cj] = p
+            p_matrix[cj, ci] = p
+    return sizes, p_matrix, comm_nodes
+
+
+def generate_sbm_from_real(
+    G_real: nx.Graph,
+    seed: Optional[int] = None,
+) -> tuple[nx.Graph, int]:
+    """Fit an SBM to ``G_real`` and draw one sample.
+
+    Returns ``(G_sbm, n_params)`` with ``n_params = k·(k+1)/2``.
+    The returned graph is a fresh ``nx.Graph`` re-labeled to integer
+    nodes ``0..n-1`` so it is directly comparable with other baselines.
+    """
+    sizes, p_matrix, _ = fit_sbm_from_graph(G_real, seed=seed)
+    sbm = nx.stochastic_block_model(sizes, p_matrix.tolist(), seed=seed)
+    G_out = nx.Graph()
+    G_out.add_nodes_from(range(sum(sizes)))
+    G_out.add_edges_from(sbm.edges())
+    k = len(sizes)
+    return G_out, k * (k + 1) // 2

--- a/src/logit_graph/simulation.py
+++ b/src/logit_graph/simulation.py
@@ -773,6 +773,10 @@ class GraphModelComparator:
             'WS': {'k': {'lo': 2, 'hi': 10, 'step': 2}, 'p': {'lo': 0.01, 'hi': 0.5}},
             'GRG': {'lo': 0.05, 'hi': 0.3},
             'BA': {'lo': 1, 'hi': 8},
+            # SBM has no scalar grid parameter — Louvain on the observed
+            # graph fixes the block structure. The dispatch in
+            # ``GraphModelSelection`` special-cases SBM and ignores this.
+            'SBM': None,
         }
         default_param_map: dict[str, Any] = {}
         if self.other_model_params is None:
@@ -811,18 +815,34 @@ class GraphModelComparator:
 
         for estimate in model_results['estimates']:
             model_name = estimate['model']
-            if model_name != 'LG':
-                param = clean_and_convert_param(estimate['param'])
+            if model_name == 'LG':
+                continue
+            if model_name == 'SBM':
+                # SBM has no scalar parameter — Louvain on G_real fixes
+                # the block structure. ``_generate_graph`` ignores the
+                # passed ``param`` for SBM.
+                fitted_graph = selector._generate_graph(model_name, None, seed_offset=0)
                 gic_value = estimate['GIC']
-                
-                fitted_graph = selector._generate_graph(model_name, param, seed_offset=0)
-                
                 self.fitted_graphs_data[model_name] = {
                     'graph': fitted_graph,
-                    'metadata': {'fit_success': True, 'param': param, 'gic_value': gic_value}
+                    'metadata': {'fit_success': True, 'param': 'Louvain-fit',
+                                 'gic_value': gic_value},
                 }
                 if self.verbose:
-                    print(f"{model_name} fitting - GIC: {gic_value:.4f}, Param: {param:.4f}")
+                    print(f"{model_name} fitting - GIC: {gic_value:.4f}, "
+                          f"Param: Louvain-fit")
+                continue
+            param = clean_and_convert_param(estimate['param'])
+            gic_value = estimate['GIC']
+
+            fitted_graph = selector._generate_graph(model_name, param, seed_offset=0)
+
+            self.fitted_graphs_data[model_name] = {
+                'graph': fitted_graph,
+                'metadata': {'fit_success': True, 'param': param, 'gic_value': gic_value},
+            }
+            if self.verbose:
+                print(f"{model_name} fitting - GIC: {gic_value:.4f}, Param: {param:.4f}")
 
     def _build_summary_df(self, graph_filepath: str) -> None:
         if self.verbose:


### PR DESCRIPTION
## Summary
Adds the Stochastic Block Model (SBM) as a 5th baseline alongside ER / WS / BA / LG in every real-data fitting driver. SBM was the only family from the paper that the production pipelines were missing.

The SBM fit uses the recipe from `notebooks/more_baselines/02_new_baselines_facebook.ipynb`:
1. **Louvain community detection** on the observed graph
2. **k×k matrix** of within / between block edge probabilities
3. Sample via **`nx.stochastic_block_model`**
4. Score with the same KPM-accelerated spectral GIC as the other baselines

No simulations are re-run in this PR — the user asked for the wiring only. Existing `make gic-*` targets will pick up SBM on the next run.

## Files

### New
- `src/logit_graph/sbm.py` — single source of truth
  - `fit_sbm_from_graph(G, seed) → (sizes, p_matrix, comm_nodes)`
  - `generate_sbm_from_real(G, seed) → (G_sbm, n_params=k(k+1)/2)`

### `src/logit_graph/` patches
- `gic.py` — `GraphInformationCriterion.generate_model_graph` dispatches "SBM" to the helper. `_MODEL_N_PARAMS["SBM"] = 1` placeholder (real count is graph-dependent).
- `model_selection.py` — `_generate_graph`, `model_function`, `select_model_avg_spectrum`, `select_model_avg_gic` all gain an "SBM" branch that **skips the scalar grid search** (Louvain on `self.graph` fixes the block structure).
- `simulation.py` — `_fit_other_models` adds SBM to `default_params` as a sentinel and surfaces its result into `fitted_graphs_data` without going through `clean_and_convert_param` (SBM's "param" is "Louvain-fit").

### Driver patches
- `notebooks/refactors/platform_fit_utils.py` — `fit_one_network` default `other_models` bumped from `["ER", "WS", "BA"]` → `["ER", "WS", "BA", "SBM"]`. **One edit propagates SBM to all five multi-graph drivers** (gplus / twitter / connectomes / human_connectomes / facebook_ego) with no further script changes needed.
- `notebooks/refactors/run_{arxiv, facebook, twitch}_gic.py` — append `("SBM", "Louvain SBM", lambda: generate_sbm_from_real(G_gcc, seed=seed)[0])` to each `baselines` list. Result tables now have a 5th row.

## Coverage check
| Driver | How SBM gets in |
|---|---|
| `run_arxiv_gic.py` | baselines list (single-graph) |
| `run_facebook_gic.py` | baselines list (single-graph) |
| `run_twitch_gic.py` | baselines list (single-graph) |
| `run_gplus_gic.py` | via `platform_fit_utils` default |
| `run_twitter_gic.py` | via `platform_fit_utils` default |
| `run_connectomes_gic.py` | via `platform_fit_utils` default |
| `run_human_connectomes_gic.py` | via `platform_fit_utils` default |
| `run_facebook_ego_gic.py` | via `platform_fit_utils` default |

Every real-data driver now produces an SBM row.

## Decisions taken on your behalf (you said "proceed")
- **Where to add the default**: changed `platform_fit_utils.fit_one_network` default (single edit) rather than per-script
- **AIC penalty for SBM**: skipped — SBM is treated as a GIC-only baseline like ER/WS/BA. `n_params = k(k+1)/2` is available from the helper if anyone wants to thread it later.

## Test plan
- [x] `python -c "from logit_graph.sbm import fit_sbm_from_graph, generate_sbm_from_real; ..."` — module imports cleanly
- [x] Karate-club smoke: Louvain finds 4 blocks, SBM sample produces a 34-node graph with similar density
- [x] `GraphInformationCriterion(model="SBM").generate_model_graph()` returns a valid graph
- [x] `GraphModelSelection(models=["SBM"], ...).select_model_avg_spectrum()` returns a proper estimates record `('SBM', 'Louvain-fit', distance, gic)`
- [ ] End-to-end runs of `make gic-*` targets — deferred per your "don't run" instruction