### PR TITLE
Apply GIC parameter penalty (2·n_params) with correct per-model counts

### DIFF
--- a/notebooks/refactors/run_arxiv_gic.py
+++ b/notebooks/refactors/run_arxiv_gic.py
@@ -224,11 +224,13 @@ def main() -> None:
     real_avg_deg = 2 * m / n
     eps = 1e-10
 
-    def _gic(p):
-        # Symmetric KL acts as our GIC stand-in (matches the notebook's compute_gic).
+    def _gic(p, n_params):
+        # GIC = 2*spectral_distance + 2*n_params (AIC-style complexity penalty);
+        # spectral_distance is the symmetric KL between the real and model ESDs.
         from scipy.stats import entropy as _entropy
-        return 0.5 * (_entropy(real_density + eps, p + eps)
+        dist = 0.5 * (_entropy(real_density + eps, p + eps)
                       + _entropy(p + eps, real_density + eps))
+        return 2.0 * dist + 2.0 * n_params
 
     # LG
     t0 = time.perf_counter()
@@ -237,25 +239,30 @@ def main() -> None:
         L_lg, n_bins=50, n_moments=kpm_moments,
         n_probes=kpm_probes, seed=seed + 99_991,
     )
-    lg_gic = _gic(lg_density)
+    lg_gic = _gic(lg_density, n_params=1)  # LG penalized on sigma only
     results["LG"] = {"gic": float(lg_gic), "param": f"σ={sigma:.3f},β={beta:.3f},d={d_lg}",
                      "n": n, "m": int(best_graph.sum() // 2)}
     print(f"  LG  GIC={lg_gic:.4f}  ({_fmt(time.perf_counter() - t0)})")
     del gm
     gc.collect()
 
-    from logit_graph.sbm import generate_sbm_from_real
+    from logit_graph.sbm import generate_sbm_from_real, fit_sbm_from_graph
+    # Free-parameter counts for the GIC penalty: ER/BA = 1 scalar, WS = 2 (k, p),
+    # SBM = k(k+1)/2 block-edge probabilities (k = number of Louvain communities).
+    _sbm_sizes, _, _ = fit_sbm_from_graph(G_gcc, seed=seed)
+    _sbm_k = len(_sbm_sizes)
+    sbm_n_params = _sbm_k * (_sbm_k + 1) // 2
     baselines = [
-        ("ER", "Erdos-Renyi",
+        ("ER", "Erdos-Renyi", 1,
          lambda: nx.erdos_renyi_graph(n, real_density_val, seed=seed)),
-        ("WS", "Watts-Strogatz",
+        ("WS", "Watts-Strogatz", 2,
          lambda: nx.watts_strogatz_graph(n, max(2, int(round(real_avg_deg))), 0.1, seed=seed)),
-        ("BA", "Barabasi-Albert",
+        ("BA", "Barabasi-Albert", 1,
          lambda: nx.barabasi_albert_graph(n, max(1, int(round(real_avg_deg / 2))), seed=seed)),
-        ("SBM", "Louvain SBM",
+        ("SBM", f"Louvain SBM (k={_sbm_k})", sbm_n_params,
          lambda: generate_sbm_from_real(G_gcc, seed=seed)[0]),
     ]
-    for name, label, gen in baselines:
+    for name, label, n_params, gen in baselines:
         t0 = time.perf_counter()
         G_m = gen()
         L_m = _sparse_normalised_laplacian(G_m)
@@ -263,7 +270,7 @@ def main() -> None:
             L_m, n_bins=50, n_moments=kpm_moments,
             n_probes=kpm_probes, seed=seed + hash(name) % 1000,
         )
-        gic_val = float(_gic(m_density))
+        gic_val = float(_gic(m_density, n_params))
         results[name] = {"gic": gic_val, "param": label,
                          "n": G_m.number_of_nodes(), "m": G_m.number_of_edges()}
         print(f"  {name:<2s}  GIC={gic_val:.4f}  ({_fmt(time.perf_counter() - t0)})")

--- a/notebooks/refactors/run_facebook_gic.py
+++ b/notebooks/refactors/run_facebook_gic.py
@@ -217,10 +217,13 @@ def main() -> None:
     real_avg_deg = 2 * m / n
     eps = 1e-10
 
-    def _gic(p):
+    def _gic(p, n_params):
+        # GIC = 2*spectral_distance + 2*n_params (AIC-style complexity penalty);
+        # spectral_distance is the symmetric KL between the real and model ESDs.
         from scipy.stats import entropy as _entropy
-        return 0.5 * (_entropy(real_density + eps, p + eps)
+        dist = 0.5 * (_entropy(real_density + eps, p + eps)
                       + _entropy(p + eps, real_density + eps))
+        return 2.0 * dist + 2.0 * n_params
 
     t0 = time.perf_counter()
     L_lg = _sparse_normalised_laplacian(best_graph)
@@ -228,25 +231,30 @@ def main() -> None:
         L_lg, n_bins=50, n_moments=kpm_moments,
         n_probes=kpm_probes, seed=seed + 99_991,
     )
-    lg_gic = float(_gic(lg_density))
+    lg_gic = float(_gic(lg_density, n_params=1))  # LG penalized on sigma only
     results["LG"] = {"gic": lg_gic, "param": f"σ={sigma:.3f},β={beta:.3f},d={d_lg}",
                      "n": n, "m": int(best_graph.sum() // 2)}
     print(f"  LG  GIC={lg_gic:.4f}  ({_fmt(time.perf_counter() - t0)})")
     del gm
     gc.collect()
 
-    from logit_graph.sbm import generate_sbm_from_real
+    from logit_graph.sbm import generate_sbm_from_real, fit_sbm_from_graph
+    # Free-parameter counts for the GIC penalty: ER/BA = 1 scalar, WS = 2 (k, p),
+    # SBM = k(k+1)/2 block-edge probabilities (k = number of Louvain communities).
+    _sbm_sizes, _, _ = fit_sbm_from_graph(G_gcc, seed=seed)
+    _sbm_k = len(_sbm_sizes)
+    sbm_n_params = _sbm_k * (_sbm_k + 1) // 2
     baselines = [
-        ("ER", "Erdos-Renyi",
+        ("ER", "Erdos-Renyi", 1,
          lambda: nx.erdos_renyi_graph(n, real_density_val, seed=seed)),
-        ("WS", "Watts-Strogatz",
+        ("WS", "Watts-Strogatz", 2,
          lambda: nx.watts_strogatz_graph(n, max(2, int(round(real_avg_deg))), 0.1, seed=seed)),
-        ("BA", "Barabasi-Albert",
+        ("BA", "Barabasi-Albert", 1,
          lambda: nx.barabasi_albert_graph(n, max(1, int(round(real_avg_deg / 2))), seed=seed)),
-        ("SBM", "Louvain SBM",
+        ("SBM", f"Louvain SBM (k={_sbm_k})", sbm_n_params,
          lambda: generate_sbm_from_real(G_gcc, seed=seed)[0]),
     ]
-    for name, label, gen in baselines:
+    for name, label, n_params, gen in baselines:
         t0 = time.perf_counter()
         G_m = gen()
         L_m = _sparse_normalised_laplacian(G_m)
@@ -254,7 +262,7 @@ def main() -> None:
             L_m, n_bins=50, n_moments=kpm_moments,
             n_probes=kpm_probes, seed=seed + hash(name) % 1000,
         )
-        gic_val = float(_gic(m_density))
+        gic_val = float(_gic(m_density, n_params))
         results[name] = {"gic": gic_val, "param": label,
                          "n": G_m.number_of_nodes(), "m": G_m.number_of_edges()}
         print(f"  {name:<2s}  GIC={gic_val:.4f}  ({_fmt(time.perf_counter() - t0)})")

--- a/notebooks/refactors/run_twitch_gic.py
+++ b/notebooks/refactors/run_twitch_gic.py
@@ -142,8 +142,10 @@ def _run_lg_mcmc(country, d, sigma, beta, G_gcc, real_density, *,
         L_lg, n_bins=50, n_moments=kpm_moments,
         n_probes=kpm_probes, seed=seed + 99_991 + d,
     )
-    gic_val = 0.5 * (_entropy(real_density + eps, lg_density + eps)
-                     + _entropy(lg_density + eps, real_density + eps))
+    _dist = 0.5 * (_entropy(real_density + eps, lg_density + eps)
+                   + _entropy(lg_density + eps, real_density + eps))
+    # GIC = 2*spectral_distance + 2*n_params; LG is penalized on sigma only (n_params=1).
+    gic_val = 2.0 * _dist + 2.0 * 1
 
     del gm, L_lg
     gc.collect()
@@ -189,9 +191,12 @@ def fit_country(country: str, edge_path: Path, *, max_iter: int, check_interval:
 
     # 1. AIC-select d ∈ d_candidates (cheap: no MCMC, just logit fits)
     eps = 1e-10
-    def _gic(p):
-        return 0.5 * (_entropy(real_density + eps, p + eps)
+    def _gic(p, n_params):
+        # GIC = 2*spectral_distance + 2*n_params (AIC-style complexity penalty);
+        # spectral_distance is the symmetric KL between the real and model ESDs.
+        dist = 0.5 * (_entropy(real_density + eps, p + eps)
                       + _entropy(p + eps, real_density + eps))
+        return 2.0 * dist + 2.0 * n_params
 
     from lg_aic_utils import aic_select_d, sample_pairs
     pairs, labels = sample_pairs(G_gcc, sample_edges, seed)
@@ -219,25 +224,30 @@ def fit_country(country: str, edge_path: Path, *, max_iter: int, check_interval:
                       "n": n, "m": best_lg["edges"], "d": best_lg["d"]}}
     gc.collect()
 
-    from logit_graph.sbm import generate_sbm_from_real
+    from logit_graph.sbm import generate_sbm_from_real, fit_sbm_from_graph
+    # Free-parameter counts for the GIC penalty: ER/BA = 1 scalar, WS = 2 (k, p),
+    # SBM = k(k+1)/2 block-edge probabilities (k = number of Louvain communities).
+    _sbm_sizes, _, _ = fit_sbm_from_graph(G_gcc, seed=seed)
+    _sbm_k = len(_sbm_sizes)
+    sbm_n_params = _sbm_k * (_sbm_k + 1) // 2
     baselines = [
-        ("ER", "Erdos-Renyi",
+        ("ER", "Erdos-Renyi", 1,
          lambda: nx.erdos_renyi_graph(n, real_density_val, seed=seed)),
-        ("WS", "Watts-Strogatz",
+        ("WS", "Watts-Strogatz", 2,
          lambda: nx.watts_strogatz_graph(n, max(2, int(round(real_avg_deg))), 0.1, seed=seed)),
-        ("BA", "Barabasi-Albert",
+        ("BA", "Barabasi-Albert", 1,
          lambda: nx.barabasi_albert_graph(n, max(1, int(round(real_avg_deg / 2))), seed=seed)),
-        ("SBM", "Louvain SBM",
+        ("SBM", f"Louvain SBM (k={_sbm_k})", sbm_n_params,
          lambda: generate_sbm_from_real(G_gcc, seed=seed)[0]),
     ]
-    for name, label, gen in baselines:
+    for name, label, n_params, gen in baselines:
         G_m = gen()
         L_m = _sparse_normalised_laplacian(G_m)
         m_density, _ = kpm_spectral_density(
             L_m, n_bins=50, n_moments=kpm_moments,
             n_probes=kpm_probes, seed=seed + hash(name) % 1000,
         )
-        gic_val = float(_gic(m_density))
+        gic_val = float(_gic(m_density, n_params))
         results[name] = {"gic": gic_val, "param": label,
                          "n": G_m.number_of_nodes(), "m": G_m.number_of_edges()}
         print(f"  {name:<2s}  GIC={gic_val:.4f}")

--- a/src/logit_graph/model_selection.py
+++ b/src/logit_graph/model_selection.py
@@ -290,11 +290,19 @@ class GraphModelSelection:
                     self.graph, model,
                 ).compute_spectral_density(self.graph)
                 distance = float(np.linalg.norm(real_spectrum - avg_spectrum))
+                # SBM fits k(k+1)/2 block-edge probabilities (k = number of
+                # Louvain communities). Penalize by the real count, not the
+                # _get_n_params() placeholder of 1, otherwise the GIC treats a
+                # ~k²-parameter block model as cheaply as a 1-parameter ER.
+                from .sbm import fit_sbm_from_graph
+                sbm_sizes, _, _ = fit_sbm_from_graph(self.graph, seed=grid_offset)
+                sbm_k = len(sbm_sizes)
+                sbm_n_params = sbm_k * (sbm_k + 1) // 2
                 current_gic = gic.GraphInformationCriterion(
                     graph=self.graph, model=model, p=None,
-                ).calculate_gic(model_den=avg_spectrum)
-                print(f'{model} gic: {current_gic}')
-                results.append((model, "Louvain-fit", distance, current_gic))
+                ).calculate_gic(model_den=avg_spectrum, n_params=sbm_n_params)
+                print(f'{model} gic: {current_gic} (k={sbm_k}, n_params={sbm_n_params})')
+                results.append((model, f"Louvain-fit (k={sbm_k})", distance, current_gic))
                 continue
             if model == "LG":
                 avg_spectrum = self.calculate_average_spectrum(model, None)


### PR DESCRIPTION
## The problem (answering: *is the GIC penalizing by number of fitted parameters?*)

**No — and it was broken in two distinct places.**

1. **Real-data drivers** (`run_arxiv_gic.py`, `run_facebook_gic.py`, `run_twitch_gic.py` — the headline LG-vs-baselines results) scored every model with a bare symmetric-KL spectral distance and *called it GIC*. There was **no parameter penalty at all**. So **SBM** — which fits `k·(k+1)/2` block-edge probabilities (often hundreds of parameters) — competed head-to-head with 1-parameter ER/BA purely on spectral fit.

2. **`model_selection.py`** *did* use `calculate_gic`'s `2·n_params` penalty, but passed **SBM as 1 parameter** (the `_MODEL_N_PARAMS["SBM"]=1` placeholder, whose own comment admits it's wrong) — even though `generate_sbm_from_real` returns the real `k·(k+1)/2` and the driver discarded it via `[0]`.

The class `GraphInformationCriterion.calculate_gic` was correct (`2·dist + 2·n_params`); the callers just weren't using it / weren't passing the right counts.

## The fix

Score every model as **`GIC = 2·spectral_distance + 2·n_params`** (AIC-style, matching `calculate_gic`), with per-model free-parameter counts:

| model | n_params |
|-------|----------|
| ER, BA | 1 |
| WS | 2 (k, p) |
| **LG** | **1** (σ; β pinned, d treated as a fixed modeling choice) |
| **SBM** | **k·(k+1)/2** (k = # Louvain communities) |

- `model_selection.py`: computes SBM's real `n_params` via `fit_sbm_from_graph` and passes it to `calculate_gic` (this also fixes `simulation.py`, which delegates baseline scoring here).
- The three real-data drivers: `_gic` now returns the penalized GIC; LG and each baseline pass their count; SBM's `k(k+1)/2` is computed from the Louvain fit.

## Effect & verification

- SBM is no longer under-penalized. Smoke test on a 5-community graph: SBM penalty goes **2 → 30** (`2·1 → 2·k(k+1)/2` with k=5). **Real-data rankings will shift** — SBM drops sharply (heavily penalized for its parameter budget); parsimonious LG benefits relatively.
- All 39 GIC / model-selection / param-estimator / bugfix tests pass.

## Caveats for the reviewer
- **Penalty scale:** the spectral distance is O(0.01–1) while `2·n_params` for SBM is O(k²), so for SBM the penalty dominates the distance — i.e. SBM ranks last largely on complexity. That's the honest AIC-style verdict on a ~k²-parameter model, but if you'd prefer a calibrated/scaled penalty, that's a one-line change. (Chosen per the AIC-style option.)
- **Cached results are stale:** the drivers cache by graph/config signature, which does *not* include the scoring formula — so re-running will return old (no-penalty) GIC values from cache. **Clear the driver caches** (or bump the config signature) before regenerating the paper numbers.