### PR TITLE
test(offset_logit/logit_estimator): edge-case coverage

### DIFF
--- a/tests/test_logit_estimator_edge.py
+++ b/tests/test_logit_estimator_edge.py
@@ -1,0 +1,93 @@
+"""Edge cases for LogitRegEstimator beyond the API surface in
+test_logit_estimator_api.py (construction, compute_aic, select_d, recovery).
+
+Adds: layer2 toggle effect on offsets, max_pairs subsampling + determinism,
+the statsmodels fit fallback, extra_penalty_per_d selection pressure, and
+estimate_parameters under fix_beta True/False.
+"""
+import numpy as np
+import networkx as nx
+
+from logit_graph.logit_estimator import LogitRegEstimator
+
+
+def _er(n, p, seed):
+    return nx.to_numpy_array(nx.erdos_renyi_graph(n, p, seed=seed))
+
+
+# -------------------------------------------------------------------
+# get_features_labels — layer2 toggle and subsampling
+# -------------------------------------------------------------------
+
+def test_layer2_toggle_changes_offsets_in_bounded_mode():
+    # In "bounded" mode the offset is log(1+S_i)+log(1+S_j); removing edge
+    # (i,j) drops each endpoint's degree by 1, so layer2 changes the offsets.
+    # (Note: "incremental" mode at d=1 is invariant to edge removal because the
+    # common-neighbor count excludes i and j.)
+    adj = _er(25, 0.3, seed=0)
+    est = LogitRegEstimator(adj, d=1, feature_mode="bounded")
+    feat_l2, _ = est.get_features_labels(layer2=True)
+    feat_no, _ = est.get_features_labels(layer2=False)
+    assert not np.allclose(feat_l2[:, 1], feat_no[:, 1])
+
+
+def test_max_pairs_subsamples_and_is_deterministic():
+    adj = _er(20, 0.25, seed=1)
+    est = LogitRegEstimator(adj, d=1)
+    f1, l1 = est.get_features_labels(max_pairs=30, seed=123)
+    f2, l2 = est.get_features_labels(max_pairs=30, seed=123)
+    assert f1.shape[0] == 30
+    assert len(l1) == 30
+    # Same seed ⇒ identical subsample.
+    np.testing.assert_array_equal(f1, f2)
+    assert l1 == l2
+
+
+# -------------------------------------------------------------------
+# _fit_offset_logit — statsmodels path returns a finite-llf result
+# -------------------------------------------------------------------
+
+def test_fit_offset_logit_returns_finite_llf():
+    adj = _er(30, 0.2, seed=2)
+    est = LogitRegEstimator(adj, d=1)
+    offsets, labels = est.get_features_labels()
+    result = est._fit_offset_logit(offsets[:, 1], labels)
+    assert np.isfinite(result.llf)
+
+
+# -------------------------------------------------------------------
+# select_d — extra_penalty_per_d pressure
+# -------------------------------------------------------------------
+
+def test_large_extra_penalty_per_d_selects_zero():
+    adj = _er(25, 0.2, seed=3)
+    est = LogitRegEstimator(adj, d=1)
+    # A huge per-d penalty makes d=0 (penalty 0) strictly cheapest.
+    best, stats = est.select_d(d_candidates=[0, 1, 2, 3], extra_penalty_per_d=1e6)
+    assert best == 0
+    # Penalty is additive: stats[d].aic grows monotonically with d here.
+    assert stats[1]["aic"] < stats[2]["aic"] < stats[3]["aic"]
+
+
+# -------------------------------------------------------------------
+# estimate_parameters — fix_beta True/False
+# -------------------------------------------------------------------
+
+def test_estimate_parameters_fix_beta_true_single_sigma():
+    adj = _er(20, 0.25, seed=4)
+    est = LogitRegEstimator(adj, d=1)
+    result, params, features = est.estimate_parameters(fix_beta=True)
+    arr = np.asarray(params)
+    # Offset logit estimates only the intercept sigma.
+    assert arr.shape[0] == 1
+    assert np.all(np.isfinite(arr))
+
+
+def test_estimate_parameters_fix_beta_false_two_params():
+    adj = _er(20, 0.25, seed=5)
+    est = LogitRegEstimator(adj, d=1)
+    result, params, features = est.estimate_parameters(fix_beta=False, l1_wt=1, alpha=0.0)
+    arr = np.asarray(params)
+    # const + degree-sum coefficient.
+    assert arr.shape[0] == 2
+    assert np.all(np.isfinite(arr))

--- a/tests/test_offset_logit_edge.py
+++ b/tests/test_offset_logit_edge.py
@@ -1,0 +1,128 @@
+"""Edge cases for the offset-logit MLE not covered in test_offset_logit_core.py.
+
+Core file covers: empty input, all-neg/all-pos, zero-offset density recovery,
+large mean-offset regression, statsmodels match, AIC formula. This file adds:
+the ``max_iter`` knob, extreme offsets, degenerate labels with nonzero offsets,
+the ``_offsets_are_zero`` detector, single observation, and combined AIC terms.
+"""
+import math
+
+import numpy as np
+
+from logit_graph.offset_logit import (
+    _offsets_are_zero,
+    aic_from_offset_fit,
+    fit_offset_logit_numba,
+)
+
+
+def _score_at(sigma, offsets, labels):
+    linpred = sigma + offsets
+    p = np.where(linpred >= 0,
+                 1.0 / (1.0 + np.exp(-linpred)),
+                 np.exp(linpred) / (1.0 + np.exp(linpred)))
+    return float(np.sum(labels - p))
+
+
+# -------------------------------------------------------------------
+# max_iter knob
+# -------------------------------------------------------------------
+
+def test_single_newton_step_is_finite():
+    rng = np.random.default_rng(0)
+    off = rng.normal(0.5, 1.0, size=200).astype(np.float64)
+    lab = (rng.random(200) < 0.3).astype(np.int8)
+    sigma, ll = fit_offset_logit_numba(off, lab, max_iter=1)
+    assert math.isfinite(sigma) and math.isfinite(ll)
+
+
+def test_more_iterations_reach_score_zero():
+    rng = np.random.default_rng(1)
+    off = rng.normal(0.0, 1.0, size=400).astype(np.float64)
+    lab = (rng.random(400) < 0.4).astype(np.int8)
+    sigma, _ = fit_offset_logit_numba(off, lab, max_iter=100)
+    # Well-conditioned ⇒ first-order condition sum(y - p) ≈ 0 at the MLE.
+    assert abs(_score_at(sigma, off, lab)) < 1e-4
+
+
+# -------------------------------------------------------------------
+# Extreme offsets stay finite
+# -------------------------------------------------------------------
+
+def test_extreme_positive_offsets_stay_finite():
+    n = 300
+    off = np.full(n, 100.0, dtype=np.float64)
+    rng = np.random.default_rng(2)
+    lab = (rng.random(n) < 0.5).astype(np.int8)
+    sigma, ll = fit_offset_logit_numba(off, lab)
+    assert math.isfinite(sigma) and math.isfinite(ll)
+
+
+def test_extreme_negative_offsets_stay_finite():
+    n = 300
+    off = np.full(n, -100.0, dtype=np.float64)
+    rng = np.random.default_rng(3)
+    lab = (rng.random(n) < 0.5).astype(np.int8)
+    sigma, ll = fit_offset_logit_numba(off, lab)
+    assert math.isfinite(sigma) and math.isfinite(ll)
+
+
+# -------------------------------------------------------------------
+# Degenerate labels with nonzero offsets (Hessian → 0 path)
+# -------------------------------------------------------------------
+
+def test_all_ones_labels_with_nonzero_offsets_finite():
+    rng = np.random.default_rng(4)
+    off = rng.normal(2.0, 0.5, size=150).astype(np.float64)
+    lab = np.ones(150, dtype=np.int8)
+    sigma, ll = fit_offset_logit_numba(off, lab)
+    assert math.isfinite(sigma) and math.isfinite(ll)
+
+
+def test_all_zeros_labels_with_nonzero_offsets_finite():
+    rng = np.random.default_rng(5)
+    off = rng.normal(-2.0, 0.5, size=150).astype(np.float64)
+    lab = np.zeros(150, dtype=np.int8)
+    sigma, ll = fit_offset_logit_numba(off, lab)
+    assert math.isfinite(sigma) and math.isfinite(ll)
+
+
+# -------------------------------------------------------------------
+# Single observation
+# -------------------------------------------------------------------
+
+def test_single_observation_is_finite():
+    off = np.array([0.5], dtype=np.float64)
+    lab = np.array([1], dtype=np.int8)
+    sigma, ll = fit_offset_logit_numba(off, lab)
+    assert math.isfinite(sigma) and math.isfinite(ll)
+
+
+# -------------------------------------------------------------------
+# _offsets_are_zero detector
+# -------------------------------------------------------------------
+
+def test_offsets_are_zero_exact():
+    assert _offsets_are_zero(np.zeros(10, dtype=np.float64))
+
+
+def test_offsets_are_zero_within_tolerance():
+    # Below the 1e-15 default tolerance ⇒ treated as zero.
+    assert _offsets_are_zero(np.full(10, 1e-16, dtype=np.float64))
+
+
+def test_offsets_not_zero_above_tolerance():
+    off = np.zeros(10, dtype=np.float64)
+    off[3] = 1e-10  # above 1e-15 ⇒ not zero
+    assert not _offsets_are_zero(off)
+
+
+# -------------------------------------------------------------------
+# AIC with combined k and extra_penalty
+# -------------------------------------------------------------------
+
+def test_aic_combines_k_and_extra_penalty():
+    res = aic_from_offset_fit(-2.0, -80.0, extra_penalty=3.0, k=2.0)
+    # -2*ll + 2*k + extra_penalty
+    assert math.isclose(res["aic"], 160.0 + 4.0 + 3.0)
+    assert res["k"] == 2.0


### PR DESCRIPTION
Adds two files (17 tests) covering edge cases beyond `test_offset_logit_core.py` and `test_logit_estimator_api.py`.

## `tests/test_offset_logit_edge.py`
- `max_iter` knob: a single Newton step is finite; more iterations reach score≈0.
- Extreme ±100 offsets stay finite (no overflow).
- Degenerate labels (all-0 / all-1) with nonzero offsets — exercises the Hessian→0 branch.
- Single observation.
- `_offsets_are_zero` detector: exact zeros, within-tolerance (1e-16), above-tolerance (1e-10).
- AIC combines `k` and `extra_penalty` simultaneously.

## `tests/test_logit_estimator_edge.py`
- layer2 toggle changes offsets in **bounded** mode (documents that **incremental** at d=1 is invariant to edge removal, since the common-neighbor count excludes i,j).
- `max_pairs` subsampling: exact row count + seed determinism.
- `_fit_offset_logit` returns a finite-llf statsmodels result.
- `extra_penalty_per_d` pressure forces `select_d` → 0, with monotone AIC in d.
- `estimate_parameters`: `fix_beta=True` → single sigma; `fix_beta=False` → const + degree-sum coefficient.

## Verification
- `pytest tests/test_offset_logit_edge.py tests/test_logit_estimator_edge.py` → 17 passed
- Full suite green (no regressions)

Part of a multi-PR effort to expand core-library test coverage.