### PR TITLE
exp(gplus): closed-form vs grid baselines + fair LG scoring (reproducible)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,13 @@ gic-gplus-quick:  ## Smoke run on small gplus subset (~30s)
 	LG_GPLUS_USE_CACHE=0 \
 		$(UV) run python notebooks/refactors/run_gplus_gic.py
 
+gic-gplus-closedform:  ## Closed-form vs grid baselines + fair LG on gplus (reproducible, ~30s)
+	$(UV) run python notebooks/refactors/run_gplus_closedform.py
+
+gic-gplus-closedform-quick:  ## Smoke run of the closed-form baseline experiment (~5s)
+	LG_CF_QUICK=1 \
+		$(UV) run python notebooks/refactors/run_gplus_closedform.py
+
 roc-paper-smoke:  ## Fast probe of ROC curve shape (~30s, n_eff=200, exps=20)
 	LG_EXPERIMENT_MODE=PAPER_ROC_SMOKE \
 	LG_ROC_USE_CACHE=0 \

--- a/notebooks/refactors/FINDINGS_gplus_closedform.md
+++ b/notebooks/refactors/FINDINGS_gplus_closedform.md
@@ -1,0 +1,66 @@
+# Closed-form baseline estimators vs grid search (gplus) — findings
+
+Quick experiment (`run_gplus_closedform.py`) on 8 gplus ego networks
+(50 ≤ n ≤ 120), n_runs=3, grid_points=3, LG via the real pipeline (best of
+d∈{0,1}). Baselines scored two ways and ranked by spectral GIC (2·KL + 2·n_params):
+
+- **grid** — current method: fixed interval, 3 grid points, **selected by min GIC**
+  (best case for the grid).
+- **cf** — closed-form moment estimate (ER p=density [exact MLE]; BA m=round(E/n);
+  WS k=2·round(E/n), p from clustering; KR d=round(2E/n); GRG r=√(k̄/(π(n−1)))).
+
+## Aggregate (mean GIC across 8 nets, lower = better)
+
+| family | grid | closed-form | Δ(grid−cf) | cf wins |
+|---|---|---|---|---|
+| ER | 4.363 | 4.330 | +0.03 | 38% |
+| BA | 3.449 | **4.223** | −0.78 | 12% |
+| WS | 4.829 | **10.823** | −5.99 | 0% |
+
+Mean rank (LG + closed-form baselines): BA 2.63, LG 2.88, ER 3.00, KR 3.25,
+GRG 3.25, WS 6.00.
+
+## Conclusion — closed-form moment matching does NOT improve baseline GIC
+
+The hypothesis from the prior analysis (that the fixed grid intervals are too
+tight and that density-matched closed forms would lower baseline GIC) is
+**refuted**:
+
+- **ER**: a wash (the KL distance on the normalized-Laplacian histogram is
+  nearly flat in p around the optimum).
+- **BA**: closed-form is *worse* (density-matched m overshoots).
+- **WS**: closed-form is *dramatically* worse (density-matched k≈2E/n, often
+  18–44, produces a near-lattice spectrum nothing like the clustered real graph).
+
+**Why:** GIC compares Laplacian *spectra*, not edge counts. For these clustered
+ego networks (C≈0.3–0.7) the spectral-GIC-optimal baseline parameter sits at a
+**lower density than the real graph**. Matching the first moment (density/degree)
+overshoots into worse spectral territory. The grid winner is consistently a
+*sparser* graph than the data (ER p≈0.13 regardless of real density; BA m≈4.5–8;
+WS k≈8–10).
+
+This also overturns the earlier "interval cap" concern. Network [7] has density
+0.407 (above the ER cap 0.25), yet its GIC-optimal ER is still p≈0.13 — the cap
+never binds harmfully because the optimum is at low density anyway.
+
+## What this means for the comparison
+
+The current grid already gives baselines their *best* GIC, so it is the **fair,
+strong-baseline** choice. Swapping in closed-form estimators would *handicap* the
+baselines (especially WS) and inflate LG's apparent advantage — the opposite of
+what we'd want for a credible comparison.
+
+The closed forms remain the correct *generative* estimators (MLE for ER; moment
+match for the rest) — they are just not the GIC-minimizing parameters, because
+spectral fit ≠ density fit.
+
+## Legitimate improvements that DO hold (not closed-form)
+
+1. **Selection rule** — the live pipeline (`model_selection.py:378`) picks the
+   grid winner by min L2 density distance but reports a KL-based GIC. Selecting by
+   GIC (as this experiment did) gives each baseline its true family minimum.
+2. **Grid resolution / averaging** — a slightly finer grid centered on the
+   low-density region plus larger n_runs would tighten baseline GIC further.
+
+Closed-form estimation is a dead end for a spectral objective; the lever is the
+search objective and resolution, not the point estimator.

--- a/notebooks/refactors/FINDINGS_gplus_closedform.md
+++ b/notebooks/refactors/FINDINGS_gplus_closedform.md
@@ -1,66 +1,78 @@
 # Closed-form baseline estimators vs grid search (gplus) — findings
 
-Quick experiment (`run_gplus_closedform.py`) on 8 gplus ego networks
-(50 ≤ n ≤ 120), n_runs=3, grid_points=3, LG via the real pipeline (best of
-d∈{0,1}). Baselines scored two ways and ranked by spectral GIC (2·KL + 2·n_params):
+Experiment: `run_gplus_closedform.py`. Score ER/BA/WS/KR/GRG against gplus ego
+networks by spectral GIC (2·KL + 2·n_params, KL on the 50-bin normalized-
+Laplacian density), comparing **closed-form moment estimators** vs the current
+**fixed-interval grid**, alongside LG fit via the real pipeline.
 
-- **grid** — current method: fixed interval, 3 grid points, **selected by min GIC**
-  (best case for the grid).
-- **cf** — closed-form moment estimate (ER p=density [exact MLE]; BA m=round(E/n);
-  WS k=2·round(E/n), p from clustering; KR d=round(2E/n); GRG r=√(k̄/(π(n−1)))).
+## Full run (matches Makefile `gic-gplus` preset)
 
-## Aggregate (mean GIC across 8 nets, lower = better)
+- Window **50 ≤ n ≤ 300** → **17** ego networks (all of them).
+- **n_runs=5, grid_points=5**, LG_ITER=2000, LG d-exploration **d ∈ {0,1,2}**.
+- grid = fixed interval, 5 points, **selected by min GIC** (best case for grid).
+- cf = closed-form: ER p=density (MLE); BA m=round(E/n); WS k=2·round(E/n),
+  p from clustering; KR d=round(2E/n); GRG r=√(k̄/(π(n−1))).
+
+### Aggregate (mean GIC across 17 nets, lower = better)
 
 | family | grid | closed-form | Δ(grid−cf) | cf wins |
 |---|---|---|---|---|
-| ER | 4.363 | 4.330 | +0.03 | 38% |
-| BA | 3.449 | **4.223** | −0.78 | 12% |
-| WS | 4.829 | **10.823** | −5.99 | 0% |
+| ER | **3.328** | 4.508 | −1.18 | 0% |
+| BA | **3.352** | 4.351 | −1.00 | 12% |
+| WS | **4.979** | 9.081 | −4.10 | 0% |
 
-Mean rank (LG + closed-form baselines): BA 2.63, LG 2.88, ER 3.00, KR 3.25,
-GRG 3.25, WS 6.00.
+Closed-form only (no grid): KR 4.499, GRG **3.840**, and **LG 3.999**.
 
-## Conclusion — closed-form moment matching does NOT improve baseline GIC
+Mean rank (LG + closed-form baselines): **GRG 2.12**, **LG 2.41**, BA 2.94,
+KR 3.71, ER 3.82, WS 6.00.
 
-The hypothesis from the prior analysis (that the fixed grid intervals are too
-tight and that density-matched closed forms would lower baseline GIC) is
-**refuted**:
+## Conclusion 1 — closed-form does NOT improve baseline GIC (confirmed at scale)
 
-- **ER**: a wash (the KL distance on the normalized-Laplacian histogram is
-  nearly flat in p around the optimum).
-- **BA**: closed-form is *worse* (density-matched m overshoots).
-- **WS**: closed-form is *dramatically* worse (density-matched k≈2E/n, often
-  18–44, produces a near-lattice spectrum nothing like the clustered real graph).
+At full scale with a finer grid and more averaging the verdict is sharper than
+the pilot: closed-form is **worse for every searchable family** — ER −1.18,
+BA −1.00, WS −4.10 — and **never wins for ER or WS** (0%).
 
 **Why:** GIC compares Laplacian *spectra*, not edge counts. For these clustered
-ego networks (C≈0.3–0.7) the spectral-GIC-optimal baseline parameter sits at a
-**lower density than the real graph**. Matching the first moment (density/degree)
-overshoots into worse spectral territory. The grid winner is consistently a
-*sparser* graph than the data (ER p≈0.13 regardless of real density; BA m≈4.5–8;
-WS k≈8–10).
+ego networks (C ≈ 0.3–0.73) the spectral-GIC-optimal baseline sits at a **much
+lower density than the data**. The grid winner is consistently far sparser than
+density-matching (ER p≈0.01–0.13 vs real 0.03–0.41; BA m≈3–8 vs cf 4–30; WS
+k≈6–10 vs cf 8–60). Matching the first moment overshoots into worse spectral
+territory — catastrophically for WS, whose density-matched k (up to 60) yields a
+near-lattice spectrum nothing like the real graph.
 
-This also overturns the earlier "interval cap" concern. Network [7] has density
-0.407 (above the ER cap 0.25), yet its GIC-optimal ER is still p≈0.13 — the cap
-never binds harmfully because the optimum is at low density anyway.
+The earlier "interval-cap" worry is also refuted: net [11] has density 0.407
+(above the ER cap 0.25), yet its GIC-optimal ER is p≈0.19 — the cap never binds
+harmfully because the optimum is at low density anyway.
 
-## What this means for the comparison
+→ Closed-form estimation is the right *generative* estimator (MLE for ER, moment
+match otherwise) but the **wrong** estimator for a spectral objective. Using it
+would *handicap* the baselines and inflate LG's apparent edge.
 
-The current grid already gives baselines their *best* GIC, so it is the **fair,
-strong-baseline** choice. Swapping in closed-form estimators would *handicap* the
-baselines (especially WS) and inflate LG's apparent advantage — the opposite of
-what we'd want for a credible comparison.
+## Conclusion 2 — the finer grid + more runs DID lower grid baseline GIC
 
-The closed forms remain the correct *generative* estimators (MLE for ER; moment
-match for the rest) — they are just not the GIC-minimizing parameters, because
-spectral fit ≠ density fit.
+vs the pilot (gp=3, n_runs=3): ER grid 4.36 → **3.33**, BA 3.45 → **3.35**,
+WS 4.83 → **4.98** (≈flat). Selecting by GIC over a finer low-density grid with
+more averaging is the **real** lever for tightening baseline GIC — not the point
+estimator.
 
-## Legitimate improvements that DO hold (not closed-form)
+## Two surprises worth a follow-up
 
-1. **Selection rule** — the live pipeline (`model_selection.py:378`) picks the
-   grid winner by min L2 density distance but reports a KL-based GIC. Selecting by
-   GIC (as this experiment did) gives each baseline its true family minimum.
-2. **Grid resolution / averaging** — a slightly finer grid centered on the
-   low-density region plus larger n_runs would tighten baseline GIC further.
+1. **GRG (closed-form) is the strongest baseline here** — best mean rank (2.12)
+   and lowest mean GIC (3.840), beating LG (3.999). The random geometric graph,
+   with its single closed-form radius, captures the high-clustering/spatial
+   structure of gplus ego nets well. GRG is **not** in the pipeline's baseline
+   set (`["ER","WS","BA","SBM"]`); adding it would be a stronger comparison.
 
-Closed-form estimation is a dead end for a spectral objective; the lever is the
-search objective and resolution, not the point estimator.
+2. **Well-fit ER and BA are competitive with LG.** On mean GIC, grid-ER (3.33)
+   and grid-BA (3.35) are *below* LG (4.00) on this window. The rank table favors
+   LG only because it ranks LG against the *handicapped* closed-form ER/BA/WS.
+   Caveat: LG here is capped at 2000 Gibbs iters (possibly undertrained at
+   n≈300), so this is an observation to investigate, not a firm claim.
+
+## Net takeaway
+
+Closed-form is a dead end for improving baseline GIC. The levers that work are
+(a) select the grid winner by GIC (the live pipeline uses L2 — `model_selection.py:378`),
+(b) a finer low-density grid + larger n_runs, and (c) consider adding GRG as a
+baseline. Worth re-checking LG convergence at n≈300 before drawing comparison
+conclusions.

--- a/notebooks/refactors/FINDINGS_gplus_closedform.md
+++ b/notebooks/refactors/FINDINGS_gplus_closedform.md
@@ -69,6 +69,36 @@ estimator.
    Caveat: LG here is capped at 2000 Gibbs iters (possibly undertrained at
    n≈300), so this is an observation to investigate, not a firm claim.
 
+## Update — fair LG scoring (burn-in + ensemble mean), n_runs=5, grid=5
+
+The first run scored LG via the pipeline's "best graph over a 2000-iter
+trajectory". `diag_lg_convergence.py` showed that GIC is a **noisy stationary
+walk**, that 2000 iters is mid-burn-in for large n and *pre*-burn-in for small
+n (n=54 still at GIC≈13 at iter 2000), and that best-of-trajectory cherry-picks
+the min of noise. We replaced it with the **same convention as the baselines**:
+burn in (max(4000, 25n) steps) then average the spectral density over 5
+post-burn-in snapshots → one GIC.
+
+Effect — **LG improves** (the 2000 cap had been *under*training it):
+
+| model | mean GIC |
+|---|---|
+| LG — best-of-2000 (old) | 3.999 |
+| **LG — fair burn-in + ensemble** | **3.549** |
+| ER grid | 3.328 |
+| BA grid | 3.352 |
+| GRG cf | 3.840 |
+| WS grid | 4.979 |
+
+LG now has the best mean rank vs the closed-form baselines (1.47) and beats GRG.
+But against **properly grid-fit** ER/BA it is still a hair behind on mean GIC
+(LG 3.55 vs ER 3.33, BA 3.35) — competitive, roughly tied, not a clear win.
+Per-net it is mixed: LG wins the denser/mid nets, ER/BA win several sparse ones.
+
+Caveat on fairness: baselines grid-search their parameter to *minimize* GIC,
+while LG's σ is the MLE (not GIC-optimized) and only d∈{0,1,2} is searched — so
+the baselines retain a small parameter-search advantage.
+
 ## Net takeaway
 
 Closed-form is a dead end for improving baseline GIC. The levers that work are

--- a/notebooks/refactors/diag_lg_convergence.py
+++ b/notebooks/refactors/diag_lg_convergence.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Diagnose LG Gibbs convergence by tracking GIC vs iteration on gplus nets.
+
+For a few representative ego networks (small / mid / large n) we run the LG
+Gibbs chain (warm-started, layer-2, incremental) and recompute the *full* GIC
+( 2*KL(real, current) + 2 ) every `CHECK` steps. This shows whether the chain
+has converged by iteration 2000 (the value used in the comparison run) or is
+still improving, and what a GIC-plateau stopping rule would pick.
+
+Read-only w.r.t. the library. Writes plots/CSV under runs/lg_convergence/.
+
+Env: LG_DIAG_BUDGET (12000)  LG_DIAG_CHECK (200)  LG_DIAG_D (1)
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import warnings
+from pathlib import Path
+
+import numpy as np
+import networkx as nx
+from scipy.stats import entropy
+
+_here = Path(__file__).resolve().parent
+_repo_root = _here.parents[1]
+_src = _repo_root / "src"
+for p in (_src, _here):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+warnings.filterwarnings("ignore")
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+from logit_graph.gic import GraphInformationCriterion  # noqa: E402
+from logit_graph.graph import GraphModel  # noqa: E402
+from logit_graph.simulation import estimate_sigma_only, _warm_start_er_p  # noqa: E402
+
+BUDGET = int(os.environ.get("LG_DIAG_BUDGET", "12000"))
+CHECK = int(os.environ.get("LG_DIAG_CHECK", "200"))
+D = int(os.environ.get("LG_DIAG_D", "1"))
+SEED = 12345
+REF_ITER = 2000  # the cap used in the comparison run
+
+
+def pick_representative(files, targets=((50, 70), (120, 145), (280, 300))):
+    chosen = {}
+    for f in files:
+        G = nx.read_edgelist(f, create_using=nx.DiGraph).to_undirected()
+        n = G.number_of_nodes()
+        for lo, hi in targets:
+            if (lo, hi) not in chosen and lo <= n <= hi:
+                chosen[(lo, hi)] = (f, n)
+        if len(chosen) == len(targets):
+            break
+    return list(chosen.values())
+
+
+def gic_trajectory(adj, d):
+    """Return (iters, gics) tracking 2*KL+2 every CHECK Gibbs steps."""
+    n = adj.shape[0]
+    real_nx = nx.from_numpy_array(adj)
+    scorer = GraphInformationCriterion(real_nx, model="LG", dist="KL")
+    real_den = scorer.compute_spectral_density(real_nx)[0]
+
+    sigma, _ = estimate_sigma_only(adj, d=d, feature_mode="incremental")
+    warm = _warm_start_er_p(sigma)
+    gm = GraphModel(n=n, d=d, sigma=sigma, er_p=warm, layer2=True,
+                    feature_mode="incremental", seed=SEED)
+
+    def cur_gic():
+        cur_den = scorer.compute_spectral_density(nx.from_numpy_array(gm.graph))[0]
+        return 2.0 * float(entropy(real_den + 1e-10, cur_den + 1e-10)) + 2.0
+
+    iters = [0]
+    gics = [cur_gic()]
+    done = 0
+    while done < BUDGET:
+        for _ in range(CHECK):
+            gm.add_remove_edge()
+        done += CHECK
+        iters.append(done)
+        gics.append(cur_gic())
+    return np.array(iters), np.array(gics), float(sigma)
+
+
+def plateau_iter(iters, gics, tol=0.02):
+    """First iteration whose best-so-far is within `tol` of the global min."""
+    best = np.minimum.accumulate(gics)
+    target = best[-1] + tol
+    idx = int(np.argmax(best <= target))
+    return int(iters[idx]), float(best[-1])
+
+
+def main():
+    files = sorted((_repo_root / "data" / "misc" / "gplus").glob("*.edges"))
+    out = _here / "runs" / "lg_convergence"
+    out.mkdir(parents=True, exist_ok=True)
+    reps = pick_representative(files)
+    print(f"LG convergence diag  d={D}  budget={BUDGET}  check={CHECK}  "
+          f"nets={[(f.stem[:8], n) for f, n in reps]}")
+
+    fig, axes = plt.subplots(1, len(reps), figsize=(5 * len(reps), 4), squeeze=False)
+    rows = []
+    for ax, (f, n) in zip(axes[0], reps):
+        adj = nx.to_numpy_array(nx.convert_node_labels_to_integers(
+            nx.read_edgelist(f, create_using=nx.DiGraph).to_undirected()))
+        t0 = time.perf_counter()
+        iters, gics, sigma = gic_trajectory(adj, D)
+        conv_it, best_gic = plateau_iter(iters, gics)
+        gic_at_ref = float(gics[np.searchsorted(iters, REF_ITER)])
+        rows.append(dict(name=f.stem[:10], n=n, sigma=round(sigma, 3),
+                         gic_init=round(float(gics[0]), 3),
+                         gic_at_2000=round(gic_at_ref, 3),
+                         gic_best=round(best_gic, 3),
+                         best_iter=conv_it,
+                         improve_after_2000=round(gic_at_ref - best_gic, 3)))
+        ax.plot(iters, gics, lw=1.4)
+        ax.axvline(REF_ITER, color="red", ls="--", lw=1, label="iter=2000 (cap)")
+        ax.axhline(best_gic, color="green", ls=":", lw=1, label=f"best={best_gic:.2f}")
+        ax.axvline(conv_it, color="green", ls="-", lw=0.8, alpha=0.5)
+        ax.set_title(f"{f.stem[:8]}  n={n}  σ={sigma:.2f}")
+        ax.set_xlabel("Gibbs iterations")
+        ax.set_ylabel("GIC = 2·KL + 2")
+        ax.legend(fontsize=8)
+        print(f"  n={n:4d}  GIC: init={gics[0]:.3f}  @2000={gic_at_ref:.3f}  "
+              f"best={best_gic:.3f} @iter={conv_it}  "
+              f"(still improves {gic_at_ref - best_gic:+.3f} after 2000)  "
+              f"[{time.perf_counter() - t0:.0f}s]")
+
+    fig.tight_layout()
+    fig.savefig(out / f"lg_convergence_d{D}.png", dpi=110)
+    import pandas as pd
+    pd.DataFrame(rows).to_csv(out / f"lg_convergence_d{D}.csv", index=False)
+    print(f"\nWrote {out / f'lg_convergence_d{D}.png'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/notebooks/refactors/run_gplus_closedform.py
+++ b/notebooks/refactors/run_gplus_closedform.py
@@ -24,7 +24,8 @@ GraphModelComparator LG path; writes only under runs/gplus_closedform/.
 
 Env knobs:
   LG_CF_MIN_NODES (50)  LG_CF_MAX_NODES (120)  LG_CF_MAX_NETS (8)
-  LG_CF_N_RUNS (3)      LG_CF_GRID_POINTS (3)  LG_CF_LG_ITER (1500)
+  LG_CF_N_RUNS (5)      LG_CF_GRID_POINTS (5)
+  LG fair scoring = burn-in (max(4000,25n)) + N_RUNS spectral snapshots
 """
 from __future__ import annotations
 
@@ -49,7 +50,12 @@ for p in (_src, _here):
 warnings.filterwarnings("ignore")
 
 from logit_graph.gic import GraphInformationCriterion, _MODEL_N_PARAMS  # noqa: E402
-from logit_graph.simulation import GraphModelComparator  # noqa: E402
+from logit_graph.graph import GraphModel  # noqa: E402
+from logit_graph.simulation import (  # noqa: E402
+    _direct_er_at_sigma,
+    _warm_start_er_p,
+    estimate_sigma_only,
+)
 
 
 def _int(env, default):
@@ -62,8 +68,13 @@ MAX_NODES = _int("LG_CF_MAX_NODES", 300)   # matches Makefile gic-gplus (full pr
 MAX_NETS = _int("LG_CF_MAX_NETS", 10_000)  # run all nets in the window
 N_RUNS = _int("LG_CF_N_RUNS", 5)
 GRID_POINTS = _int("LG_CF_GRID_POINTS", 5)
-LG_ITER = _int("LG_CF_LG_ITER", 2000)      # matches Makefile gic-gplus
 LG_D_LIST = [0, 1, 2]                       # LG d exploration
+# Fair LG scoring: burn-in then N_RUNS spectral snapshots (stride apart),
+# scaled with n. Burn-in past the noisy walk seen in diag_lg_convergence.py.
+LG_BURN_MIN = _int("LG_CF_LG_BURN_MIN", 4000)
+LG_BURN_PER_N = _int("LG_CF_LG_BURN_PER_N", 25)
+LG_STRIDE_MIN = _int("LG_CF_LG_STRIDE_MIN", 600)
+LG_STRIDE_PER_N = _int("LG_CF_LG_STRIDE_PER_N", 6)
 SEED = 12345
 
 # Current fixed intervals (mirror simulation.py defaults).
@@ -181,20 +192,53 @@ def grid_best_ws(real_nx, n, n_runs, seed):
 
 
 # ---------------------------------------------------------------------------
-# LG via the real pipeline (best of d in {0,1})
+# LG scored FAIRLY: burn-in + ensemble-mean spectral density (same convention
+# as the baselines, which average n_runs sample densities). This avoids the
+# pipeline's "best graph over a noisy trajectory" cherry-pick, which is
+# downward-biased and budget-dependent (see diag_lg_convergence.py).
 # ---------------------------------------------------------------------------
 
+def _lg_burn(n):
+    return max(LG_BURN_MIN, LG_BURN_PER_N * n)
+
+
+def _lg_stride(n):
+    return max(LG_STRIDE_MIN, LG_STRIDE_PER_N * n)
+
+
+def lg_gic_one_d(adj, d, seed):
+    n = adj.shape[0]
+    real_nx = nx.from_numpy_array(adj)
+    scorer = GraphInformationCriterion(real_nx, model="LG", dist="KL")
+    sigma, _ = estimate_sigma_only(adj, d=d, feature_mode="incremental")
+
+    dens = []
+    if d == 0:
+        # d=0 equilibrium is ER(expit(sigma)); ensemble of independent draws.
+        for r in range(N_RUNS):
+            g = nx.from_numpy_array(_direct_er_at_sigma(n, sigma, seed=seed + r))
+            dens.append(scorer.compute_spectral_density(g)[0])
+    else:
+        gm = GraphModel(n=n, d=d, sigma=sigma, er_p=_warm_start_er_p(sigma),
+                        layer2=True, feature_mode="incremental", seed=seed)
+        for _ in range(_lg_burn(n)):
+            gm.add_remove_edge()
+        for s in range(N_RUNS):
+            for _ in range(_lg_stride(n)):
+                gm.add_remove_edge()
+            dens.append(scorer.compute_spectral_density(nx.from_numpy_array(gm.graph))[0])
+
+    avg = np.mean(dens, axis=0)
+    return float(scorer.calculate_gic(model_den=avg, n_params=1)), sigma
+
+
 def lg_gic(adj, seed):
-    lg_params = dict(max_iterations=LG_ITER, patience=300, edge_delta=None,
-                     min_gic_threshold=5, check_interval=50)
-    cmp = GraphModelComparator(d_list=LG_D_LIST, lg_params=lg_params, dist_type="KL",
-                               verbose=False, random_state=seed)
     best = (np.inf, None)
     for d in LG_D_LIST:
         try:
-            _, sigma, gic_val, *_ = cmp._get_logit_graph_for_d(adj, d)
-            if gic_val < best[0]:
-                best = (gic_val, d)
+            g, _ = lg_gic_one_d(adj, d, seed + d)
+            if g < best[0]:
+                best = (g, d)
         except Exception as e:
             print(f"    LG d={d} failed: {e}")
     return best
@@ -211,7 +255,8 @@ def main():
     out_dir.mkdir(parents=True, exist_ok=True)
 
     print(f"closed-form baseline experiment  window=[{MIN_NODES},{MAX_NODES}]  "
-          f"max_nets={MAX_NETS}  n_runs={N_RUNS}  grid_points={GRID_POINTS}  lg_iter={LG_ITER}")
+          f"max_nets={MAX_NETS}  n_runs={N_RUNS}  grid_points={GRID_POINTS}  "
+          f"lg_burn=max({LG_BURN_MIN},{LG_BURN_PER_N}n)  lg_stride=max({LG_STRIDE_MIN},{LG_STRIDE_PER_N}n)")
 
     rows = []
     picked = 0

--- a/notebooks/refactors/run_gplus_closedform.py
+++ b/notebooks/refactors/run_gplus_closedform.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Quick experiment: closed-form (moment-matched) baseline estimators vs the
+current fixed-interval grid search, on gplus ego networks, alongside LG.
+
+For each gplus ego network in a small size window we score, by spectral GIC
+(2*KL + 2*n_params, KL on the 50-bin normalized-Laplacian density):
+
+  * LG            -- the real pipeline fit (estimate sigma, generate, best-of)
+  * ER/BA/WS      -- two ways each:
+       grid : current method (fixed interval, grid_points pts, pick min GIC)
+       cf   : closed-form moment estimate (no search)
+  * KR/GRG        -- closed-form only (bonus families)
+
+Closed-form estimators (n nodes, E edges, kbar = 2E/n avg degree):
+  ER  p = 2E/(n(n-1))                      (exact MLE)
+  BA  m = round(E/n)            in [1, n)   (edge count E = m(n-m))
+  WS  k = 2*round(E/n) (even)   in [2, n)   (E = nk/2, rewiring conserves edges)
+  WS  p = 1 - (C_obs/C0)^(1/3), C0 = 3(k-2)/(4(k-1))   (clustering moment)
+  KR  d = round(kbar)          (nd even)   (E = nd/2)
+  GRG r = sqrt(kbar / (pi*(n-1)))          (E[deg] ~ (n-1) pi r^2, 2-D)
+
+Read-only w.r.t. the library: uses logit_graph's own GIC scorer and the same
+GraphModelComparator LG path; writes only under runs/gplus_closedform/.
+
+Env knobs:
+  LG_CF_MIN_NODES (50)  LG_CF_MAX_NODES (120)  LG_CF_MAX_NETS (8)
+  LG_CF_N_RUNS (3)      LG_CF_GRID_POINTS (3)  LG_CF_LG_ITER (1500)
+"""
+from __future__ import annotations
+
+import math
+import os
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import networkx as nx
+import pandas as pd
+
+_here = Path(__file__).resolve().parent
+_repo_root = _here.parents[1]
+_src = _repo_root / "src"
+for p in (_src, _here):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+warnings.filterwarnings("ignore")
+
+from logit_graph.gic import GraphInformationCriterion, _MODEL_N_PARAMS  # noqa: E402
+from logit_graph.simulation import GraphModelComparator  # noqa: E402
+
+
+def _int(env, default):
+    raw = os.environ.get(env)
+    return int(raw) if raw is not None else default
+
+
+MIN_NODES = _int("LG_CF_MIN_NODES", 50)
+MAX_NODES = _int("LG_CF_MAX_NODES", 120)
+MAX_NETS = _int("LG_CF_MAX_NETS", 8)
+N_RUNS = _int("LG_CF_N_RUNS", 3)
+GRID_POINTS = _int("LG_CF_GRID_POINTS", 3)
+LG_ITER = _int("LG_CF_LG_ITER", 1500)
+SEED = 12345
+
+# Current fixed intervals (mirror simulation.py defaults).
+GRID_INTERVALS = {"ER": (0.01, 0.25), "BA": (1, 8), "WS_k": (2, 10), "WS_p": (0.01, 0.5)}
+
+
+# ---------------------------------------------------------------------------
+# GIC scoring (apples-to-apples with the pipeline)
+# ---------------------------------------------------------------------------
+
+def gic_of(real_nx, model_name, gen_fn, n_runs, seed):
+    """GIC = 2*KL(real_density, mean_model_density) + 2*n_params."""
+    n_params = _MODEL_N_PARAMS.get(model_name, 1)
+    specs = []
+    for r in range(n_runs):
+        try:
+            g = gen_fn(seed + r)
+        except Exception:
+            continue
+        den, _ = GraphInformationCriterion(real_nx, model=model_name).compute_spectral_density(g)
+        specs.append(den)
+    if not specs:
+        return np.nan, np.nan
+    avg = np.mean(specs, axis=0)
+    scorer = GraphInformationCriterion(real_nx, model=model_name, dist="KL")
+    return float(scorer.calculate_gic(model_den=avg, n_params=n_params)), n_params
+
+
+# ---------------------------------------------------------------------------
+# Generators
+# ---------------------------------------------------------------------------
+
+def _er(n, p):
+    p = float(np.clip(p, 1e-6, 1.0))
+    return lambda s: nx.erdos_renyi_graph(n, p, seed=s)
+
+
+def _ba(n, m):
+    m = int(np.clip(m, 1, n - 1))
+    return lambda s: nx.barabasi_albert_graph(n, m, seed=s)
+
+
+def _ws(n, k, p):
+    k = int(np.clip(k, 2, n - 1))
+    if k % 2 == 1:
+        k += 1
+    p = float(np.clip(p, 0.0, 1.0))
+    return lambda s: nx.watts_strogatz_graph(n, k, p, seed=s)
+
+
+def _kr(n, d):
+    d = int(np.clip(d, 0, n - 1))
+    if (n * d) % 2 == 1:
+        d -= 1
+    return lambda s: nx.random_regular_graph(d, n, seed=s)
+
+
+def _grg(n, r):
+    r = float(np.clip(r, 1e-3, 1.5))
+    return lambda s: nx.random_geometric_graph(n, r, seed=s)
+
+
+# ---------------------------------------------------------------------------
+# Closed-form estimators
+# ---------------------------------------------------------------------------
+
+def closed_form_params(G):
+    n = G.number_of_nodes()
+    E = G.number_of_edges()
+    kbar = 2 * E / n
+    p_er = 2 * E / (n * (n - 1))
+    m_ba = max(1, round(E / n))
+    k_ws = max(2, int(round(kbar)))
+    if k_ws % 2 == 1:
+        k_ws += 1
+    # WS rewiring p from clustering moment.
+    C_obs = nx.average_clustering(G)
+    if k_ws > 2:
+        C0 = 3 * (k_ws - 2) / (4 * (k_ws - 1))
+        p_ws = 0.0 if C_obs >= C0 else 1.0 - (C_obs / C0) ** (1.0 / 3.0)
+    else:
+        p_ws = 0.0
+    d_kr = int(round(kbar))
+    r_grg = math.sqrt(kbar / (math.pi * (n - 1)))
+    return dict(n=n, E=E, density=p_er, kbar=kbar,
+                ER=p_er, BA=m_ba, WS_k=k_ws, WS_p=p_ws, KR=d_kr, GRG=r_grg,
+                C_obs=C_obs)
+
+
+# ---------------------------------------------------------------------------
+# Current-style grid search (fixed interval, pick min GIC = best case for grid)
+# ---------------------------------------------------------------------------
+
+def grid_best(real_nx, model_name, n, build_gen, lo, hi, n_runs, seed):
+    best = (np.nan, None)
+    for j, val in enumerate(np.linspace(lo, hi, GRID_POINTS)):
+        g, _ = gic_of(real_nx, model_name, build_gen(val), n_runs, seed + 100 * j)
+        if not np.isnan(g) and (best[1] is None or g < best[0]):
+            best = (g, val)
+    return best
+
+
+def grid_best_ws(real_nx, n, n_runs, seed):
+    klo, khi = GRID_INTERVALS["WS_k"]
+    plo, phi = GRID_INTERVALS["WS_p"]
+    best = (np.nan, None)
+    j = 0
+    for k in range(int(klo), int(khi) + 1, 2):
+        for p in np.linspace(plo, phi, GRID_POINTS):
+            g, _ = gic_of(real_nx, "WS", _ws(n, k, p), n_runs, seed + 100 * j)
+            j += 1
+            if not np.isnan(g) and (best[1] is None or g < best[0]):
+                best = (g, (k, round(float(p), 3)))
+    return best
+
+
+# ---------------------------------------------------------------------------
+# LG via the real pipeline (best of d in {0,1})
+# ---------------------------------------------------------------------------
+
+def lg_gic(adj, seed):
+    lg_params = dict(max_iterations=LG_ITER, patience=300, edge_delta=None,
+                     min_gic_threshold=5, check_interval=50)
+    cmp = GraphModelComparator(d_list=[0, 1], lg_params=lg_params, dist_type="KL",
+                               verbose=False, random_state=seed)
+    best = (np.inf, None)
+    for d in (0, 1):
+        try:
+            _, sigma, gic_val, *_ = cmp._get_logit_graph_for_d(adj, d)
+            if gic_val < best[0]:
+                best = (gic_val, d)
+        except Exception as e:
+            print(f"    LG d={d} failed: {e}")
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    data_dir = _repo_root / "data" / "misc" / "gplus"
+    files = sorted(data_dir.glob("*.edges"))
+    out_dir = _here / "runs" / "gplus_closedform"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"closed-form baseline experiment  window=[{MIN_NODES},{MAX_NODES}]  "
+          f"max_nets={MAX_NETS}  n_runs={N_RUNS}  grid_points={GRID_POINTS}  lg_iter={LG_ITER}")
+
+    rows = []
+    picked = 0
+    for f in files:
+        if picked >= MAX_NETS:
+            break
+        G = nx.read_edgelist(f, create_using=nx.DiGraph).to_undirected()
+        G = nx.convert_node_labels_to_integers(G)
+        n = G.number_of_nodes()
+        if not (MIN_NODES <= n <= MAX_NODES):
+            continue
+        picked += 1
+        cf = closed_form_params(G)
+        adj = nx.to_numpy_array(G)
+        real_nx = nx.from_numpy_array(adj)
+        name = f.stem[:10]
+        print(f"\n[{picked}] {name}  n={n}  E={cf['E']}  density={cf['density']:.3f}  "
+              f"kbar={cf['kbar']:.1f}  C={cf['C_obs']:.3f}")
+
+        # LG
+        lg_val, lg_d = lg_gic(adj, SEED)
+        print(f"    LG     gic={lg_val:.3f} (d={lg_d})")
+
+        # ER
+        er_grid = grid_best(real_nx, "ER", n,
+                            lambda v: _er(n, v), *GRID_INTERVALS["ER"], N_RUNS, SEED)
+        er_cf, _ = gic_of(real_nx, "ER", _er(n, cf["ER"]), N_RUNS, SEED)
+        print(f"    ER     grid={er_grid[0]:.3f} (p={er_grid[1]:.3f})   "
+              f"cf={er_cf:.3f} (p={cf['ER']:.3f})")
+
+        # BA
+        ba_grid = grid_best(real_nx, "BA", n,
+                            lambda v: _ba(n, v), *GRID_INTERVALS["BA"], N_RUNS, SEED)
+        ba_cf, _ = gic_of(real_nx, "BA", _ba(n, cf["BA"]), N_RUNS, SEED)
+        print(f"    BA     grid={ba_grid[0]:.3f} (m={ba_grid[1]:.1f})   "
+              f"cf={ba_cf:.3f} (m={cf['BA']})")
+
+        # WS
+        ws_grid = grid_best_ws(real_nx, n, N_RUNS, SEED)
+        ws_cf, _ = gic_of(real_nx, "WS", _ws(n, cf["WS_k"], cf["WS_p"]), N_RUNS, SEED)
+        print(f"    WS     grid={ws_grid[0]:.3f} (k,p={ws_grid[1]})   "
+              f"cf={ws_cf:.3f} (k={cf['WS_k']},p={cf['WS_p']:.3f})")
+
+        # KR / GRG closed-form only
+        kr_cf, _ = gic_of(real_nx, "KR", _kr(n, cf["KR"]), N_RUNS, SEED)
+        grg_cf, _ = gic_of(real_nx, "GRG", _grg(n, cf["GRG"]), N_RUNS, SEED)
+        print(f"    KR cf={kr_cf:.3f} (d={cf['KR']})   GRG cf={grg_cf:.3f} (r={cf['GRG']:.3f})")
+
+        rows.append(dict(
+            name=name, n=n, E=cf["E"], density=cf["density"], kbar=cf["kbar"],
+            LG=lg_val, LG_d=lg_d,
+            ER_grid=er_grid[0], ER_cf=er_cf,
+            BA_grid=ba_grid[0], BA_cf=ba_cf,
+            WS_grid=ws_grid[0], WS_cf=ws_cf,
+            KR_cf=kr_cf, GRG_cf=grg_cf,
+        ))
+
+    df = pd.DataFrame(rows)
+    if df.empty:
+        print("\nNo networks in window.")
+        return
+    df.to_csv(out_dir / "results.csv", index=False)
+
+    print("\n" + "=" * 78)
+    print("AGGREGATE (mean GIC across networks, lower = better)")
+    print("=" * 78)
+    for fam in ("ER", "BA", "WS"):
+        g = df[f"{fam}_grid"].mean()
+        c = df[f"{fam}_cf"].mean()
+        win = (df[f"{fam}_cf"] < df[f"{fam}_grid"]).mean()
+        print(f"  {fam}:  grid={g:7.3f}   closed-form={c:7.3f}   "
+              f"Δ(grid-cf)={g - c:+7.3f}   cf_wins={win:.0%}")
+    print(f"  KR(cf)={df['KR_cf'].mean():.3f}   GRG(cf)={df['GRG_cf'].mean():.3f}   "
+          f"LG={df['LG'].mean():.3f}")
+
+    # Ranking among LG + closed-form baselines (lower GIC = rank 1)
+    rank_cols = {"LG": "LG", "ER": "ER_cf", "BA": "BA_cf", "WS": "WS_cf",
+                 "KR": "KR_cf", "GRG": "GRG_cf"}
+    ranks = df[list(rank_cols.values())].rank(axis=1)
+    ranks.columns = list(rank_cols.keys())
+    print("\nMean rank (LG + closed-form baselines, lower = better):")
+    print(ranks.mean().sort_values().to_string())
+    print(f"\nWrote {out_dir / 'results.csv'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/notebooks/refactors/run_gplus_closedform.py
+++ b/notebooks/refactors/run_gplus_closedform.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
-"""Quick experiment: closed-form (moment-matched) baseline estimators vs the
-current fixed-interval grid search, on gplus ego networks, alongside LG.
+"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid
+search, on Google+ ego networks, alongside a fairly-scored Logit-Graph (LG).
 
-For each gplus ego network in a small size window we score, by spectral GIC
-(2*KL + 2*n_params, KL on the 50-bin normalized-Laplacian density):
+For each gplus ego network in the size window we score, by spectral GIC
+(2*KL + 2*n_params, KL on the 50-bin normalized-Laplacian density, lower=better):
 
-  * LG            -- the real pipeline fit (estimate sigma, generate, best-of)
+  * LG            -- best of d in {0,1,2}, each scored by burn-in + ensemble mean
+                     of the spectral density over N_RUNS post-burn-in snapshots
+                     (same averaging convention the baselines get; avoids the
+                     pipeline's best-of-trajectory cherry-pick — see
+                     diag_lg_convergence.py).
   * ER/BA/WS      -- two ways each:
-       grid : current method (fixed interval, grid_points pts, pick min GIC)
+       grid : fixed interval, GRID_POINTS points, parameter picked by min GIC
        cf   : closed-form moment estimate (no search)
   * KR/GRG        -- closed-form only (bonus families)
 
@@ -19,13 +23,18 @@ Closed-form estimators (n nodes, E edges, kbar = 2E/n avg degree):
   KR  d = round(kbar)          (nd even)   (E = nd/2)
   GRG r = sqrt(kbar / (pi*(n-1)))          (E[deg] ~ (n-1) pi r^2, 2-D)
 
-Read-only w.r.t. the library: uses logit_graph's own GIC scorer and the same
-GraphModelComparator LG path; writes only under runs/gplus_closedform/.
+Reproducible: single fixed seed (LG_CF_SEED), BLAS threads pinned to 1, and the
+gplus tarball is auto-extracted if the .edges files are missing. Read-only w.r.t.
+the library; writes only under runs/gplus_closedform/. Findings:
+FINDINGS_gplus_closedform.md.
 
-Env knobs:
-  LG_CF_MIN_NODES (50)  LG_CF_MAX_NODES (120)  LG_CF_MAX_NETS (8)
+Env knobs (all optional):
+  LG_CF_SEED (12345)    LG_CF_QUICK (0 -> full; 1 -> smoke on a few small nets)
+  LG_CF_MIN_NODES (50)  LG_CF_MAX_NODES (300)  LG_CF_MAX_NETS (all)
   LG_CF_N_RUNS (5)      LG_CF_GRID_POINTS (5)
-  LG fair scoring = burn-in (max(4000,25n)) + N_RUNS spectral snapshots
+
+  make gic-gplus-closedform        full run (~30s, 17 nets)
+  make gic-gplus-closedform-quick  smoke (~5s, a few small nets)
 """
 from __future__ import annotations
 
@@ -35,6 +44,10 @@ import sys
 import time
 import warnings
 from pathlib import Path
+
+# Pin BLAS threads BEFORE numpy import for deterministic eigvalsh across runs.
+for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ.setdefault(_v, "1")
 
 import numpy as np
 import networkx as nx
@@ -63,11 +76,12 @@ def _int(env, default):
     return int(raw) if raw is not None else default
 
 
+QUICK = os.environ.get("LG_CF_QUICK", "0") == "1"
 MIN_NODES = _int("LG_CF_MIN_NODES", 50)
-MAX_NODES = _int("LG_CF_MAX_NODES", 300)   # matches Makefile gic-gplus (full preset)
-MAX_NETS = _int("LG_CF_MAX_NETS", 10_000)  # run all nets in the window
-N_RUNS = _int("LG_CF_N_RUNS", 5)
-GRID_POINTS = _int("LG_CF_GRID_POINTS", 5)
+MAX_NODES = _int("LG_CF_MAX_NODES", 120 if QUICK else 300)  # full matches gic-gplus
+MAX_NETS = _int("LG_CF_MAX_NETS", 4 if QUICK else 10_000)   # full = all nets in window
+N_RUNS = _int("LG_CF_N_RUNS", 3 if QUICK else 5)
+GRID_POINTS = _int("LG_CF_GRID_POINTS", 3 if QUICK else 5)
 LG_D_LIST = [0, 1, 2]                       # LG d exploration
 # Fair LG scoring: burn-in then N_RUNS spectral snapshots (stride apart),
 # scaled with n. Burn-in past the noisy walk seen in diag_lg_convergence.py.
@@ -75,7 +89,7 @@ LG_BURN_MIN = _int("LG_CF_LG_BURN_MIN", 4000)
 LG_BURN_PER_N = _int("LG_CF_LG_BURN_PER_N", 25)
 LG_STRIDE_MIN = _int("LG_CF_LG_STRIDE_MIN", 600)
 LG_STRIDE_PER_N = _int("LG_CF_LG_STRIDE_PER_N", 6)
-SEED = 12345
+SEED = _int("LG_CF_SEED", 12345)
 
 # Current fixed intervals (mirror simulation.py defaults).
 GRID_INTERVALS = {"ER": (0.01, 0.25), "BA": (1, 8), "WS_k": (2, 10), "WS_p": (0.01, 0.5)}
@@ -248,14 +262,29 @@ def lg_gic(adj, seed):
 # Main
 # ---------------------------------------------------------------------------
 
+def _ensure_data(data_dir):
+    """Extract data/misc/gplus.tar.gz if the .edges files are not present."""
+    if data_dir.exists() and any(data_dir.glob("*.edges")):
+        return
+    tarball = _repo_root / "data" / "misc" / "gplus.tar.gz"
+    if not tarball.exists():
+        return
+    import tarfile
+    print(f"extracting {tarball.relative_to(_repo_root)} ...")
+    with tarfile.open(tarball) as tf:
+        tf.extractall(_repo_root / "data" / "misc")
+
+
 def main():
     data_dir = _repo_root / "data" / "misc" / "gplus"
+    _ensure_data(data_dir)
     files = sorted(data_dir.glob("*.edges"))
     out_dir = _here / "runs" / "gplus_closedform"
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    print(f"closed-form baseline experiment  window=[{MIN_NODES},{MAX_NODES}]  "
-          f"max_nets={MAX_NETS}  n_runs={N_RUNS}  grid_points={GRID_POINTS}  "
+    print(f"closed-form baseline experiment  seed={SEED}  quick={QUICK}  "
+          f"window=[{MIN_NODES},{MAX_NODES}]  max_nets={MAX_NETS}  "
+          f"n_runs={N_RUNS}  grid_points={GRID_POINTS}  "
           f"lg_burn=max({LG_BURN_MIN},{LG_BURN_PER_N}n)  lg_stride=max({LG_STRIDE_MIN},{LG_STRIDE_PER_N}n)")
 
     rows = []

--- a/notebooks/refactors/run_gplus_closedform.py
+++ b/notebooks/refactors/run_gplus_closedform.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import math
 import os
 import sys
+import time
 import warnings
 from pathlib import Path
 
@@ -57,11 +58,12 @@ def _int(env, default):
 
 
 MIN_NODES = _int("LG_CF_MIN_NODES", 50)
-MAX_NODES = _int("LG_CF_MAX_NODES", 120)
-MAX_NETS = _int("LG_CF_MAX_NETS", 8)
-N_RUNS = _int("LG_CF_N_RUNS", 3)
-GRID_POINTS = _int("LG_CF_GRID_POINTS", 3)
-LG_ITER = _int("LG_CF_LG_ITER", 1500)
+MAX_NODES = _int("LG_CF_MAX_NODES", 300)   # matches Makefile gic-gplus (full preset)
+MAX_NETS = _int("LG_CF_MAX_NETS", 10_000)  # run all nets in the window
+N_RUNS = _int("LG_CF_N_RUNS", 5)
+GRID_POINTS = _int("LG_CF_GRID_POINTS", 5)
+LG_ITER = _int("LG_CF_LG_ITER", 2000)      # matches Makefile gic-gplus
+LG_D_LIST = [0, 1, 2]                       # LG d exploration
 SEED = 12345
 
 # Current fixed intervals (mirror simulation.py defaults).
@@ -185,10 +187,10 @@ def grid_best_ws(real_nx, n, n_runs, seed):
 def lg_gic(adj, seed):
     lg_params = dict(max_iterations=LG_ITER, patience=300, edge_delta=None,
                      min_gic_threshold=5, check_interval=50)
-    cmp = GraphModelComparator(d_list=[0, 1], lg_params=lg_params, dist_type="KL",
+    cmp = GraphModelComparator(d_list=LG_D_LIST, lg_params=lg_params, dist_type="KL",
                                verbose=False, random_state=seed)
     best = (np.inf, None)
-    for d in (0, 1):
+    for d in LG_D_LIST:
         try:
             _, sigma, gic_val, *_ = cmp._get_logit_graph_for_d(adj, d)
             if gic_val < best[0]:
@@ -222,6 +224,7 @@ def main():
         if not (MIN_NODES <= n <= MAX_NODES):
             continue
         picked += 1
+        t0 = time.perf_counter()
         cf = closed_form_params(G)
         adj = nx.to_numpy_array(G)
         real_nx = nx.from_numpy_array(adj)
@@ -256,7 +259,8 @@ def main():
         # KR / GRG closed-form only
         kr_cf, _ = gic_of(real_nx, "KR", _kr(n, cf["KR"]), N_RUNS, SEED)
         grg_cf, _ = gic_of(real_nx, "GRG", _grg(n, cf["GRG"]), N_RUNS, SEED)
-        print(f"    KR cf={kr_cf:.3f} (d={cf['KR']})   GRG cf={grg_cf:.3f} (r={cf['GRG']:.3f})")
+        print(f"    KR cf={kr_cf:.3f} (d={cf['KR']})   GRG cf={grg_cf:.3f} (r={cf['GRG']:.3f})"
+              f"   [{time.perf_counter() - t0:.0f}s]")
 
         rows.append(dict(
             name=name, n=n, E=cf["E"], density=cf["density"], kbar=cf["kbar"],


### PR DESCRIPTION
Reproducible experiment comparing baseline graph-family estimators on Google+ ego networks, with a fairly-scored Logit-Graph (LG). Adds a Makefile target; **no library code changes** (read-only use of the existing GIC scorer/generators).

## Run it
- `make gic-gplus-closedform` — full run, 17 ego nets (50 ≤ n ≤ 300), ~30s
- `make gic-gplus-closedform-quick` — smoke (~5s)

Reproducible: fixed seed (`LG_CF_SEED=12345`), BLAS threads pinned to 1 — `results.csv` is **byte-identical across repeated runs** (verified). The gplus tarball is auto-extracted if the `.edges` files are missing.

## What it does
For each ego network, score by spectral GIC (`2·KL + 2·n_params`, lower = better):
- **ER/BA/WS** two ways: **grid** (fixed interval, param picked by min GIC) and **cf** (closed-form moment estimate).
- **KR/GRG** closed-form only.
- **LG** = best of d∈{0,1,2}, each scored by **burn-in + ensemble mean** of the spectral density over N_RUNS post-burn-in snapshots.

Closed-form estimators: ER `p=2E/(n(n-1))` (MLE); BA `m=round(E/n)`; WS `k=2·round(E/n)`, `p` from the clustering moment; KR `d=round(2E/n)`; GRG `r=√(k̄/(π(n-1)))`.

## Findings (full write-up: `FINDINGS_gplus_closedform.md`)
1. **Closed-form does NOT improve baseline GIC** — worse for every searchable family (ER −1.18, BA −1.00, WS −4.10), catastrophically for WS. GIC scores Laplacian *spectra*, not edge counts; the spectral optimum sits at *lower* density than the data, so density-matching overshoots. (Also refutes an earlier "interval-cap" worry.)
2. **LG must be scored at convergence.** `diag_lg_convergence.py` shows GIC is a noisy stationary walk; the pipeline's 2000-iter best-of-trajectory was *undertraining* LG and cherry-picking noise. Burn-in + ensemble-mean scoring drops LG's mean GIC **3.999 → 3.549**.
3. With fair scoring LG tops the closed-form ranking (mean rank 1.47) and beats GRG, but is **competitive/roughly tied** with properly grid-fit ER (3.33) / BA (3.35) on this window — not a clear win. GRG (closed-form) is a surprisingly strong baseline (3.84) and isn't in the current pipeline's baseline set.

## Files
- `notebooks/refactors/run_gplus_closedform.py` — the experiment
- `notebooks/refactors/diag_lg_convergence.py` — LG GIC-vs-iteration diagnostic
- `notebooks/refactors/FINDINGS_gplus_closedform.md` — results + interpretation
- `Makefile` — two targets

Output (`runs/gplus_closedform/`) is gitignored, as with the other gic-* pipelines.