### PR TITLE
exp(connectomes): closed-form vs grid baselines + fair LG (reproducible)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,13 @@ gic-connectomes-quick:  ## Smoke run on small connectomes only (~30s)
 	LG_CONN_USE_CACHE=0 \
 		$(UV) run python notebooks/refactors/run_connectomes_gic.py
 
+gic-connectomes-closedform:  ## Closed-form vs grid baselines + fair LG on animal connectomes (reproducible, ~1-2 min)
+	$(UV) run python notebooks/refactors/run_connectomes_closedform.py
+
+gic-connectomes-closedform-quick:  ## Smoke run of the connectomes closed-form experiment (~10s)
+	LG_CCF_QUICK=1 \
+		$(UV) run python notebooks/refactors/run_connectomes_closedform.py
+
 gic-twitch:  ## Rank LG vs ER/WS/BA by GIC on Twitch country networks (6 graphs, ~2-5 min)
 	LG_TWITCH_USE_CACHE=1 \
 		$(UV) run python notebooks/refactors/run_twitch_gic.py

--- a/notebooks/refactors/FINDINGS_connectomes_closedform.md
+++ b/notebooks/refactors/FINDINGS_connectomes_closedform.md
@@ -1,0 +1,76 @@
+# Closed-form baseline estimators vs grid search (animal connectomes) — findings
+
+Experiment: `run_connectomes_closedform.py` (connectome twin of the gplus run).
+Score ER/BA/WS/KR/GRG against the **18 animal connectomes** by spectral GIC
+(2·KL + 2·n_params, KL on the normalized-Laplacian density; dense eigvalsh for
+n≤500, deterministic KPM for larger n), comparing **closed-form moment
+estimators** vs the current **fixed-interval grid**, alongside LG fit by
+**burn-in + ensemble mean** of the spectral density (the fair scoring developed
+for gplus).
+
+Config: all 18 connectomes (n 29–1770 after largest-CC), `n_runs=5`,
+`grid_points=5`, LG d∈{0,1,2}, seed 12345. Graphs loaded from GraphML as
+undirected, **unweighted (binary)** largest connected component.
+
+## Aggregate (mean GIC across 18 connectomes, lower = better)
+
+| family | grid | closed-form | Δ(grid−cf) | cf wins |
+|---|---|---|---|---|
+| ER | 4.009 | **3.807** | +0.20 | 39% |
+| BA | **3.829** | 4.031 | −0.20 | 33% |
+| WS | **5.642** | 6.796 | −1.15 | 28% |
+
+Closed-form only: KR 4.766, GRG **4.179**, and **LG 3.595**.
+
+Mean rank (LG + closed-form baselines): **LG 2.22**, **GRG 2.50**, ER 2.89,
+KR 3.61, BA 3.94, WS 5.83.
+
+## Conclusion — the verdict flips vs gplus, and it's about the grid interval
+
+On gplus (ego nets, densities 0.03–0.41) closed-form was clearly *worse* for
+every family. On connectomes it is **competitive — ER is even slightly better
+on average** (Δ +0.20), and BA/WS lose by far smaller margins than on gplus
+(BA −0.20 vs −1.00; WS −1.15 vs −4.10).
+
+**Why:** the connectome densities span **0.003 → 0.713** — far wider than gplus
+— and frequently fall **outside the grid's fixed ER interval [0.01, 0.25]**.
+When the true density is outside the interval the grid is capped away from the
+optimum and the density-matched closed form wins:
+
+- **Too dense (> 0.25):** `mouse_brain_1` density 0.713 → ER grid capped at
+  p=0.25 gives 3.536, closed-form p=0.713 gives **2.658**. Same for the dense
+  rhesus cortices.
+- **Too sparse (< 0.01):** `kasthuri_graph_v4` density 0.003 → grid's *lower*
+  bound 0.01 forces an over-dense ER (6.327) vs closed-form **4.004**;
+  `drosophila_medulla_1` 0.006 → grid 2.897 vs cf **2.337**.
+- **Inside the interval (mid density):** the grid still wins, exactly as on gplus.
+
+This is the **interval-cap effect** hypothesized in the original gplus analysis.
+It did *not* bite on gplus (optimum was at low density, inside the box) but it
+**does** bite here because connectome densities are extreme and spread out. So
+the closed-form-vs-grid verdict is **dataset-dependent**, governed by whether the
+data's density lands inside the fixed grid interval.
+
+## LG and GRG
+
+- **LG is the strongest model here** — mean GIC **3.595**, best mean rank (2.22),
+  and it beats *all* the grid-fit baselines (ER 4.009, BA 3.829, WS 5.642), unlike
+  gplus where grid ER/BA edged it out. LG selects **d=0** for the dense
+  connectomes (mouse_brain, rat brains, mouse_retina, drosophila) and d=1 for the
+  sparser C. elegans / rhesus nets.
+- **GRG (closed-form) is again the strongest baseline** (rank 2.50), and is the
+  single best model on the dense spatial brain connectomes (rat brains GRG ≈
+  2.1–2.4). It is still absent from the pipeline's baseline set
+  (`["ER","WS","BA","SBM"]`) — worth adding.
+- **WS closed-form still loses** (density-matched k overshoots — e.g. k=170 for
+  mouse_retina), though less catastrophically than on gplus.
+
+## Net takeaway
+
+Closed-form moment matching is **not** a universal improvement, but it is
+**competitive on connectomes** precisely where the fixed grid interval fails to
+bracket the observed density. The robust, dataset-agnostic fix is what the closed
+form approximates: **data-adaptive intervals** (centre the grid on the empirical
+density / degree, then refine locally), so the parameter search can reach the
+optimum at any density. LG, scored at convergence, is the best model on this
+dataset; GRG is a strong, currently-missing baseline.

--- a/notebooks/refactors/run_connectomes_closedform.py
+++ b/notebooks/refactors/run_connectomes_closedform.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid
+search, on the 18 animal connectomes, alongside a fairly-scored Logit-Graph (LG).
+
+Connectome version of run_gplus_closedform.py. Each connectome is one graph per
+organism/region (mouse, macaque, rat, C. elegans, drosophila, ...), loaded from
+GraphML as the undirected, unweighted (binary) largest connected component.
+
+For each connectome in the size window we score, by spectral GIC
+(2*KL + 2*n_params, KL on the normalized-Laplacian density, lower=better):
+
+  * LG            -- best of d in {0,1,2}, each scored by burn-in + ensemble mean
+                     of the spectral density over N_RUNS post-burn-in snapshots
+                     (same averaging convention the baselines get).
+  * ER/BA/WS      -- two ways each:
+       grid : fixed interval, GRID_POINTS points, parameter picked by min GIC
+       cf   : closed-form moment estimate (no search)
+  * KR/GRG        -- closed-form only (bonus families)
+
+Closed-form estimators (n nodes, E edges, kbar = 2E/n avg degree):
+  ER  p = 2E/(n(n-1))                      (exact MLE)
+  BA  m = round(E/n)            in [1, n)   (edge count E = m(n-m))
+  WS  k = 2*round(E/n) (even)   in [2, n)   (E = nk/2, rewiring conserves edges)
+  WS  p = 1 - (C_obs/C0)^(1/3), C0 = 3(k-2)/(4(k-1))   (clustering moment)
+  KR  d = round(kbar)          (nd even)   (E = nd/2)
+  GRG r = sqrt(kbar / (pi*(n-1)))          (E[deg] ~ (n-1) pi r^2, 2-D)
+
+The normalized-Laplacian spectral density uses dense eigvalsh for n <= 500 and
+the deterministic KPM estimator for larger n (logit_graph.gic, seeded), so the
+big connectomes (n up to ~1800) stay tractable. Reproducible: fixed seed
+(LG_CCF_SEED), BLAS threads pinned to 1. Read-only w.r.t. the library; writes
+only under runs/connectomes_closedform/. Findings:
+FINDINGS_connectomes_closedform.md.
+
+Env knobs (all optional):
+  LG_CCF_SEED (12345)     LG_CCF_QUICK (0 -> full; 1 -> smoke on small connectomes)
+  LG_CCF_MIN_NODES (20)   LG_CCF_MAX_NODES (2000)   LG_CCF_MAX_NETS (all)
+  LG_CCF_N_RUNS (5)       LG_CCF_GRID_POINTS (5)
+
+  make gic-connectomes-closedform        full run
+  make gic-connectomes-closedform-quick  smoke on the small connectomes
+"""
+from __future__ import annotations
+
+import math
+import os
+import sys
+import time
+import warnings
+from pathlib import Path
+
+# Pin BLAS threads BEFORE numpy import for deterministic eigvalsh across runs.
+for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ.setdefault(_v, "1")
+
+import numpy as np
+import networkx as nx
+import pandas as pd
+
+_here = Path(__file__).resolve().parent
+_repo_root = _here.parents[1]
+_src = _repo_root / "src"
+for p in (_src, _here):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+warnings.filterwarnings("ignore")
+
+from logit_graph.gic import GraphInformationCriterion, _MODEL_N_PARAMS  # noqa: E402
+from logit_graph.graph import GraphModel  # noqa: E402
+from logit_graph.simulation import (  # noqa: E402
+    _direct_er_at_sigma,
+    _warm_start_er_p,
+    estimate_sigma_only,
+)
+
+
+def _int(env, default):
+    raw = os.environ.get(env)
+    return int(raw) if raw is not None else default
+
+
+QUICK = os.environ.get("LG_CCF_QUICK", "0") == "1"
+MIN_NODES = _int("LG_CCF_MIN_NODES", 20)
+MAX_NODES = _int("LG_CCF_MAX_NODES", 300 if QUICK else 2000)  # all 18 connectomes
+MAX_NETS = _int("LG_CCF_MAX_NETS", 6 if QUICK else 10_000)
+N_RUNS = _int("LG_CCF_N_RUNS", 3 if QUICK else 5)
+GRID_POINTS = _int("LG_CCF_GRID_POINTS", 3 if QUICK else 5)
+LG_D_LIST = [0, 1, 2]
+# Fair LG scoring: burn-in then N_RUNS spectral snapshots (stride apart).
+LG_BURN_MIN = _int("LG_CCF_LG_BURN_MIN", 4000)
+LG_BURN_PER_N = _int("LG_CCF_LG_BURN_PER_N", 25)
+LG_STRIDE_MIN = _int("LG_CCF_LG_STRIDE_MIN", 600)
+LG_STRIDE_PER_N = _int("LG_CCF_LG_STRIDE_PER_N", 6)
+SEED = _int("LG_CCF_SEED", 12345)
+
+# Current fixed intervals (mirror simulation.py defaults).
+GRID_INTERVALS = {"ER": (0.01, 0.25), "BA": (1, 8), "WS_k": (2, 10), "WS_p": (0.01, 0.5)}
+
+
+# ---------------------------------------------------------------------------
+# GIC scoring (apples-to-apples with the pipeline)
+# ---------------------------------------------------------------------------
+
+def gic_of(real_nx, model_name, gen_fn, n_runs, seed):
+    """GIC = 2*KL(real_density, mean_model_density) + 2*n_params."""
+    n_params = _MODEL_N_PARAMS.get(model_name, 1)
+    specs = []
+    for r in range(n_runs):
+        try:
+            g = gen_fn(seed + r)
+        except Exception:
+            continue
+        den, _ = GraphInformationCriterion(real_nx, model=model_name).compute_spectral_density(g)
+        specs.append(den)
+    if not specs:
+        return np.nan, np.nan
+    avg = np.mean(specs, axis=0)
+    scorer = GraphInformationCriterion(real_nx, model=model_name, dist="KL")
+    return float(scorer.calculate_gic(model_den=avg, n_params=n_params)), n_params
+
+
+# ---------------------------------------------------------------------------
+# Generators
+# ---------------------------------------------------------------------------
+
+def _er(n, p):
+    p = float(np.clip(p, 1e-6, 1.0))
+    return lambda s: nx.erdos_renyi_graph(n, p, seed=s)
+
+
+def _ba(n, m):
+    m = int(np.clip(m, 1, n - 1))
+    return lambda s: nx.barabasi_albert_graph(n, m, seed=s)
+
+
+def _ws(n, k, p):
+    k = int(np.clip(k, 2, n - 1))
+    if k % 2 == 1:
+        k += 1
+    p = float(np.clip(p, 0.0, 1.0))
+    return lambda s: nx.watts_strogatz_graph(n, k, p, seed=s)
+
+
+def _kr(n, d):
+    d = int(np.clip(d, 0, n - 1))
+    if (n * d) % 2 == 1:
+        d -= 1
+    return lambda s: nx.random_regular_graph(d, n, seed=s)
+
+
+def _grg(n, r):
+    r = float(np.clip(r, 1e-3, 1.5))
+    return lambda s: nx.random_geometric_graph(n, r, seed=s)
+
+
+# ---------------------------------------------------------------------------
+# Closed-form estimators
+# ---------------------------------------------------------------------------
+
+def closed_form_params(G):
+    n = G.number_of_nodes()
+    E = G.number_of_edges()
+    kbar = 2 * E / n
+    p_er = 2 * E / (n * (n - 1))
+    m_ba = max(1, round(E / n))
+    k_ws = max(2, int(round(kbar)))
+    if k_ws % 2 == 1:
+        k_ws += 1
+    C_obs = nx.average_clustering(G)  # unweighted (weight=None default)
+    if k_ws > 2:
+        C0 = 3 * (k_ws - 2) / (4 * (k_ws - 1))
+        p_ws = 0.0 if C_obs >= C0 else 1.0 - (C_obs / C0) ** (1.0 / 3.0)
+    else:
+        p_ws = 0.0
+    d_kr = int(round(kbar))
+    r_grg = math.sqrt(kbar / (math.pi * (n - 1)))
+    return dict(n=n, E=E, density=p_er, kbar=kbar,
+                ER=p_er, BA=m_ba, WS_k=k_ws, WS_p=p_ws, KR=d_kr, GRG=r_grg,
+                C_obs=C_obs)
+
+
+# ---------------------------------------------------------------------------
+# Current-style grid search (fixed interval, pick min GIC = best case for grid)
+# ---------------------------------------------------------------------------
+
+def grid_best(real_nx, model_name, n, build_gen, lo, hi, n_runs, seed):
+    best = (np.nan, None)
+    for j, val in enumerate(np.linspace(lo, hi, GRID_POINTS)):
+        g, _ = gic_of(real_nx, model_name, build_gen(val), n_runs, seed + 100 * j)
+        if not np.isnan(g) and (best[1] is None or g < best[0]):
+            best = (g, val)
+    return best
+
+
+def grid_best_ws(real_nx, n, n_runs, seed):
+    klo, khi = GRID_INTERVALS["WS_k"]
+    plo, phi = GRID_INTERVALS["WS_p"]
+    best = (np.nan, None)
+    j = 0
+    for k in range(int(klo), int(khi) + 1, 2):
+        for p in np.linspace(plo, phi, GRID_POINTS):
+            g, _ = gic_of(real_nx, "WS", _ws(n, k, p), n_runs, seed + 100 * j)
+            j += 1
+            if not np.isnan(g) and (best[1] is None or g < best[0]):
+                best = (g, (k, round(float(p), 3)))
+    return best
+
+
+# ---------------------------------------------------------------------------
+# LG scored FAIRLY: burn-in + ensemble-mean spectral density (same convention
+# as the baselines, which average n_runs sample densities).
+# ---------------------------------------------------------------------------
+
+def _lg_burn(n):
+    return max(LG_BURN_MIN, LG_BURN_PER_N * n)
+
+
+def _lg_stride(n):
+    return max(LG_STRIDE_MIN, LG_STRIDE_PER_N * n)
+
+
+def lg_gic_one_d(adj, d, seed):
+    n = adj.shape[0]
+    real_nx = nx.from_numpy_array(adj)
+    scorer = GraphInformationCriterion(real_nx, model="LG", dist="KL")
+    sigma, _ = estimate_sigma_only(adj, d=d, feature_mode="incremental")
+
+    dens = []
+    if d == 0:
+        for r in range(N_RUNS):
+            g = nx.from_numpy_array(_direct_er_at_sigma(n, sigma, seed=seed + r))
+            dens.append(scorer.compute_spectral_density(g)[0])
+    else:
+        gm = GraphModel(n=n, d=d, sigma=sigma, er_p=_warm_start_er_p(sigma),
+                        layer2=True, feature_mode="incremental", seed=seed)
+        for _ in range(_lg_burn(n)):
+            gm.add_remove_edge()
+        for s in range(N_RUNS):
+            for _ in range(_lg_stride(n)):
+                gm.add_remove_edge()
+            dens.append(scorer.compute_spectral_density(nx.from_numpy_array(gm.graph))[0])
+
+    avg = np.mean(dens, axis=0)
+    return float(scorer.calculate_gic(model_den=avg, n_params=1)), sigma
+
+
+def lg_gic(adj, seed):
+    best = (np.inf, None)
+    for d in LG_D_LIST:
+        try:
+            g, _ = lg_gic_one_d(adj, d, seed + d)
+            if g < best[0]:
+                best = (g, d)
+        except Exception as e:
+            print(f"    LG d={d} failed: {e}")
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def _load_graphml(path):
+    """Undirected, unweighted (binary) largest connected component."""
+    G = nx.read_graphml(path)
+    G = nx.Graph(G)  # collapse multi-edges + direction
+    G.remove_edges_from(nx.selfloop_edges(G))
+    cc = max(nx.connected_components(G), key=len)
+    return nx.convert_node_labels_to_integers(G.subgraph(cc).copy())
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    data_dir = _repo_root / "data" / "connectomes"
+    files = sorted(data_dir.glob("*.graphml"))
+    if not files:
+        print(f"No .graphml files under {data_dir} — connectome data is gitignored; "
+              f"place the 18 .graphml files there first.")
+        return
+    out_dir = _here / "runs" / "connectomes_closedform"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"connectomes closed-form experiment  seed={SEED}  quick={QUICK}  "
+          f"window=[{MIN_NODES},{MAX_NODES}]  max_nets={MAX_NETS}  "
+          f"n_runs={N_RUNS}  grid_points={GRID_POINTS}  "
+          f"lg_burn=max({LG_BURN_MIN},{LG_BURN_PER_N}n)  lg_stride=max({LG_STRIDE_MIN},{LG_STRIDE_PER_N}n)")
+
+    # Sort connectomes by node count so smaller (faster) ones run first.
+    loaded = []
+    for f in files:
+        try:
+            G = _load_graphml(f)
+        except Exception as e:
+            print(f"  skip {f.stem}: {e}")
+            continue
+        loaded.append((f.stem, G))
+    loaded.sort(key=lambda t: t[1].number_of_nodes())
+
+    rows = []
+    picked = 0
+    for name, G in loaded:
+        if picked >= MAX_NETS:
+            break
+        n = G.number_of_nodes()
+        if not (MIN_NODES <= n <= MAX_NODES):
+            continue
+        picked += 1
+        t0 = time.perf_counter()
+        cf = closed_form_params(G)
+        adj = nx.to_numpy_array(G, weight=None)  # binarize (connectomes are weighted)
+        real_nx = nx.from_numpy_array(adj)
+        print(f"\n[{picked}] {name}  n={n}  E={cf['E']}  density={cf['density']:.3f}  "
+              f"kbar={cf['kbar']:.1f}  C={cf['C_obs']:.3f}")
+
+        lg_val, lg_d = lg_gic(adj, SEED)
+        print(f"    LG     gic={lg_val:.3f} (d={lg_d})")
+
+        er_grid = grid_best(real_nx, "ER", n,
+                            lambda v: _er(n, v), *GRID_INTERVALS["ER"], N_RUNS, SEED)
+        er_cf, _ = gic_of(real_nx, "ER", _er(n, cf["ER"]), N_RUNS, SEED)
+        print(f"    ER     grid={er_grid[0]:.3f} (p={er_grid[1]:.3f})   "
+              f"cf={er_cf:.3f} (p={cf['ER']:.3f})")
+
+        ba_grid = grid_best(real_nx, "BA", n,
+                            lambda v: _ba(n, v), *GRID_INTERVALS["BA"], N_RUNS, SEED)
+        ba_cf, _ = gic_of(real_nx, "BA", _ba(n, cf["BA"]), N_RUNS, SEED)
+        print(f"    BA     grid={ba_grid[0]:.3f} (m={ba_grid[1]:.1f})   "
+              f"cf={ba_cf:.3f} (m={cf['BA']})")
+
+        ws_grid = grid_best_ws(real_nx, n, N_RUNS, SEED)
+        ws_cf, _ = gic_of(real_nx, "WS", _ws(n, cf["WS_k"], cf["WS_p"]), N_RUNS, SEED)
+        print(f"    WS     grid={ws_grid[0]:.3f} (k,p={ws_grid[1]})   "
+              f"cf={ws_cf:.3f} (k={cf['WS_k']},p={cf['WS_p']:.3f})")
+
+        kr_cf, _ = gic_of(real_nx, "KR", _kr(n, cf["KR"]), N_RUNS, SEED)
+        grg_cf, _ = gic_of(real_nx, "GRG", _grg(n, cf["GRG"]), N_RUNS, SEED)
+        print(f"    KR cf={kr_cf:.3f} (d={cf['KR']})   GRG cf={grg_cf:.3f} (r={cf['GRG']:.3f})"
+              f"   [{time.perf_counter() - t0:.0f}s]")
+
+        rows.append(dict(
+            name=name, n=n, E=cf["E"], density=cf["density"], kbar=cf["kbar"],
+            LG=lg_val, LG_d=lg_d,
+            ER_grid=er_grid[0], ER_cf=er_cf,
+            BA_grid=ba_grid[0], BA_cf=ba_cf,
+            WS_grid=ws_grid[0], WS_cf=ws_cf,
+            KR_cf=kr_cf, GRG_cf=grg_cf,
+        ))
+
+    df = pd.DataFrame(rows)
+    if df.empty:
+        print("\nNo connectomes in window.")
+        return
+    df.to_csv(out_dir / "results.csv", index=False)
+
+    print("\n" + "=" * 78)
+    print("AGGREGATE (mean GIC across connectomes, lower = better)")
+    print("=" * 78)
+    for fam in ("ER", "BA", "WS"):
+        g = df[f"{fam}_grid"].mean()
+        c = df[f"{fam}_cf"].mean()
+        win = (df[f"{fam}_cf"] < df[f"{fam}_grid"]).mean()
+        print(f"  {fam}:  grid={g:7.3f}   closed-form={c:7.3f}   "
+              f"Δ(grid-cf)={g - c:+7.3f}   cf_wins={win:.0%}")
+    print(f"  KR(cf)={df['KR_cf'].mean():.3f}   GRG(cf)={df['GRG_cf'].mean():.3f}   "
+          f"LG={df['LG'].mean():.3f}")
+
+    rank_cols = {"LG": "LG", "ER": "ER_cf", "BA": "BA_cf", "WS": "WS_cf",
+                 "KR": "KR_cf", "GRG": "GRG_cf"}
+    ranks = df[list(rank_cols.values())].rank(axis=1)
+    ranks.columns = list(rank_cols.keys())
+    print("\nMean rank (LG + closed-form baselines, lower = better):")
+    print(ranks.mean().sort_values().to_string())
+    print(f"\nWrote {out_dir / 'results.csv'}  ({len(df)} connectomes)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Connectome twin of #42 (gplus). Compares baseline graph-family estimators on the **18 animal connectomes**, with a fairly-scored Logit-Graph. **No library code changes** (read-only use of the GIC scorer/generators). Independent of #42 (self-contained runner, branched off main).

## Run it
- `make gic-connectomes-closedform` — full run, all 18 connectomes, ~1–4 min (dense `mouse_retina`/`drosophila` KPM dominate)
- `make gic-connectomes-closedform-quick` — smoke (~10s, small connectomes)

Reproducible: byte-identical across two runs (verified on the n≈500 rat-brain subset that exercises the KPM path). Connectomes loaded from GraphML as undirected, **unweighted (binary)** largest connected component; dense `eigvalsh` for n≤500, deterministic KPM above.

## Aggregate (mean GIC across 18 connectomes, lower = better)
| family | grid | closed-form | Δ(grid−cf) | cf wins |
|---|---|---|---|---|
| ER | 4.009 | **3.807** | +0.20 | 39% |
| BA | **3.829** | 4.031 | −0.20 | 33% |
| WS | **5.642** | 6.796 | −1.15 | 28% |

Closed-form only: KR 4.766, GRG **4.179**, **LG 3.595**.
Mean rank: **LG 2.22**, GRG 2.50, ER 2.89, KR 3.61, BA 3.94, WS 5.83.

## Key finding — the verdict FLIPS vs gplus, and it's about the grid interval
On gplus (densities 0.03–0.41) closed-form was clearly *worse* for every family. On connectomes it is **competitive — ER is slightly better on average**, and BA/WS lose by far smaller margins (BA −0.20 vs −1.00; WS −1.15 vs −4.10).

**Why:** connectome densities span **0.003 → 0.713** and frequently fall **outside the grid's fixed ER interval [0.01, 0.25]**. There the grid is capped away from the optimum and the density-matched closed form wins:
- too dense (>0.25): `mouse_brain_1` density 0.713 → ER grid (capped p=0.25) 3.536 vs cf (p=0.713) **2.658**
- too sparse (<0.01): `kasthuri` 0.003 → grid 6.327 vs cf **4.004**; `drosophila` 0.006 → grid 2.897 vs cf **2.337**
- inside the interval (mid density): the grid still wins, as on gplus

This is the **interval-cap effect** hypothesized in the gplus analysis — it didn't bite there (optimum was inside the box) but **does** here because connectome densities are extreme. So the closed-form-vs-grid verdict is **dataset-dependent**.

## LG / GRG
- **LG is the strongest model** (mean GIC 3.595, best rank), beating *all* grid baselines here (unlike gplus); it picks d=0 for the dense connectomes.
- **GRG (closed-form) is again the strongest baseline** (rank 2.50) and best on the dense spatial brain connectomes — still missing from the pipeline's `["ER","WS","BA","SBM"]` set.
- WS closed-form still loses (density-matched k overshoots), less catastrophically than gplus.

## Files
- `notebooks/refactors/run_connectomes_closedform.py` — the experiment
- `notebooks/refactors/FINDINGS_connectomes_closedform.md` — results + interpretation
- `Makefile` — two targets

Output (`runs/connectomes_closedform/`) is gitignored, as with the other gic-* pipelines.