### PR TITLE
exp(human-connectomes): closed-form vs grid baselines + fair LG (reproducible)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,13 @@ gic-human-connectomes-quick:  ## Smoke run on coarse parcellation (~30s)
 	LG_HCONN_USE_CACHE=0 \
 		$(UV) run python notebooks/refactors/run_human_connectomes_gic.py
 
+gic-human-connectomes-closedform:  ## Closed-form vs grid baselines + fair LG on OASIS-3 human connectomes (reproducible, ~2-4 min)
+	$(UV) run python notebooks/refactors/run_human_connectomes_closedform.py
+
+gic-human-connectomes-closedform-quick:  ## Smoke run of the human-connectome closed-form experiment (~15s)
+	LG_HCF_QUICK=1 \
+		$(UV) run python notebooks/refactors/run_human_connectomes_closedform.py
+
 gic-connectomes:  ## Rank LG vs ER/WS/BA by GIC on animal connectomes (~3-5 min)
 	LG_CONN_USE_CACHE=1 \
 		$(UV) run python notebooks/refactors/run_connectomes_gic.py

--- a/notebooks/refactors/FINDINGS_human_connectomes_closedform.md
+++ b/notebooks/refactors/FINDINGS_human_connectomes_closedform.md
@@ -1,0 +1,79 @@
+# Closed-form baselines vs grid (OASIS-3 human connectomes) — findings
+
+Experiment: `run_human_connectomes_closedform.py` (human-connectome twin of the
+gplus / animal-connectome runs). Score ER/BA/WS/KR/GRG against OASIS-3 brain
+networks by spectral GIC (2·KL + 2·n_params), comparing **closed-form moment
+estimators** vs the current **fixed-interval grid**, alongside LG fit by
+**burn-in + ensemble mean** of the spectral density.
+
+Config: 8 subjects sampled (seeded) from each of 4 parcellation scales —
+`oasis3 scale1` (n≈110, density≈0.50), `scale2` (n≈156, 0.43), `scale3` (n≈258,
+0.31), `repeated_10_scale_250` (n≈378, 0.085) — **32 subjects**, `n_runs=5`,
+`grid_points=5`, LG d∈{0,1,2}, seed 12345. Graphs loaded from GraphML as
+undirected, **unweighted (binary)** largest connected component (brain edges are
+weighted fiber densities).
+
+## Aggregate (mean GIC across 32 subjects, lower = better)
+
+| family | grid | closed-form | Δ(grid−cf) | cf wins |
+|---|---|---|---|---|
+| ER | 3.798 | 3.802 | −0.00 | 56% |
+| BA | 4.103 | **3.700** | +0.40 | **75%** |
+| WS | **5.306** | 8.165 | −2.86 | 0% |
+
+Closed-form only: KR 3.808, **GRG 2.773**, **LG 3.575**.
+
+Mean rank (LG + closed-form baselines): **GRG 1.00**, **LG 2.78**, BA 3.19,
+ER 3.72, KR 4.31, WS 6.00.
+
+## Headline — GRG is the best model on every single subject
+
+**GRG (closed-form) ranks 1st on all 32 subjects** (mean rank exactly 1.00,
+mean GIC 2.773 — far below everything else). Brain connectomes have strong
+geometric / spatial organisation, and the random geometric graph — a single
+closed-form radius — captures it better than any other family *and* better than
+LG. GRG was 2nd on the animal connectomes; on the human OASIS-3 nets it is the
+outright winner. It remains **absent from the pipeline's baseline set**
+(`["ER","WS","BA","SBM"]`) — the strongest argument yet for adding it.
+
+## Closed-form is competitive-to-better here — the interval cap bites hard
+
+The OASIS scales are **dense** (density 0.31–0.54), far above the grid's ER cap
+(0.25) and BA cap (m=8):
+
+- **BA: closed-form clearly wins** (cf 3.700 vs grid 4.103, cf wins 75%). The
+  grid caps at m=8 while the real m is ≈25–45, so grid-BA is far too sparse;
+  closed-form m matches and wins decisively.
+- **ER: a wash** (cf wins 56%) — the dense subjects' p>0.25 is unreachable by the
+  grid, but the normalized-Laplacian KL is fairly flat in p, so the cap costs
+  less than for BA.
+- **WS: closed-form still collapses** (density-matched k≈50–90 → near-lattice
+  spectrum nothing like a brain), and grid-WS is the worst family overall.
+- The **sparse** scale (`repeated_10_scale_250`, density 0.085) behaves like
+  gplus — grid edges out cf — confirming the verdict tracks whether the density
+  lands inside the grid box.
+
+## LG
+
+LG is the **2nd-best model** (mean GIC 3.575) and **beats every grid-fit baseline
+at every scale**:
+
+| scale | n | density | LG | ER-grid | BA-grid | WS-grid |
+|---|---|---|---|---|---|---|
+| scale1 | 110 | 0.498 | **3.534** | 3.898 | 3.948 | 5.561 |
+| scale2 | 156 | 0.433 | **3.666** | 3.752 | 4.322 | 5.684 |
+| scale3 | 258 | 0.304 | **3.476** | 3.552 | 4.486 | 5.370 |
+| rep_250 | 378 | 0.085 | **3.625** | 3.992 | 3.653 | 4.610 |
+
+LG selects **d=0** for the dense OASIS scales and d=1 for the sparse repeated
+scale. So among the standard pipeline models LG is the best — only the
+(currently-unused) GRG beats it.
+
+## Net takeaway
+
+Consistent with the animal connectomes and sharper: on dense, spatially-organised
+brain networks the fixed grid interval is the binding constraint (closed-form /
+density-matching is competitive-to-better, BA especially), **GRG is the dominant
+baseline**, and **LG is the best of the standard models**. The robust fixes are
+the same: data-adaptive parameter intervals (what closed-form approximates) and
+adding GRG to the baseline set.

--- a/notebooks/refactors/run_human_connectomes_closedform.py
+++ b/notebooks/refactors/run_human_connectomes_closedform.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid
+search, on OASIS-3 human brain connectomes, alongside a fairly-scored LG.
+
+Human-connectome twin of run_connectomes_closedform.py. The OASIS-3 dataset has
+several parcellation scales (different node counts) with hundreds of subjects
+each; all subjects in a scale share a node count. We sample PER_SCALE subjects
+from each of a few scales (seeded) and score, by spectral GIC
+(2*KL + 2*n_params, KL on the normalized-Laplacian density, lower=better):
+
+  * LG            -- best of d in {0,1,2}, each scored by burn-in + ensemble mean
+                     of the spectral density over N_RUNS post-burn-in snapshots.
+  * ER/BA/WS      -- two ways each:
+       grid : fixed interval, GRID_POINTS points, parameter picked by min GIC
+       cf   : closed-form moment estimate (no search)
+  * KR/GRG        -- closed-form only (bonus families)
+
+Closed-form estimators (n nodes, E edges, kbar = 2E/n avg degree):
+  ER  p = 2E/(n(n-1))                      (exact MLE)
+  BA  m = round(E/n)            in [1, n)   (edge count E = m(n-m))
+  WS  k = 2*round(E/n) (even)   in [2, n)   (E = nk/2, rewiring conserves edges)
+  WS  p = 1 - (C_obs/C0)^(1/3), C0 = 3(k-2)/(4(k-1))   (clustering moment)
+  KR  d = round(kbar)          (nd even)   (E = nd/2)
+  GRG r = sqrt(kbar / (pi*(n-1)))          (E[deg] ~ (n-1) pi r^2, 2-D)
+
+Brain graphs are weighted (fiber density); we binarize to the undirected,
+unweighted largest connected component. Dense eigvalsh for n<=500, deterministic
+KPM above. Reproducible: fixed seed (LG_HCF_SEED) drives the subject sampling
+and all generators; BLAS threads pinned to 1. Read-only w.r.t. the library;
+writes only under runs/human_connectomes_closedform/. Findings:
+FINDINGS_human_connectomes_closedform.md.
+
+Env knobs (all optional):
+  LG_HCF_SEED (12345)   LG_HCF_QUICK (0 -> full; 1 -> smoke, one small scale)
+  LG_HCF_SCALES (oasis3 scale1,scale2,scale3 + repeated_10_scale_250)
+  LG_HCF_PER_SCALE (8)  LG_HCF_N_RUNS (5)  LG_HCF_GRID_POINTS (5)
+  LG_HCF_MIN_NODES (20) LG_HCF_MAX_NODES (500)
+
+  make gic-human-connectomes-closedform        full run
+  make gic-human-connectomes-closedform-quick  smoke
+"""
+from __future__ import annotations
+
+import math
+import os
+import random
+import sys
+import time
+import warnings
+from pathlib import Path
+
+# Pin BLAS threads BEFORE numpy import for deterministic eigvalsh across runs.
+for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ.setdefault(_v, "1")
+
+import numpy as np
+import networkx as nx
+import pandas as pd
+
+_here = Path(__file__).resolve().parent
+_repo_root = _here.parents[1]
+_src = _repo_root / "src"
+for p in (_src, _here):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+warnings.filterwarnings("ignore")
+
+from logit_graph.gic import GraphInformationCriterion, _MODEL_N_PARAMS  # noqa: E402
+from logit_graph.graph import GraphModel  # noqa: E402
+from logit_graph.simulation import (  # noqa: E402
+    _direct_er_at_sigma,
+    _warm_start_er_p,
+    estimate_sigma_only,
+)
+
+
+def _int(env, default):
+    raw = os.environ.get(env)
+    return int(raw) if raw is not None else default
+
+
+QUICK = os.environ.get("LG_HCF_QUICK", "0") == "1"
+_DEFAULT_SCALES = ("oasis3_graphmls_scale1,oasis3_graphmls_scale2,"
+                   "oasis3_graphmls_scale3,repeated_10_scale_250")
+SCALES = os.environ.get(
+    "LG_HCF_SCALES", "repeated_10_scale_33" if QUICK else _DEFAULT_SCALES
+).split(",")
+PER_SCALE = _int("LG_HCF_PER_SCALE", 3 if QUICK else 8)
+MIN_NODES = _int("LG_HCF_MIN_NODES", 20)
+MAX_NODES = _int("LG_HCF_MAX_NODES", 500)
+N_RUNS = _int("LG_HCF_N_RUNS", 3 if QUICK else 5)
+GRID_POINTS = _int("LG_HCF_GRID_POINTS", 3 if QUICK else 5)
+LG_D_LIST = [0, 1, 2]
+LG_BURN_MIN = _int("LG_HCF_LG_BURN_MIN", 4000)
+LG_BURN_PER_N = _int("LG_HCF_LG_BURN_PER_N", 25)
+LG_STRIDE_MIN = _int("LG_HCF_LG_STRIDE_MIN", 600)
+LG_STRIDE_PER_N = _int("LG_HCF_LG_STRIDE_PER_N", 6)
+SEED = _int("LG_HCF_SEED", 12345)
+
+GRID_INTERVALS = {"ER": (0.01, 0.25), "BA": (1, 8), "WS_k": (2, 10), "WS_p": (0.01, 0.5)}
+
+
+# ---------------------------------------------------------------------------
+# GIC scoring
+# ---------------------------------------------------------------------------
+
+def gic_of(real_nx, model_name, gen_fn, n_runs, seed):
+    """GIC = 2*KL(real_density, mean_model_density) + 2*n_params."""
+    n_params = _MODEL_N_PARAMS.get(model_name, 1)
+    specs = []
+    for r in range(n_runs):
+        try:
+            g = gen_fn(seed + r)
+        except Exception:
+            continue
+        den, _ = GraphInformationCriterion(real_nx, model=model_name).compute_spectral_density(g)
+        specs.append(den)
+    if not specs:
+        return np.nan, np.nan
+    avg = np.mean(specs, axis=0)
+    scorer = GraphInformationCriterion(real_nx, model=model_name, dist="KL")
+    return float(scorer.calculate_gic(model_den=avg, n_params=n_params)), n_params
+
+
+# ---------------------------------------------------------------------------
+# Generators
+# ---------------------------------------------------------------------------
+
+def _er(n, p):
+    p = float(np.clip(p, 1e-6, 1.0))
+    return lambda s: nx.erdos_renyi_graph(n, p, seed=s)
+
+
+def _ba(n, m):
+    m = int(np.clip(m, 1, n - 1))
+    return lambda s: nx.barabasi_albert_graph(n, m, seed=s)
+
+
+def _ws(n, k, p):
+    k = int(np.clip(k, 2, n - 1))
+    if k % 2 == 1:
+        k += 1
+    p = float(np.clip(p, 0.0, 1.0))
+    return lambda s: nx.watts_strogatz_graph(n, k, p, seed=s)
+
+
+def _kr(n, d):
+    d = int(np.clip(d, 0, n - 1))
+    if (n * d) % 2 == 1:
+        d -= 1
+    return lambda s: nx.random_regular_graph(d, n, seed=s)
+
+
+def _grg(n, r):
+    r = float(np.clip(r, 1e-3, 1.5))
+    return lambda s: nx.random_geometric_graph(n, r, seed=s)
+
+
+# ---------------------------------------------------------------------------
+# Closed-form estimators
+# ---------------------------------------------------------------------------
+
+def closed_form_params(G):
+    n = G.number_of_nodes()
+    E = G.number_of_edges()
+    kbar = 2 * E / n
+    p_er = 2 * E / (n * (n - 1))
+    m_ba = max(1, round(E / n))
+    k_ws = max(2, int(round(kbar)))
+    if k_ws % 2 == 1:
+        k_ws += 1
+    C_obs = nx.average_clustering(G)
+    if k_ws > 2:
+        C0 = 3 * (k_ws - 2) / (4 * (k_ws - 1))
+        p_ws = 0.0 if C_obs >= C0 else 1.0 - (C_obs / C0) ** (1.0 / 3.0)
+    else:
+        p_ws = 0.0
+    d_kr = int(round(kbar))
+    r_grg = math.sqrt(kbar / (math.pi * (n - 1)))
+    return dict(n=n, E=E, density=p_er, kbar=kbar,
+                ER=p_er, BA=m_ba, WS_k=k_ws, WS_p=p_ws, KR=d_kr, GRG=r_grg,
+                C_obs=C_obs)
+
+
+# ---------------------------------------------------------------------------
+# Grid search (fixed interval, pick min GIC = best case for grid)
+# ---------------------------------------------------------------------------
+
+def grid_best(real_nx, model_name, n, build_gen, lo, hi, n_runs, seed):
+    best = (np.nan, None)
+    for j, val in enumerate(np.linspace(lo, hi, GRID_POINTS)):
+        g, _ = gic_of(real_nx, model_name, build_gen(val), n_runs, seed + 100 * j)
+        if not np.isnan(g) and (best[1] is None or g < best[0]):
+            best = (g, val)
+    return best
+
+
+def grid_best_ws(real_nx, n, n_runs, seed):
+    klo, khi = GRID_INTERVALS["WS_k"]
+    plo, phi = GRID_INTERVALS["WS_p"]
+    best = (np.nan, None)
+    j = 0
+    for k in range(int(klo), int(khi) + 1, 2):
+        for p in np.linspace(plo, phi, GRID_POINTS):
+            g, _ = gic_of(real_nx, "WS", _ws(n, k, p), n_runs, seed + 100 * j)
+            j += 1
+            if not np.isnan(g) and (best[1] is None or g < best[0]):
+                best = (g, (k, round(float(p), 3)))
+    return best
+
+
+# ---------------------------------------------------------------------------
+# LG scored fairly: burn-in + ensemble-mean spectral density
+# ---------------------------------------------------------------------------
+
+def _lg_burn(n):
+    return max(LG_BURN_MIN, LG_BURN_PER_N * n)
+
+
+def _lg_stride(n):
+    return max(LG_STRIDE_MIN, LG_STRIDE_PER_N * n)
+
+
+def lg_gic_one_d(adj, d, seed):
+    n = adj.shape[0]
+    real_nx = nx.from_numpy_array(adj)
+    scorer = GraphInformationCriterion(real_nx, model="LG", dist="KL")
+    sigma, _ = estimate_sigma_only(adj, d=d, feature_mode="incremental")
+
+    dens = []
+    if d == 0:
+        for r in range(N_RUNS):
+            g = nx.from_numpy_array(_direct_er_at_sigma(n, sigma, seed=seed + r))
+            dens.append(scorer.compute_spectral_density(g)[0])
+    else:
+        gm = GraphModel(n=n, d=d, sigma=sigma, er_p=_warm_start_er_p(sigma),
+                        layer2=True, feature_mode="incremental", seed=seed)
+        for _ in range(_lg_burn(n)):
+            gm.add_remove_edge()
+        for s in range(N_RUNS):
+            for _ in range(_lg_stride(n)):
+                gm.add_remove_edge()
+            dens.append(scorer.compute_spectral_density(nx.from_numpy_array(gm.graph))[0])
+
+    avg = np.mean(dens, axis=0)
+    return float(scorer.calculate_gic(model_den=avg, n_params=1)), sigma
+
+
+def lg_gic(adj, seed):
+    best = (np.inf, None)
+    for d in LG_D_LIST:
+        try:
+            g, _ = lg_gic_one_d(adj, d, seed + d)
+            if g < best[0]:
+                best = (g, d)
+        except Exception as e:
+            print(f"    LG d={d} failed: {e}")
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def _load_graphml(path):
+    """Undirected, unweighted (binary) largest connected component."""
+    G = nx.read_graphml(path)
+    G = nx.Graph(G)
+    G.remove_edges_from(nx.selfloop_edges(G))
+    cc = max(nx.connected_components(G), key=len)
+    return nx.convert_node_labels_to_integers(G.subgraph(cc).copy())
+
+
+def _sample_subjects():
+    """(scale, path) pairs: PER_SCALE seeded subjects from each scale present."""
+    rng = random.Random(SEED)
+    chosen = []
+    for scale in SCALES:
+        paths = sorted((_repo_root / "data" / "brain_graph" / scale).glob("*.graphml"))
+        if not paths:
+            print(f"  scale '{scale}' not found under data/brain_graph/ — skipping")
+            continue
+        k = min(PER_SCALE, len(paths))
+        for p in sorted(rng.sample(paths, k)):
+            chosen.append((scale, p))
+    return chosen
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    out_dir = _here / "runs" / "human_connectomes_closedform"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"human-connectomes closed-form experiment  seed={SEED}  quick={QUICK}  "
+          f"scales={SCALES}  per_scale={PER_SCALE}  window=[{MIN_NODES},{MAX_NODES}]  "
+          f"n_runs={N_RUNS}  grid_points={GRID_POINTS}")
+
+    subjects = _sample_subjects()
+    if not subjects:
+        print("No subjects found — brain_graph data is gitignored; place the "
+              "OASIS-3 .graphml scales under data/brain_graph/ first.")
+        return
+
+    rows = []
+    picked = 0
+    for scale, path in subjects:
+        try:
+            G = _load_graphml(path)
+        except Exception as e:
+            print(f"  skip {path.stem}: {e}")
+            continue
+        n = G.number_of_nodes()
+        if not (MIN_NODES <= n <= MAX_NODES):
+            continue
+        picked += 1
+        t0 = time.perf_counter()
+        cf = closed_form_params(G)
+        adj = nx.to_numpy_array(G, weight=None)  # binarize
+        real_nx = nx.from_numpy_array(adj)
+        name = f"{scale.replace('oasis3_graphmls_', '').replace('repeated_10_', 'rep_')}/{path.stem[:8]}"
+        print(f"\n[{picked}] {name}  n={n}  E={cf['E']}  density={cf['density']:.3f}  "
+              f"kbar={cf['kbar']:.1f}  C={cf['C_obs']:.3f}")
+
+        lg_val, lg_d = lg_gic(adj, SEED)
+        print(f"    LG     gic={lg_val:.3f} (d={lg_d})")
+
+        er_grid = grid_best(real_nx, "ER", n,
+                            lambda v: _er(n, v), *GRID_INTERVALS["ER"], N_RUNS, SEED)
+        er_cf, _ = gic_of(real_nx, "ER", _er(n, cf["ER"]), N_RUNS, SEED)
+        print(f"    ER     grid={er_grid[0]:.3f} (p={er_grid[1]:.3f})   "
+              f"cf={er_cf:.3f} (p={cf['ER']:.3f})")
+
+        ba_grid = grid_best(real_nx, "BA", n,
+                            lambda v: _ba(n, v), *GRID_INTERVALS["BA"], N_RUNS, SEED)
+        ba_cf, _ = gic_of(real_nx, "BA", _ba(n, cf["BA"]), N_RUNS, SEED)
+        print(f"    BA     grid={ba_grid[0]:.3f} (m={ba_grid[1]:.1f})   "
+              f"cf={ba_cf:.3f} (m={cf['BA']})")
+
+        ws_grid = grid_best_ws(real_nx, n, N_RUNS, SEED)
+        ws_cf, _ = gic_of(real_nx, "WS", _ws(n, cf["WS_k"], cf["WS_p"]), N_RUNS, SEED)
+        print(f"    WS     grid={ws_grid[0]:.3f} (k,p={ws_grid[1]})   "
+              f"cf={ws_cf:.3f} (k={cf['WS_k']},p={cf['WS_p']:.3f})")
+
+        kr_cf, _ = gic_of(real_nx, "KR", _kr(n, cf["KR"]), N_RUNS, SEED)
+        grg_cf, _ = gic_of(real_nx, "GRG", _grg(n, cf["GRG"]), N_RUNS, SEED)
+        print(f"    KR cf={kr_cf:.3f} (d={cf['KR']})   GRG cf={grg_cf:.3f} (r={cf['GRG']:.3f})"
+              f"   [{time.perf_counter() - t0:.0f}s]")
+
+        rows.append(dict(
+            scale=scale, name=path.stem, n=n, E=cf["E"], density=cf["density"], kbar=cf["kbar"],
+            LG=lg_val, LG_d=lg_d,
+            ER_grid=er_grid[0], ER_cf=er_cf,
+            BA_grid=ba_grid[0], BA_cf=ba_cf,
+            WS_grid=ws_grid[0], WS_cf=ws_cf,
+            KR_cf=kr_cf, GRG_cf=grg_cf,
+        ))
+
+    df = pd.DataFrame(rows)
+    if df.empty:
+        print("\nNo subjects in window.")
+        return
+    df.to_csv(out_dir / "results.csv", index=False)
+
+    print("\n" + "=" * 78)
+    print("AGGREGATE (mean GIC across subjects, lower = better)")
+    print("=" * 78)
+    for fam in ("ER", "BA", "WS"):
+        g = df[f"{fam}_grid"].mean()
+        c = df[f"{fam}_cf"].mean()
+        win = (df[f"{fam}_cf"] < df[f"{fam}_grid"]).mean()
+        print(f"  {fam}:  grid={g:7.3f}   closed-form={c:7.3f}   "
+              f"Δ(grid-cf)={g - c:+7.3f}   cf_wins={win:.0%}")
+    print(f"  KR(cf)={df['KR_cf'].mean():.3f}   GRG(cf)={df['GRG_cf'].mean():.3f}   "
+          f"LG={df['LG'].mean():.3f}")
+
+    rank_cols = {"LG": "LG", "ER": "ER_cf", "BA": "BA_cf", "WS": "WS_cf",
+                 "KR": "KR_cf", "GRG": "GRG_cf"}
+    ranks = df[list(rank_cols.values())].rank(axis=1)
+    ranks.columns = list(rank_cols.keys())
+    print("\nMean rank (LG + closed-form baselines, lower = better):")
+    print(ranks.mean().sort_values().to_string())
+    print("\nPer-scale mean GIC (LG vs grid baselines):")
+    print(df.groupby("scale")[["n", "density", "LG", "ER_grid", "BA_grid", "WS_grid"]]
+          .mean().round(3).to_string())
+    print(f"\nWrote {out_dir / 'results.csv'}  ({len(df)} subjects)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
OASIS-3 human-connectome twin of #42 (gplus) and #43 (animal connectomes). Compares baseline graph-family estimators on human brain networks, with a fairly-scored Logit-Graph. **No library code changes** (read-only use of the GIC scorer/generators). Independent, self-contained runner branched off main.

## Run it
- `make gic-human-connectomes-closedform` — full run, 32 subjects (8 each from 4 parcellation scales), ~2–4 min
- `make gic-human-connectomes-closedform-quick` — smoke (~15s)

Reproducible: fixed seed (`LG_HCF_SEED=12345`) drives the **seeded subject sampling** and all generators; BLAS threads pinned — `results.csv` is **byte-identical across runs** (verified). Brain GraphML loaded as undirected, **unweighted (binary)** largest connected component.

## Aggregate (mean GIC across 32 subjects, lower = better)
| family | grid | closed-form | Δ(grid−cf) | cf wins |
|---|---|---|---|---|
| ER | 3.798 | 3.802 | −0.00 | 56% |
| BA | 4.103 | **3.700** | +0.40 | **75%** |
| WS | **5.306** | 8.165 | −2.86 | 0% |

Closed-form only: KR 3.808, **GRG 2.773**, **LG 3.575**.
Mean rank: **GRG 1.00**, **LG 2.78**, BA 3.19, ER 3.72, KR 4.31, WS 6.00.

## Headline — GRG is the best model on **every** subject
**GRG (closed-form) ranks 1st on all 32 subjects** (mean rank exactly 1.00, GIC 2.773 — far below everything). Brain connectomes are strongly geometric/spatial, and the random geometric graph (one closed-form radius) captures that better than any family *and* better than LG. It was 2nd on the animal connectomes; here it's the outright winner — and it's still **missing from the pipeline's baseline set** (`["ER","WS","BA","SBM"]`).

## Closed-form is competitive-to-better — the interval cap bites hard
The OASIS scales are **dense** (density 0.31–0.54), above the grid's ER cap (0.25) and BA cap (m=8):
- **BA: closed-form clearly wins** (cf 3.700 vs grid 4.103, wins 75%) — grid caps at m=8 while the real m≈25–45, so grid-BA is far too sparse.
- **ER: a wash** (wins 56%) — p>0.25 is unreachable but the KL is fairly flat in p.
- **WS: closed-form still collapses** (density-matched k≈50–90 → near-lattice).
- The **sparse** scale (`repeated_10_scale_250`, density 0.085) behaves like gplus — grid edges out cf — confirming the verdict tracks whether density lands inside the grid box.

## LG
LG is the **2nd-best model** (3.575) and **beats every grid-fit baseline at every scale** (e.g. scale1: LG 3.53 vs ER-grid 3.90 / BA-grid 3.95 / WS-grid 5.56). It picks d=0 for the dense OASIS scales, d=1 for the sparse repeated scale. So among the standard pipeline models LG is best — only the currently-unused GRG beats it.

## Files
- `notebooks/refactors/run_human_connectomes_closedform.py` — the experiment
- `notebooks/refactors/FINDINGS_human_connectomes_closedform.md` — results + interpretation
- `Makefile` — two targets

Output (`runs/human_connectomes_closedform/`) is gitignored, as with the other gic-* pipelines.