### PR TITLE
exp(facebook-ego): closed-form vs grid baselines + fair LG (reproducible)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,13 @@ gic-facebook-ego-quick:  ## Smoke run on small SNAP Facebook ego networks (~15s)
 	LG_FBEGO_USE_CACHE=0 \
 		$(UV) run python notebooks/refactors/run_facebook_ego_gic.py
 
+gic-facebook-ego-closedform:  ## Closed-form vs grid baselines + fair LG on the 10 Facebook ego nets (reproducible, ~2-4 min)
+	$(UV) run python notebooks/refactors/run_facebook_ego_closedform.py
+
+gic-facebook-ego-closedform-quick:  ## Smoke run of the Facebook-ego closed-form experiment (~20s)
+	LG_FBE_QUICK=1 \
+		$(UV) run python notebooks/refactors/run_facebook_ego_closedform.py
+
 gic-facebook:  ## Rank LG vs ER/WS/BA by GIC on full MUSAE Facebook page-page graph (~2-3 min)
 	LG_FB_USE_CACHE=1 \
 		$(UV) run python notebooks/refactors/run_facebook_gic.py

--- a/notebooks/refactors/FINDINGS_facebook_ego_closedform.md
+++ b/notebooks/refactors/FINDINGS_facebook_ego_closedform.md
@@ -1,0 +1,62 @@
+# Closed-form baselines vs grid (Facebook ego networks) — findings
+
+Experiment: `run_facebook_ego_closedform.py`. Score ER/BA/WS/KR/GRG against the
+**10 SNAP Facebook ego networks** by spectral GIC (2·KL + 2·n_params), comparing
+**closed-form moment estimators** vs the current **fixed-interval grid**,
+alongside LG fit by **burn-in + ensemble mean** of the spectral density.
+
+All 10 ego nets (n 40–1034 after largest-CC) are small enough for the LG chain,
+so every one is scored. `n_runs=5`, `grid_points=5`, LG d∈{0,1,2}, seed 12345.
+Densities span 0.034–0.282 — the small ego nets are mid-dense, the large ones
+(n≥500) are sparse.
+
+## Aggregate (mean GIC across 10 ego nets, lower = better)
+
+| family | grid | closed-form | Δ(grid−cf) | cf wins |
+|---|---|---|---|---|
+| ER | **3.317** | 4.336 | −1.02 | 40% |
+| BA | **3.573** | 4.352 | −0.78 | 30% |
+| WS | **4.706** | 8.569 | −3.86 | 10% |
+
+Closed-form only: KR 4.471, GRG **3.377**, and **LG 3.483**.
+
+Mean rank (LG + closed-form baselines): **GRG 2.0**, **LG 2.5**, ER 3.2, BA 3.4,
+KR 3.9, WS 6.0.
+
+## Conclusion — a mix, split by ego-net size/density
+
+Facebook ego sits between gplus (grid clearly wins) and the connectomes
+(closed-form competitive), because the collection itself spans two regimes:
+
+- **Small, mid-dense ego nets** (n<300, density 0.05–0.28: ids 3980, 698, 686,
+  414, 0, 348) → **grid wins**, the gplus pattern.
+- **Large, sparse ego nets** (n 532–1034, density 0.034–0.11: ids 3437, 1684,
+  107, 1912) → **closed-form is competitive-to-better** (e.g. id 107: ER cf 2.621
+  vs grid 2.698; BA cf 2.621 vs grid 2.837). Their density falls near/below the
+  grid's lower useful range, so the coarse grid resolves the optimum poorly while
+  density-matching lands on it.
+
+That split is why the aggregate shows grid ahead on the mean yet closed-form
+winning a sizeable fraction (ER 40%, BA 30%).
+
+- **GRG (closed-form) is the best baseline overall** (rank 2.0, GIC 3.377) and the
+  single best model on most of the larger ego nets — consistent with every other
+  dataset, and still absent from the pipeline's `["ER","WS","BA","SBM"]` set.
+- **LG is 2nd** (3.483) and the best *standard* model; it selects d=0 for the
+  large sparse nets and d=1–2 for the small dense ones.
+- **WS closed-form collapses** (density-matched k overshoots), worst family.
+
+## Cross-dataset picture (now five datasets)
+
+| dataset | density | closed-form vs grid | best model |
+|---|---|---|---|
+| gplus (ego) | 0.03–0.41 | grid wins | LG |
+| twitter (ego) | 0.05–0.39 | grid wins | LG |
+| **facebook (ego)** | **0.03–0.28** | **mixed (size-split)** | **GRG, then LG** |
+| animal connectomes | 0.003–0.71 | mixed / cf competitive | LG (GRG 2nd) |
+| human connectomes | 0.09–0.54 | cf competitive (BA wins) | GRG, then LG |
+
+The verdict stays consistent: closed-form vs grid tracks whether the data's
+density lands inside the fixed grid interval; **LG (scored at convergence) is
+best-or-near-best everywhere**; and **GRG is a consistently strong baseline the
+pipeline omits**.

--- a/notebooks/refactors/run_facebook_ego_closedform.py
+++ b/notebooks/refactors/run_facebook_ego_closedform.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid
+search, on the 10 SNAP Facebook ego networks, alongside a fairly-scored LG.
+
+Facebook-ego twin of run_gplus_closedform.py / run_twitter_closedform.py. The 10
+ego networks are all small enough (n 52-1034) for the LG Gibbs chain, so we
+score every one. Spectral GIC (2*KL + 2*n_params, KL on the normalized-Laplacian
+density, lower=better):
+
+  * LG            -- best of d in {0,1,2}, each scored by burn-in + ensemble mean
+                     of the spectral density over N_RUNS post-burn-in snapshots.
+  * ER/BA/WS      -- two ways each:
+       grid : fixed interval, GRID_POINTS points, parameter picked by min GIC
+       cf   : closed-form moment estimate (no search)
+  * KR/GRG        -- closed-form only (bonus families)
+
+Closed-form estimators (n nodes, E edges, kbar = 2E/n avg degree):
+  ER  p = 2E/(n(n-1))                      (exact MLE)
+  BA  m = round(E/n)            in [1, n)   (edge count E = m(n-m))
+  WS  k = 2*round(E/n) (even)   in [2, n)   (E = nk/2, rewiring conserves edges)
+  WS  p = 1 - (C_obs/C0)^(1/3), C0 = 3(k-2)/(4(k-1))   (clustering moment)
+  KR  d = round(kbar)          (nd even)   (E = nd/2)
+  GRG r = sqrt(kbar / (pi*(n-1)))          (E[deg] ~ (n-1) pi r^2, 2-D)
+
+Reproducible: fixed seed (LG_FBE_SEED), BLAS threads pinned to 1; the facebook
+tarball is auto-extracted if the .edges files are missing. Read-only w.r.t. the
+library; writes only under runs/facebook_ego_closedform/. Findings:
+FINDINGS_facebook_ego_closedform.md.
+
+Env knobs (all optional):
+  LG_FBE_SEED (12345)    LG_FBE_QUICK (0 -> all 10; 1 -> smoke on small ones)
+  LG_FBE_MIN_NODES (20)  LG_FBE_MAX_NODES (2000)   LG_FBE_MAX_NETS (all)
+  LG_FBE_N_RUNS (5)      LG_FBE_GRID_POINTS (5)
+
+  make gic-facebook-ego-closedform        full run (all 10 ego nets)
+  make gic-facebook-ego-closedform-quick  smoke (small ego nets)
+"""
+from __future__ import annotations
+
+import math
+import os
+import sys
+import time
+import warnings
+from pathlib import Path
+
+for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ.setdefault(_v, "1")
+
+import numpy as np
+import networkx as nx
+import pandas as pd
+
+_here = Path(__file__).resolve().parent
+_repo_root = _here.parents[1]
+_src = _repo_root / "src"
+for p in (_src, _here):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+warnings.filterwarnings("ignore")
+
+from logit_graph.gic import GraphInformationCriterion, _MODEL_N_PARAMS  # noqa: E402
+from logit_graph.graph import GraphModel  # noqa: E402
+from logit_graph.simulation import (  # noqa: E402
+    _direct_er_at_sigma,
+    _warm_start_er_p,
+    estimate_sigma_only,
+)
+
+
+def _int(env, default):
+    raw = os.environ.get(env)
+    return int(raw) if raw is not None else default
+
+
+QUICK = os.environ.get("LG_FBE_QUICK", "0") == "1"
+MIN_NODES = _int("LG_FBE_MIN_NODES", 20)
+MAX_NODES = _int("LG_FBE_MAX_NODES", 250 if QUICK else 2000)
+MAX_NETS = _int("LG_FBE_MAX_NETS", 4 if QUICK else 10_000)
+N_RUNS = _int("LG_FBE_N_RUNS", 3 if QUICK else 5)
+GRID_POINTS = _int("LG_FBE_GRID_POINTS", 3 if QUICK else 5)
+LG_D_LIST = [0, 1, 2]
+LG_BURN_MIN = _int("LG_FBE_LG_BURN_MIN", 4000)
+LG_BURN_PER_N = _int("LG_FBE_LG_BURN_PER_N", 25)
+LG_STRIDE_MIN = _int("LG_FBE_LG_STRIDE_MIN", 600)
+LG_STRIDE_PER_N = _int("LG_FBE_LG_STRIDE_PER_N", 6)
+SEED = _int("LG_FBE_SEED", 12345)
+
+GRID_INTERVALS = {"ER": (0.01, 0.25), "BA": (1, 8), "WS_k": (2, 10), "WS_p": (0.01, 0.5)}
+
+
+def gic_of(real_nx, model_name, gen_fn, n_runs, seed):
+    """GIC = 2*KL(real_density, mean_model_density) + 2*n_params."""
+    n_params = _MODEL_N_PARAMS.get(model_name, 1)
+    specs = []
+    for r in range(n_runs):
+        try:
+            g = gen_fn(seed + r)
+        except Exception:
+            continue
+        den, _ = GraphInformationCriterion(real_nx, model=model_name).compute_spectral_density(g)
+        specs.append(den)
+    if not specs:
+        return np.nan, np.nan
+    avg = np.mean(specs, axis=0)
+    scorer = GraphInformationCriterion(real_nx, model=model_name, dist="KL")
+    return float(scorer.calculate_gic(model_den=avg, n_params=n_params)), n_params
+
+
+def _er(n, p):
+    p = float(np.clip(p, 1e-6, 1.0))
+    return lambda s: nx.erdos_renyi_graph(n, p, seed=s)
+
+
+def _ba(n, m):
+    m = int(np.clip(m, 1, n - 1))
+    return lambda s: nx.barabasi_albert_graph(n, m, seed=s)
+
+
+def _ws(n, k, p):
+    k = int(np.clip(k, 2, n - 1))
+    if k % 2 == 1:
+        k += 1
+    p = float(np.clip(p, 0.0, 1.0))
+    return lambda s: nx.watts_strogatz_graph(n, k, p, seed=s)
+
+
+def _kr(n, d):
+    d = int(np.clip(d, 0, n - 1))
+    if (n * d) % 2 == 1:
+        d -= 1
+    return lambda s: nx.random_regular_graph(d, n, seed=s)
+
+
+def _grg(n, r):
+    r = float(np.clip(r, 1e-3, 1.5))
+    return lambda s: nx.random_geometric_graph(n, r, seed=s)
+
+
+def closed_form_params(G):
+    n = G.number_of_nodes()
+    E = G.number_of_edges()
+    kbar = 2 * E / n
+    p_er = 2 * E / (n * (n - 1))
+    m_ba = max(1, round(E / n))
+    k_ws = max(2, int(round(kbar)))
+    if k_ws % 2 == 1:
+        k_ws += 1
+    C_obs = nx.average_clustering(G)
+    if k_ws > 2:
+        C0 = 3 * (k_ws - 2) / (4 * (k_ws - 1))
+        p_ws = 0.0 if C_obs >= C0 else 1.0 - (C_obs / C0) ** (1.0 / 3.0)
+    else:
+        p_ws = 0.0
+    d_kr = int(round(kbar))
+    r_grg = math.sqrt(kbar / (math.pi * (n - 1)))
+    return dict(n=n, E=E, density=p_er, kbar=kbar,
+                ER=p_er, BA=m_ba, WS_k=k_ws, WS_p=p_ws, KR=d_kr, GRG=r_grg,
+                C_obs=C_obs)
+
+
+def grid_best(real_nx, model_name, n, build_gen, lo, hi, n_runs, seed):
+    best = (np.nan, None)
+    for j, val in enumerate(np.linspace(lo, hi, GRID_POINTS)):
+        g, _ = gic_of(real_nx, model_name, build_gen(val), n_runs, seed + 100 * j)
+        if not np.isnan(g) and (best[1] is None or g < best[0]):
+            best = (g, val)
+    return best
+
+
+def grid_best_ws(real_nx, n, n_runs, seed):
+    klo, khi = GRID_INTERVALS["WS_k"]
+    plo, phi = GRID_INTERVALS["WS_p"]
+    best = (np.nan, None)
+    j = 0
+    for k in range(int(klo), int(khi) + 1, 2):
+        for p in np.linspace(plo, phi, GRID_POINTS):
+            g, _ = gic_of(real_nx, "WS", _ws(n, k, p), n_runs, seed + 100 * j)
+            j += 1
+            if not np.isnan(g) and (best[1] is None or g < best[0]):
+                best = (g, (k, round(float(p), 3)))
+    return best
+
+
+def _lg_burn(n):
+    return max(LG_BURN_MIN, LG_BURN_PER_N * n)
+
+
+def _lg_stride(n):
+    return max(LG_STRIDE_MIN, LG_STRIDE_PER_N * n)
+
+
+def lg_gic_one_d(adj, d, seed):
+    n = adj.shape[0]
+    real_nx = nx.from_numpy_array(adj)
+    scorer = GraphInformationCriterion(real_nx, model="LG", dist="KL")
+    sigma, _ = estimate_sigma_only(adj, d=d, feature_mode="incremental")
+
+    dens = []
+    if d == 0:
+        for r in range(N_RUNS):
+            g = nx.from_numpy_array(_direct_er_at_sigma(n, sigma, seed=seed + r))
+            dens.append(scorer.compute_spectral_density(g)[0])
+    else:
+        gm = GraphModel(n=n, d=d, sigma=sigma, er_p=_warm_start_er_p(sigma),
+                        layer2=True, feature_mode="incremental", seed=seed)
+        for _ in range(_lg_burn(n)):
+            gm.add_remove_edge()
+        for s in range(N_RUNS):
+            for _ in range(_lg_stride(n)):
+                gm.add_remove_edge()
+            dens.append(scorer.compute_spectral_density(nx.from_numpy_array(gm.graph))[0])
+
+    avg = np.mean(dens, axis=0)
+    return float(scorer.calculate_gic(model_den=avg, n_params=1)), sigma
+
+
+def lg_gic(adj, seed):
+    best = (np.inf, None)
+    for d in LG_D_LIST:
+        try:
+            g, _ = lg_gic_one_d(adj, d, seed + d)
+            if g < best[0]:
+                best = (g, d)
+        except Exception as e:
+            print(f"    LG d={d} failed: {e}")
+    return best
+
+
+def _ensure_data(data_dir):
+    if data_dir.exists() and any(data_dir.glob("*.edges")):
+        return
+    tarball = _repo_root / "data" / "misc" / "facebook.tar.gz"
+    if not tarball.exists():
+        return
+    import tarfile
+    print(f"extracting {tarball.relative_to(_repo_root)} ...")
+    with tarfile.open(tarball) as tf:
+        tf.extractall(_repo_root / "data" / "misc")
+
+
+def _load_edges(path):
+    """Undirected, self-loop-free largest connected component, relabeled 0..n-1."""
+    G = nx.read_edgelist(path, nodetype=int)
+    G = nx.Graph(G)
+    G.remove_edges_from(nx.selfloop_edges(G))
+    cc = max(nx.connected_components(G), key=len)
+    return nx.convert_node_labels_to_integers(G.subgraph(cc).copy())
+
+
+def main():
+    data_dir = _repo_root / "data" / "misc" / "facebook"
+    _ensure_data(data_dir)
+    files = sorted(data_dir.glob("*.edges"), key=lambda p: p.stat().st_size)
+    out_dir = _here / "runs" / "facebook_ego_closedform"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    if not files:
+        print("No facebook .edges files found under data/misc/facebook/.")
+        return
+
+    print(f"facebook-ego closed-form experiment  seed={SEED}  quick={QUICK}  "
+          f"window=[{MIN_NODES},{MAX_NODES}]  n_runs={N_RUNS}  grid_points={GRID_POINTS}")
+
+    rows = []
+    picked = 0
+    for f in files:
+        if picked >= MAX_NETS:
+            break
+        try:
+            G = _load_edges(f)
+        except Exception as e:
+            print(f"  skip {f.stem}: {e}")
+            continue
+        n = G.number_of_nodes()
+        if not (MIN_NODES <= n <= MAX_NODES):
+            continue
+        picked += 1
+        t0 = time.perf_counter()
+        cf = closed_form_params(G)
+        adj = nx.to_numpy_array(G)
+        real_nx = nx.from_numpy_array(adj)
+        name = f.stem
+        print(f"\n[{picked}] {name}  n={n}  E={cf['E']}  density={cf['density']:.3f}  "
+              f"kbar={cf['kbar']:.1f}  C={cf['C_obs']:.3f}")
+
+        lg_val, lg_d = lg_gic(adj, SEED)
+        print(f"    LG     gic={lg_val:.3f} (d={lg_d})")
+
+        er_grid = grid_best(real_nx, "ER", n,
+                            lambda v: _er(n, v), *GRID_INTERVALS["ER"], N_RUNS, SEED)
+        er_cf, _ = gic_of(real_nx, "ER", _er(n, cf["ER"]), N_RUNS, SEED)
+        print(f"    ER     grid={er_grid[0]:.3f} (p={er_grid[1]:.3f})   "
+              f"cf={er_cf:.3f} (p={cf['ER']:.3f})")
+
+        ba_grid = grid_best(real_nx, "BA", n,
+                            lambda v: _ba(n, v), *GRID_INTERVALS["BA"], N_RUNS, SEED)
+        ba_cf, _ = gic_of(real_nx, "BA", _ba(n, cf["BA"]), N_RUNS, SEED)
+        print(f"    BA     grid={ba_grid[0]:.3f} (m={ba_grid[1]:.1f})   "
+              f"cf={ba_cf:.3f} (m={cf['BA']})")
+
+        ws_grid = grid_best_ws(real_nx, n, N_RUNS, SEED)
+        ws_cf, _ = gic_of(real_nx, "WS", _ws(n, cf["WS_k"], cf["WS_p"]), N_RUNS, SEED)
+        print(f"    WS     grid={ws_grid[0]:.3f} (k,p={ws_grid[1]})   "
+              f"cf={ws_cf:.3f} (k={cf['WS_k']},p={cf['WS_p']:.3f})")
+
+        kr_cf, _ = gic_of(real_nx, "KR", _kr(n, cf["KR"]), N_RUNS, SEED)
+        grg_cf, _ = gic_of(real_nx, "GRG", _grg(n, cf["GRG"]), N_RUNS, SEED)
+        print(f"    KR cf={kr_cf:.3f} (d={cf['KR']})   GRG cf={grg_cf:.3f} (r={cf['GRG']:.3f})"
+              f"   [{time.perf_counter() - t0:.0f}s]")
+
+        rows.append(dict(
+            name=name, n=n, E=cf["E"], density=cf["density"], kbar=cf["kbar"],
+            LG=lg_val, LG_d=lg_d,
+            ER_grid=er_grid[0], ER_cf=er_cf,
+            BA_grid=ba_grid[0], BA_cf=ba_cf,
+            WS_grid=ws_grid[0], WS_cf=ws_cf,
+            KR_cf=kr_cf, GRG_cf=grg_cf,
+        ))
+
+    df = pd.DataFrame(rows)
+    if df.empty:
+        print("\nNo ego nets scored.")
+        return
+    df.to_csv(out_dir / "results.csv", index=False)
+
+    print("\n" + "=" * 78)
+    print("AGGREGATE (mean GIC across ego nets, lower = better)")
+    print("=" * 78)
+    for fam in ("ER", "BA", "WS"):
+        g = df[f"{fam}_grid"].mean()
+        c = df[f"{fam}_cf"].mean()
+        win = (df[f"{fam}_cf"] < df[f"{fam}_grid"]).mean()
+        print(f"  {fam}:  grid={g:7.3f}   closed-form={c:7.3f}   "
+              f"Δ(grid-cf)={g - c:+7.3f}   cf_wins={win:.0%}")
+    print(f"  KR(cf)={df['KR_cf'].mean():.3f}   GRG(cf)={df['GRG_cf'].mean():.3f}   "
+          f"LG={df['LG'].mean():.3f}")
+
+    rank_cols = {"LG": "LG", "ER": "ER_cf", "BA": "BA_cf", "WS": "WS_cf",
+                 "KR": "KR_cf", "GRG": "GRG_cf"}
+    ranks = df[list(rank_cols.values())].rank(axis=1)
+    ranks.columns = list(rank_cols.keys())
+    print("\nMean rank (LG + closed-form baselines, lower = better):")
+    print(ranks.mean().sort_values().to_string())
+    print(f"\nWrote {out_dir / 'results.csv'}  ({len(df)} ego nets)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Facebook ego-net entry in the closed-form series (after gplus #42, animal #43, human #44, twitter #46 — all merged). Scores baseline graph-family estimators on the **10 SNAP Facebook ego networks**, with a fairly-scored LG. **No library code changes**; self-contained runner off main.

## Run it
- `make gic-facebook-ego-closedform` — full run, all 10 ego nets (~2–4 min)
- `make gic-facebook-ego-closedform-quick` — smoke (~20s)

Reproducible: fixed seed (`LG_FBE_SEED=12345`), BLAS threads pinned, tarball auto-extracted — `results.csv` is **byte-identical across runs** (verified). Undirected, self-loop-free largest connected component.

## Aggregate (mean GIC across 10 ego nets, lower = better)
| family | grid | closed-form | Δ(grid−cf) | cf wins |
|---|---|---|---|---|
| ER | **3.317** | 4.336 | −1.02 | 40% |
| BA | **3.573** | 4.352 | −0.78 | 30% |
| WS | **4.706** | 8.569 | −3.86 | 10% |

Closed-form only: KR 4.471, GRG **3.377**, **LG 3.483**.
Mean rank: **GRG 2.0**, **LG 2.5**, ER 3.2, BA 3.4, KR 3.9, WS 6.0.

## Conclusion — a size-split mix
The collection spans two regimes:
- **Small, mid-dense** ego nets (n<300, density 0.05–0.28) → **grid wins** (gplus pattern).
- **Large, sparse** ego nets (n 532–1034, density 0.03–0.11) → **closed-form competitive-to-better** (e.g. id 107: ER cf 2.621 vs grid 2.698). Their density falls near/below the grid's useful range.

That split is why the mean favors grid yet closed-form wins 40%/30% (ER/BA).
- **GRG (closed-form) is the best baseline** (rank 2.0) and best on most large ego nets — consistent across every dataset, still missing from the pipeline's `["ER","WS","BA","SBM"]` set.
- **LG is 2nd** (best standard model); picks d=0 for the large sparse nets, d=1–2 for the small dense ones.
- WS closed-form collapses (density-matched k overshoots).

## Cross-dataset picture (now five datasets)
| dataset | density | cf vs grid | best model |
|---|---|---|---|
| gplus / twitter (ego) | 0.03–0.41 | grid wins | LG |
| **facebook (ego)** | **0.03–0.28** | **mixed (size-split)** | **GRG, then LG** |
| animal connectomes | 0.003–0.71 | mixed / cf competitive | LG (GRG 2nd) |
| human connectomes | 0.09–0.54 | cf competitive (BA wins) | GRG, then LG |

## Files
- `notebooks/refactors/run_facebook_ego_closedform.py`
- `notebooks/refactors/FINDINGS_facebook_ego_closedform.md`
- `Makefile` — two targets

Output (`runs/facebook_ego_closedform/`) is gitignored, as with the other gic-* pipelines.