### PR TITLE
chore: trim verbose comments in the closed-form simulation scripts

### DIFF
--- a/notebooks/refactors/diag_lg_convergence.py
+++ b/notebooks/refactors/diag_lg_convergence.py
@@ -1,16 +1,5 @@
 #!/usr/bin/env python3
-"""Diagnose LG Gibbs convergence by tracking GIC vs iteration on gplus nets.
-
-For a few representative ego networks (small / mid / large n) we run the LG
-Gibbs chain (warm-started, layer-2, incremental) and recompute the *full* GIC
-( 2*KL(real, current) + 2 ) every `CHECK` steps. This shows whether the chain
-has converged by iteration 2000 (the value used in the comparison run) or is
-still improving, and what a GIC-plateau stopping rule would pick.
-
-Read-only w.r.t. the library. Writes plots/CSV under runs/lg_convergence/.
-
-Env: LG_DIAG_BUDGET (12000)  LG_DIAG_CHECK (200)  LG_DIAG_D (1)
-"""
+"""Diagnose LG Gibbs convergence by tracking GIC vs iteration on gplus nets."""
 from __future__ import annotations
 
 import os
@@ -44,7 +33,7 @@ BUDGET = int(os.environ.get("LG_DIAG_BUDGET", "12000"))
 CHECK = int(os.environ.get("LG_DIAG_CHECK", "200"))
 D = int(os.environ.get("LG_DIAG_D", "1"))
 SEED = 12345
-REF_ITER = 2000  # the cap used in the comparison run
+REF_ITER = 2000
 
 
 def pick_representative(files, targets=((50, 70), (120, 145), (280, 300))):

--- a/notebooks/refactors/run_arxiv_closedform.py
+++ b/notebooks/refactors/run_arxiv_closedform.py
@@ -1,36 +1,5 @@
 #!/usr/bin/env python3
-"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid
-search, on the cit-HepTh arXiv citation network, alongside a fairly-scored LG.
-
-cit-HepTh is one large graph (~27.8k nodes, ~352k edges) — far above the size at
-which the LG Gibbs chain mixes in reasonable time. So we sample SUBGRAPHS
-**BFS-connected subgraphs** capped at CAP nodes (seeded random BFS roots) and
-score each, measuring the families' fit to real *local* citation sub-networks
-rather than the global graph. Spectral GIC (2*KL + 2*n_params, KL on the
-normalized-Laplacian density, lower=better):
-
-  * LG            -- best of d in {0,1,2}, scored by burn-in + ensemble mean of
-                     the spectral density over N_RUNS post-burn-in snapshots.
-  * ER/BA/WS      -- grid (fixed interval, pick min GIC) and cf (closed-form).
-  * KR/GRG        -- closed-form only.
-
-Closed-form estimators (n nodes, E edges, kbar = 2E/n):
-  ER p=2E/(n(n-1)) [MLE]; BA m=round(E/n); WS k=2*round(E/n)+clustering p;
-  KR d=round(kbar); GRG r=sqrt(kbar/(pi*(n-1))).
-
-Reproducible: fixed seed (LG_ARCF_SEED) drives BFS roots + generators; BLAS
-pinned. Dense eigvalsh for n<=500, deterministic KPM above. Read-only w.r.t. the
-library; writes only under runs/arxiv_closedform/. Findings:
-FINDINGS_arxiv_closedform.md.
-
-Env knobs (all optional):
-  LG_ARCF_SEED (12345)   LG_ARCF_QUICK (0 -> SUBGRAPHS; 1 -> a few small ones)
-  LG_ARCF_CAP (700)      LG_ARCF_SUBGRAPHS (16)
-  LG_ARCF_N_RUNS (5)     LG_ARCF_GRID_POINTS (5)   LG_ARCF_DATA (path override)
-
-  make gic-arxiv-closedform        full run (BFS subgraphs of cit-HepTh)
-  make gic-arxiv-closedform-quick  smoke (a few subgraphs)
-"""
+"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid"""
 from __future__ import annotations
 
 import math
@@ -222,10 +191,6 @@ def lg_gic(adj, seed):
             print(f"    LG d={d} failed: {e}")
     return best
 
-
-# ---------------------------------------------------------------------------
-# Citation graph loading + BFS subgraph sampling
-# ---------------------------------------------------------------------------
 
 def _data_path():
     override = os.environ.get("LG_ARCF_DATA")

--- a/notebooks/refactors/run_connectomes_closedform.py
+++ b/notebooks/refactors/run_connectomes_closedform.py
@@ -1,45 +1,5 @@
 #!/usr/bin/env python3
-"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid
-search, on the 18 animal connectomes, alongside a fairly-scored Logit-Graph (LG).
-
-Connectome version of run_gplus_closedform.py. Each connectome is one graph per
-organism/region (mouse, macaque, rat, C. elegans, drosophila, ...), loaded from
-GraphML as the undirected, unweighted (binary) largest connected component.
-
-For each connectome in the size window we score, by spectral GIC
-(2*KL + 2*n_params, KL on the normalized-Laplacian density, lower=better):
-
-  * LG            -- best of d in {0,1,2}, each scored by burn-in + ensemble mean
-                     of the spectral density over N_RUNS post-burn-in snapshots
-                     (same averaging convention the baselines get).
-  * ER/BA/WS      -- two ways each:
-       grid : fixed interval, GRID_POINTS points, parameter picked by min GIC
-       cf   : closed-form moment estimate (no search)
-  * KR/GRG        -- closed-form only (bonus families)
-
-Closed-form estimators (n nodes, E edges, kbar = 2E/n avg degree):
-  ER  p = 2E/(n(n-1))                      (exact MLE)
-  BA  m = round(E/n)            in [1, n)   (edge count E = m(n-m))
-  WS  k = 2*round(E/n) (even)   in [2, n)   (E = nk/2, rewiring conserves edges)
-  WS  p = 1 - (C_obs/C0)^(1/3), C0 = 3(k-2)/(4(k-1))   (clustering moment)
-  KR  d = round(kbar)          (nd even)   (E = nd/2)
-  GRG r = sqrt(kbar / (pi*(n-1)))          (E[deg] ~ (n-1) pi r^2, 2-D)
-
-The normalized-Laplacian spectral density uses dense eigvalsh for n <= 500 and
-the deterministic KPM estimator for larger n (logit_graph.gic, seeded), so the
-big connectomes (n up to ~1800) stay tractable. Reproducible: fixed seed
-(LG_CCF_SEED), BLAS threads pinned to 1. Read-only w.r.t. the library; writes
-only under runs/connectomes_closedform/. Findings:
-FINDINGS_connectomes_closedform.md.
-
-Env knobs (all optional):
-  LG_CCF_SEED (12345)     LG_CCF_QUICK (0 -> full; 1 -> smoke on small connectomes)
-  LG_CCF_MIN_NODES (20)   LG_CCF_MAX_NODES (2000)   LG_CCF_MAX_NETS (all)
-  LG_CCF_N_RUNS (5)       LG_CCF_GRID_POINTS (5)
-
-  make gic-connectomes-closedform        full run
-  make gic-connectomes-closedform-quick  smoke on the small connectomes
-"""
+"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid"""
 from __future__ import annotations
 
 import math
@@ -49,7 +9,6 @@ import time
 import warnings
 from pathlib import Path
 
-# Pin BLAS threads BEFORE numpy import for deterministic eigvalsh across runs.
 for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
     os.environ.setdefault(_v, "1")
 
@@ -82,25 +41,19 @@ def _int(env, default):
 
 QUICK = os.environ.get("LG_CCF_QUICK", "0") == "1"
 MIN_NODES = _int("LG_CCF_MIN_NODES", 20)
-MAX_NODES = _int("LG_CCF_MAX_NODES", 300 if QUICK else 2000)  # all 18 connectomes
+MAX_NODES = _int("LG_CCF_MAX_NODES", 300 if QUICK else 2000)
 MAX_NETS = _int("LG_CCF_MAX_NETS", 6 if QUICK else 10_000)
 N_RUNS = _int("LG_CCF_N_RUNS", 3 if QUICK else 5)
 GRID_POINTS = _int("LG_CCF_GRID_POINTS", 3 if QUICK else 5)
 LG_D_LIST = [0, 1, 2]
-# Fair LG scoring: burn-in then N_RUNS spectral snapshots (stride apart).
 LG_BURN_MIN = _int("LG_CCF_LG_BURN_MIN", 4000)
 LG_BURN_PER_N = _int("LG_CCF_LG_BURN_PER_N", 25)
 LG_STRIDE_MIN = _int("LG_CCF_LG_STRIDE_MIN", 600)
 LG_STRIDE_PER_N = _int("LG_CCF_LG_STRIDE_PER_N", 6)
 SEED = _int("LG_CCF_SEED", 12345)
 
-# Current fixed intervals (mirror simulation.py defaults).
 GRID_INTERVALS = {"ER": (0.01, 0.25), "BA": (1, 8), "WS_k": (2, 10), "WS_p": (0.01, 0.5)}
 
-
-# ---------------------------------------------------------------------------
-# GIC scoring (apples-to-apples with the pipeline)
-# ---------------------------------------------------------------------------
 
 def gic_of(real_nx, model_name, gen_fn, n_runs, seed):
     """GIC = 2*KL(real_density, mean_model_density) + 2*n_params."""
@@ -119,10 +72,6 @@ def gic_of(real_nx, model_name, gen_fn, n_runs, seed):
     scorer = GraphInformationCriterion(real_nx, model=model_name, dist="KL")
     return float(scorer.calculate_gic(model_den=avg, n_params=n_params)), n_params
 
-
-# ---------------------------------------------------------------------------
-# Generators
-# ---------------------------------------------------------------------------
 
 def _er(n, p):
     p = float(np.clip(p, 1e-6, 1.0))
@@ -154,10 +103,6 @@ def _grg(n, r):
     return lambda s: nx.random_geometric_graph(n, r, seed=s)
 
 
-# ---------------------------------------------------------------------------
-# Closed-form estimators
-# ---------------------------------------------------------------------------
-
 def closed_form_params(G):
     n = G.number_of_nodes()
     E = G.number_of_edges()
@@ -167,7 +112,7 @@ def closed_form_params(G):
     k_ws = max(2, int(round(kbar)))
     if k_ws % 2 == 1:
         k_ws += 1
-    C_obs = nx.average_clustering(G)  # unweighted (weight=None default)
+    C_obs = nx.average_clustering(G)
     if k_ws > 2:
         C0 = 3 * (k_ws - 2) / (4 * (k_ws - 1))
         p_ws = 0.0 if C_obs >= C0 else 1.0 - (C_obs / C0) ** (1.0 / 3.0)
@@ -179,10 +124,6 @@ def closed_form_params(G):
                 ER=p_er, BA=m_ba, WS_k=k_ws, WS_p=p_ws, KR=d_kr, GRG=r_grg,
                 C_obs=C_obs)
 
-
-# ---------------------------------------------------------------------------
-# Current-style grid search (fixed interval, pick min GIC = best case for grid)
-# ---------------------------------------------------------------------------
 
 def grid_best(real_nx, model_name, n, build_gen, lo, hi, n_runs, seed):
     best = (np.nan, None)
@@ -206,11 +147,6 @@ def grid_best_ws(real_nx, n, n_runs, seed):
                 best = (g, (k, round(float(p), 3)))
     return best
 
-
-# ---------------------------------------------------------------------------
-# LG scored FAIRLY: burn-in + ensemble-mean spectral density (same convention
-# as the baselines, which average n_runs sample densities).
-# ---------------------------------------------------------------------------
 
 def _lg_burn(n):
     return max(LG_BURN_MIN, LG_BURN_PER_N * n)
@@ -257,22 +193,14 @@ def lg_gic(adj, seed):
     return best
 
 
-# ---------------------------------------------------------------------------
-# Data loading
-# ---------------------------------------------------------------------------
-
 def _load_graphml(path):
     """Undirected, unweighted (binary) largest connected component."""
     G = nx.read_graphml(path)
-    G = nx.Graph(G)  # collapse multi-edges + direction
+    G = nx.Graph(G)
     G.remove_edges_from(nx.selfloop_edges(G))
     cc = max(nx.connected_components(G), key=len)
     return nx.convert_node_labels_to_integers(G.subgraph(cc).copy())
 
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
 
 def main():
     data_dir = _repo_root / "data" / "connectomes"
@@ -289,7 +217,6 @@ def main():
           f"n_runs={N_RUNS}  grid_points={GRID_POINTS}  "
           f"lg_burn=max({LG_BURN_MIN},{LG_BURN_PER_N}n)  lg_stride=max({LG_STRIDE_MIN},{LG_STRIDE_PER_N}n)")
 
-    # Sort connectomes by node count so smaller (faster) ones run first.
     loaded = []
     for f in files:
         try:
@@ -311,7 +238,7 @@ def main():
         picked += 1
         t0 = time.perf_counter()
         cf = closed_form_params(G)
-        adj = nx.to_numpy_array(G, weight=None)  # binarize (connectomes are weighted)
+        adj = nx.to_numpy_array(G, weight=None)
         real_nx = nx.from_numpy_array(adj)
         print(f"\n[{picked}] {name}  n={n}  E={cf['E']}  density={cf['density']:.3f}  "
               f"kbar={cf['kbar']:.1f}  C={cf['C_obs']:.3f}")

--- a/notebooks/refactors/run_facebook_ego_closedform.py
+++ b/notebooks/refactors/run_facebook_ego_closedform.py
@@ -1,40 +1,5 @@
 #!/usr/bin/env python3
-"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid
-search, on the 10 SNAP Facebook ego networks, alongside a fairly-scored LG.
-
-Facebook-ego twin of run_gplus_closedform.py / run_twitter_closedform.py. The 10
-ego networks are all small enough (n 52-1034) for the LG Gibbs chain, so we
-score every one. Spectral GIC (2*KL + 2*n_params, KL on the normalized-Laplacian
-density, lower=better):
-
-  * LG            -- best of d in {0,1,2}, each scored by burn-in + ensemble mean
-                     of the spectral density over N_RUNS post-burn-in snapshots.
-  * ER/BA/WS      -- two ways each:
-       grid : fixed interval, GRID_POINTS points, parameter picked by min GIC
-       cf   : closed-form moment estimate (no search)
-  * KR/GRG        -- closed-form only (bonus families)
-
-Closed-form estimators (n nodes, E edges, kbar = 2E/n avg degree):
-  ER  p = 2E/(n(n-1))                      (exact MLE)
-  BA  m = round(E/n)            in [1, n)   (edge count E = m(n-m))
-  WS  k = 2*round(E/n) (even)   in [2, n)   (E = nk/2, rewiring conserves edges)
-  WS  p = 1 - (C_obs/C0)^(1/3), C0 = 3(k-2)/(4(k-1))   (clustering moment)
-  KR  d = round(kbar)          (nd even)   (E = nd/2)
-  GRG r = sqrt(kbar / (pi*(n-1)))          (E[deg] ~ (n-1) pi r^2, 2-D)
-
-Reproducible: fixed seed (LG_FBE_SEED), BLAS threads pinned to 1; the facebook
-tarball is auto-extracted if the .edges files are missing. Read-only w.r.t. the
-library; writes only under runs/facebook_ego_closedform/. Findings:
-FINDINGS_facebook_ego_closedform.md.
-
-Env knobs (all optional):
-  LG_FBE_SEED (12345)    LG_FBE_QUICK (0 -> all 10; 1 -> smoke on small ones)
-  LG_FBE_MIN_NODES (20)  LG_FBE_MAX_NODES (2000)   LG_FBE_MAX_NETS (all)
-  LG_FBE_N_RUNS (5)      LG_FBE_GRID_POINTS (5)
-
-  make gic-facebook-ego-closedform        full run (all 10 ego nets)
-  make gic-facebook-ego-closedform-quick  smoke (small ego nets)
-"""
+"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid"""
 from __future__ import annotations
 
 import math

--- a/notebooks/refactors/run_gplus_closedform.py
+++ b/notebooks/refactors/run_gplus_closedform.py
@@ -1,41 +1,5 @@
 #!/usr/bin/env python3
-"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid
-search, on Google+ ego networks, alongside a fairly-scored Logit-Graph (LG).
-
-For each gplus ego network in the size window we score, by spectral GIC
-(2*KL + 2*n_params, KL on the 50-bin normalized-Laplacian density, lower=better):
-
-  * LG            -- best of d in {0,1,2}, each scored by burn-in + ensemble mean
-                     of the spectral density over N_RUNS post-burn-in snapshots
-                     (same averaging convention the baselines get; avoids the
-                     pipeline's best-of-trajectory cherry-pick — see
-                     diag_lg_convergence.py).
-  * ER/BA/WS      -- two ways each:
-       grid : fixed interval, GRID_POINTS points, parameter picked by min GIC
-       cf   : closed-form moment estimate (no search)
-  * KR/GRG        -- closed-form only (bonus families)
-
-Closed-form estimators (n nodes, E edges, kbar = 2E/n avg degree):
-  ER  p = 2E/(n(n-1))                      (exact MLE)
-  BA  m = round(E/n)            in [1, n)   (edge count E = m(n-m))
-  WS  k = 2*round(E/n) (even)   in [2, n)   (E = nk/2, rewiring conserves edges)
-  WS  p = 1 - (C_obs/C0)^(1/3), C0 = 3(k-2)/(4(k-1))   (clustering moment)
-  KR  d = round(kbar)          (nd even)   (E = nd/2)
-  GRG r = sqrt(kbar / (pi*(n-1)))          (E[deg] ~ (n-1) pi r^2, 2-D)
-
-Reproducible: single fixed seed (LG_CF_SEED), BLAS threads pinned to 1, and the
-gplus tarball is auto-extracted if the .edges files are missing. Read-only w.r.t.
-the library; writes only under runs/gplus_closedform/. Findings:
-FINDINGS_gplus_closedform.md.
-
-Env knobs (all optional):
-  LG_CF_SEED (12345)    LG_CF_QUICK (0 -> full; 1 -> smoke on a few small nets)
-  LG_CF_MIN_NODES (50)  LG_CF_MAX_NODES (300)  LG_CF_MAX_NETS (all)
-  LG_CF_N_RUNS (5)      LG_CF_GRID_POINTS (5)
-
-  make gic-gplus-closedform        full run (~30s, 17 nets)
-  make gic-gplus-closedform-quick  smoke (~5s, a few small nets)
-"""
+"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid"""
 from __future__ import annotations
 
 import math
@@ -45,7 +9,6 @@ import time
 import warnings
 from pathlib import Path
 
-# Pin BLAS threads BEFORE numpy import for deterministic eigvalsh across runs.
 for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
     os.environ.setdefault(_v, "1")
 
@@ -78,26 +41,19 @@ def _int(env, default):
 
 QUICK = os.environ.get("LG_CF_QUICK", "0") == "1"
 MIN_NODES = _int("LG_CF_MIN_NODES", 50)
-MAX_NODES = _int("LG_CF_MAX_NODES", 120 if QUICK else 300)  # full matches gic-gplus
-MAX_NETS = _int("LG_CF_MAX_NETS", 4 if QUICK else 10_000)   # full = all nets in window
+MAX_NODES = _int("LG_CF_MAX_NODES", 120 if QUICK else 300)
+MAX_NETS = _int("LG_CF_MAX_NETS", 4 if QUICK else 10_000)
 N_RUNS = _int("LG_CF_N_RUNS", 3 if QUICK else 5)
 GRID_POINTS = _int("LG_CF_GRID_POINTS", 3 if QUICK else 5)
-LG_D_LIST = [0, 1, 2]                       # LG d exploration
-# Fair LG scoring: burn-in then N_RUNS spectral snapshots (stride apart),
-# scaled with n. Burn-in past the noisy walk seen in diag_lg_convergence.py.
+LG_D_LIST = [0, 1, 2]
 LG_BURN_MIN = _int("LG_CF_LG_BURN_MIN", 4000)
 LG_BURN_PER_N = _int("LG_CF_LG_BURN_PER_N", 25)
 LG_STRIDE_MIN = _int("LG_CF_LG_STRIDE_MIN", 600)
 LG_STRIDE_PER_N = _int("LG_CF_LG_STRIDE_PER_N", 6)
 SEED = _int("LG_CF_SEED", 12345)
 
-# Current fixed intervals (mirror simulation.py defaults).
 GRID_INTERVALS = {"ER": (0.01, 0.25), "BA": (1, 8), "WS_k": (2, 10), "WS_p": (0.01, 0.5)}
 
-
-# ---------------------------------------------------------------------------
-# GIC scoring (apples-to-apples with the pipeline)
-# ---------------------------------------------------------------------------
 
 def gic_of(real_nx, model_name, gen_fn, n_runs, seed):
     """GIC = 2*KL(real_density, mean_model_density) + 2*n_params."""
@@ -116,10 +72,6 @@ def gic_of(real_nx, model_name, gen_fn, n_runs, seed):
     scorer = GraphInformationCriterion(real_nx, model=model_name, dist="KL")
     return float(scorer.calculate_gic(model_den=avg, n_params=n_params)), n_params
 
-
-# ---------------------------------------------------------------------------
-# Generators
-# ---------------------------------------------------------------------------
 
 def _er(n, p):
     p = float(np.clip(p, 1e-6, 1.0))
@@ -151,10 +103,6 @@ def _grg(n, r):
     return lambda s: nx.random_geometric_graph(n, r, seed=s)
 
 
-# ---------------------------------------------------------------------------
-# Closed-form estimators
-# ---------------------------------------------------------------------------
-
 def closed_form_params(G):
     n = G.number_of_nodes()
     E = G.number_of_edges()
@@ -164,7 +112,6 @@ def closed_form_params(G):
     k_ws = max(2, int(round(kbar)))
     if k_ws % 2 == 1:
         k_ws += 1
-    # WS rewiring p from clustering moment.
     C_obs = nx.average_clustering(G)
     if k_ws > 2:
         C0 = 3 * (k_ws - 2) / (4 * (k_ws - 1))
@@ -177,10 +124,6 @@ def closed_form_params(G):
                 ER=p_er, BA=m_ba, WS_k=k_ws, WS_p=p_ws, KR=d_kr, GRG=r_grg,
                 C_obs=C_obs)
 
-
-# ---------------------------------------------------------------------------
-# Current-style grid search (fixed interval, pick min GIC = best case for grid)
-# ---------------------------------------------------------------------------
 
 def grid_best(real_nx, model_name, n, build_gen, lo, hi, n_runs, seed):
     best = (np.nan, None)
@@ -205,13 +148,6 @@ def grid_best_ws(real_nx, n, n_runs, seed):
     return best
 
 
-# ---------------------------------------------------------------------------
-# LG scored FAIRLY: burn-in + ensemble-mean spectral density (same convention
-# as the baselines, which average n_runs sample densities). This avoids the
-# pipeline's "best graph over a noisy trajectory" cherry-pick, which is
-# downward-biased and budget-dependent (see diag_lg_convergence.py).
-# ---------------------------------------------------------------------------
-
 def _lg_burn(n):
     return max(LG_BURN_MIN, LG_BURN_PER_N * n)
 
@@ -228,7 +164,6 @@ def lg_gic_one_d(adj, d, seed):
 
     dens = []
     if d == 0:
-        # d=0 equilibrium is ER(expit(sigma)); ensemble of independent draws.
         for r in range(N_RUNS):
             g = nx.from_numpy_array(_direct_er_at_sigma(n, sigma, seed=seed + r))
             dens.append(scorer.compute_spectral_density(g)[0])
@@ -257,10 +192,6 @@ def lg_gic(adj, seed):
             print(f"    LG d={d} failed: {e}")
     return best
 
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
 
 def _ensure_data(data_dir):
     """Extract data/misc/gplus.tar.gz if the .edges files are not present."""
@@ -306,31 +237,26 @@ def main():
         print(f"\n[{picked}] {name}  n={n}  E={cf['E']}  density={cf['density']:.3f}  "
               f"kbar={cf['kbar']:.1f}  C={cf['C_obs']:.3f}")
 
-        # LG
         lg_val, lg_d = lg_gic(adj, SEED)
         print(f"    LG     gic={lg_val:.3f} (d={lg_d})")
 
-        # ER
         er_grid = grid_best(real_nx, "ER", n,
                             lambda v: _er(n, v), *GRID_INTERVALS["ER"], N_RUNS, SEED)
         er_cf, _ = gic_of(real_nx, "ER", _er(n, cf["ER"]), N_RUNS, SEED)
         print(f"    ER     grid={er_grid[0]:.3f} (p={er_grid[1]:.3f})   "
               f"cf={er_cf:.3f} (p={cf['ER']:.3f})")
 
-        # BA
         ba_grid = grid_best(real_nx, "BA", n,
                             lambda v: _ba(n, v), *GRID_INTERVALS["BA"], N_RUNS, SEED)
         ba_cf, _ = gic_of(real_nx, "BA", _ba(n, cf["BA"]), N_RUNS, SEED)
         print(f"    BA     grid={ba_grid[0]:.3f} (m={ba_grid[1]:.1f})   "
               f"cf={ba_cf:.3f} (m={cf['BA']})")
 
-        # WS
         ws_grid = grid_best_ws(real_nx, n, N_RUNS, SEED)
         ws_cf, _ = gic_of(real_nx, "WS", _ws(n, cf["WS_k"], cf["WS_p"]), N_RUNS, SEED)
         print(f"    WS     grid={ws_grid[0]:.3f} (k,p={ws_grid[1]})   "
               f"cf={ws_cf:.3f} (k={cf['WS_k']},p={cf['WS_p']:.3f})")
 
-        # KR / GRG closed-form only
         kr_cf, _ = gic_of(real_nx, "KR", _kr(n, cf["KR"]), N_RUNS, SEED)
         grg_cf, _ = gic_of(real_nx, "GRG", _grg(n, cf["GRG"]), N_RUNS, SEED)
         print(f"    KR cf={kr_cf:.3f} (d={cf['KR']})   GRG cf={grg_cf:.3f} (r={cf['GRG']:.3f})"
@@ -363,7 +289,6 @@ def main():
     print(f"  KR(cf)={df['KR_cf'].mean():.3f}   GRG(cf)={df['GRG_cf'].mean():.3f}   "
           f"LG={df['LG'].mean():.3f}")
 
-    # Ranking among LG + closed-form baselines (lower GIC = rank 1)
     rank_cols = {"LG": "LG", "ER": "ER_cf", "BA": "BA_cf", "WS": "WS_cf",
                  "KR": "KR_cf", "GRG": "GRG_cf"}
     ranks = df[list(rank_cols.values())].rank(axis=1)

--- a/notebooks/refactors/run_human_connectomes_closedform.py
+++ b/notebooks/refactors/run_human_connectomes_closedform.py
@@ -1,44 +1,5 @@
 #!/usr/bin/env python3
-"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid
-search, on OASIS-3 human brain connectomes, alongside a fairly-scored LG.
-
-Human-connectome twin of run_connectomes_closedform.py. The OASIS-3 dataset has
-several parcellation scales (different node counts) with hundreds of subjects
-each; all subjects in a scale share a node count. We sample PER_SCALE subjects
-from each of a few scales (seeded) and score, by spectral GIC
-(2*KL + 2*n_params, KL on the normalized-Laplacian density, lower=better):
-
-  * LG            -- best of d in {0,1,2}, each scored by burn-in + ensemble mean
-                     of the spectral density over N_RUNS post-burn-in snapshots.
-  * ER/BA/WS      -- two ways each:
-       grid : fixed interval, GRID_POINTS points, parameter picked by min GIC
-       cf   : closed-form moment estimate (no search)
-  * KR/GRG        -- closed-form only (bonus families)
-
-Closed-form estimators (n nodes, E edges, kbar = 2E/n avg degree):
-  ER  p = 2E/(n(n-1))                      (exact MLE)
-  BA  m = round(E/n)            in [1, n)   (edge count E = m(n-m))
-  WS  k = 2*round(E/n) (even)   in [2, n)   (E = nk/2, rewiring conserves edges)
-  WS  p = 1 - (C_obs/C0)^(1/3), C0 = 3(k-2)/(4(k-1))   (clustering moment)
-  KR  d = round(kbar)          (nd even)   (E = nd/2)
-  GRG r = sqrt(kbar / (pi*(n-1)))          (E[deg] ~ (n-1) pi r^2, 2-D)
-
-Brain graphs are weighted (fiber density); we binarize to the undirected,
-unweighted largest connected component. Dense eigvalsh for n<=500, deterministic
-KPM above. Reproducible: fixed seed (LG_HCF_SEED) drives the subject sampling
-and all generators; BLAS threads pinned to 1. Read-only w.r.t. the library;
-writes only under runs/human_connectomes_closedform/. Findings:
-FINDINGS_human_connectomes_closedform.md.
-
-Env knobs (all optional):
-  LG_HCF_SEED (12345)   LG_HCF_QUICK (0 -> full; 1 -> smoke, one small scale)
-  LG_HCF_SCALES (oasis3 scale1,scale2,scale3 + repeated_10_scale_250)
-  LG_HCF_PER_SCALE (8)  LG_HCF_N_RUNS (5)  LG_HCF_GRID_POINTS (5)
-  LG_HCF_MIN_NODES (20) LG_HCF_MAX_NODES (500)
-
-  make gic-human-connectomes-closedform        full run
-  make gic-human-connectomes-closedform-quick  smoke
-"""
+"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid"""
 from __future__ import annotations
 
 import math
@@ -49,7 +10,6 @@ import time
 import warnings
 from pathlib import Path
 
-# Pin BLAS threads BEFORE numpy import for deterministic eigvalsh across runs.
 for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
     os.environ.setdefault(_v, "1")
 
@@ -101,10 +61,6 @@ SEED = _int("LG_HCF_SEED", 12345)
 GRID_INTERVALS = {"ER": (0.01, 0.25), "BA": (1, 8), "WS_k": (2, 10), "WS_p": (0.01, 0.5)}
 
 
-# ---------------------------------------------------------------------------
-# GIC scoring
-# ---------------------------------------------------------------------------
-
 def gic_of(real_nx, model_name, gen_fn, n_runs, seed):
     """GIC = 2*KL(real_density, mean_model_density) + 2*n_params."""
     n_params = _MODEL_N_PARAMS.get(model_name, 1)
@@ -122,10 +78,6 @@ def gic_of(real_nx, model_name, gen_fn, n_runs, seed):
     scorer = GraphInformationCriterion(real_nx, model=model_name, dist="KL")
     return float(scorer.calculate_gic(model_den=avg, n_params=n_params)), n_params
 
-
-# ---------------------------------------------------------------------------
-# Generators
-# ---------------------------------------------------------------------------
 
 def _er(n, p):
     p = float(np.clip(p, 1e-6, 1.0))
@@ -157,10 +109,6 @@ def _grg(n, r):
     return lambda s: nx.random_geometric_graph(n, r, seed=s)
 
 
-# ---------------------------------------------------------------------------
-# Closed-form estimators
-# ---------------------------------------------------------------------------
-
 def closed_form_params(G):
     n = G.number_of_nodes()
     E = G.number_of_edges()
@@ -182,10 +130,6 @@ def closed_form_params(G):
                 ER=p_er, BA=m_ba, WS_k=k_ws, WS_p=p_ws, KR=d_kr, GRG=r_grg,
                 C_obs=C_obs)
 
-
-# ---------------------------------------------------------------------------
-# Grid search (fixed interval, pick min GIC = best case for grid)
-# ---------------------------------------------------------------------------
 
 def grid_best(real_nx, model_name, n, build_gen, lo, hi, n_runs, seed):
     best = (np.nan, None)
@@ -209,10 +153,6 @@ def grid_best_ws(real_nx, n, n_runs, seed):
                 best = (g, (k, round(float(p), 3)))
     return best
 
-
-# ---------------------------------------------------------------------------
-# LG scored fairly: burn-in + ensemble-mean spectral density
-# ---------------------------------------------------------------------------
 
 def _lg_burn(n):
     return max(LG_BURN_MIN, LG_BURN_PER_N * n)
@@ -259,10 +199,6 @@ def lg_gic(adj, seed):
     return best
 
 
-# ---------------------------------------------------------------------------
-# Data loading
-# ---------------------------------------------------------------------------
-
 def _load_graphml(path):
     """Undirected, unweighted (binary) largest connected component."""
     G = nx.read_graphml(path)
@@ -286,10 +222,6 @@ def _sample_subjects():
             chosen.append((scale, p))
     return chosen
 
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
 
 def main():
     out_dir = _here / "runs" / "human_connectomes_closedform"
@@ -319,7 +251,7 @@ def main():
         picked += 1
         t0 = time.perf_counter()
         cf = closed_form_params(G)
-        adj = nx.to_numpy_array(G, weight=None)  # binarize
+        adj = nx.to_numpy_array(G, weight=None)
         real_nx = nx.from_numpy_array(adj)
         name = f"{scale.replace('oasis3_graphmls_', '').replace('repeated_10_', 'rep_')}/{path.stem[:8]}"
         print(f"\n[{picked}] {name}  n={n}  E={cf['E']}  density={cf['density']:.3f}  "

--- a/notebooks/refactors/run_twitch_closedform.py
+++ b/notebooks/refactors/run_twitch_closedform.py
@@ -1,38 +1,5 @@
 #!/usr/bin/env python3
-"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid
-search, on Twitch country networks, alongside a fairly-scored Logit-Graph (LG).
-
-The 6 Twitch country graphs are large (n 1912-9498) — far above the size at
-which the LG Gibbs chain mixes in reasonable time. So instead of the whole
-country graph we sample, per country, PER_COUNTRY **BFS-connected subgraphs**
-capped at CAP nodes (seeded random BFS roots), and score each subgraph. This
-measures the families' fit to real *local* Twitch sub-networks, not the global
-graph. Spectral GIC (2*KL + 2*n_params, KL on the normalized-Laplacian density,
-lower=better):
-
-  * LG            -- best of d in {0,1,2}, scored by burn-in + ensemble mean of
-                     the spectral density over N_RUNS post-burn-in snapshots.
-  * ER/BA/WS      -- grid (fixed interval, pick min GIC) and cf (closed-form).
-  * KR/GRG        -- closed-form only.
-
-Closed-form estimators (n nodes, E edges, kbar = 2E/n):
-  ER p=2E/(n(n-1)) [MLE]; BA m=round(E/n); WS k=2*round(E/n)+clustering p;
-  KR d=round(kbar); GRG r=sqrt(kbar/(pi*(n-1))).
-
-Reproducible: fixed seed (LG_TWCF_SEED) drives BFS roots + generators; BLAS
-pinned. Dense eigvalsh for n<=500, deterministic KPM above. Read-only w.r.t. the
-library; writes only under runs/twitch_closedform/. Findings:
-FINDINGS_twitch_closedform.md.
-
-Env knobs (all optional):
-  LG_TWCF_SEED (12345)     LG_TWCF_QUICK (0 -> all 6 countries; 1 -> 2 countries)
-  LG_TWCF_COUNTRIES (PTBR,RU,ES,FR,ENGB,DE)
-  LG_TWCF_CAP (700)        LG_TWCF_PER_COUNTRY (3)
-  LG_TWCF_N_RUNS (5)       LG_TWCF_GRID_POINTS (5)
-
-  make gic-twitch-closedform        full run (BFS subgraphs from all 6 countries)
-  make gic-twitch-closedform-quick  smoke (2 countries, 1 subgraph each)
-"""
+"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid"""
 from __future__ import annotations
 
 import math
@@ -226,10 +193,6 @@ def lg_gic(adj, seed):
             print(f"    LG d={d} failed: {e}")
     return best
 
-
-# ---------------------------------------------------------------------------
-# Country loading + BFS subgraph sampling
-# ---------------------------------------------------------------------------
 
 def _load_country(path):
     G = nx.read_edgelist(path, comments="#", nodetype=int)

--- a/notebooks/refactors/run_twitter_closedform.py
+++ b/notebooks/refactors/run_twitter_closedform.py
@@ -1,40 +1,5 @@
 #!/usr/bin/env python3
-"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid
-search, on Twitter SNAP ego networks, alongside a fairly-scored Logit-Graph (LG).
-
-Twitter twin of run_gplus_closedform.py. The SNAP twitter collection has 973
-ego networks (n up to ~247); we sample MAX_NETS of them (seeded) from the size
-window and score, by spectral GIC (2*KL + 2*n_params, KL on the normalized-
-Laplacian density, lower=better):
-
-  * LG            -- best of d in {0,1,2}, each scored by burn-in + ensemble mean
-                     of the spectral density over N_RUNS post-burn-in snapshots.
-  * ER/BA/WS      -- two ways each:
-       grid : fixed interval, GRID_POINTS points, parameter picked by min GIC
-       cf   : closed-form moment estimate (no search)
-  * KR/GRG        -- closed-form only (bonus families)
-
-Closed-form estimators (n nodes, E edges, kbar = 2E/n avg degree):
-  ER  p = 2E/(n(n-1))                      (exact MLE)
-  BA  m = round(E/n)            in [1, n)   (edge count E = m(n-m))
-  WS  k = 2*round(E/n) (even)   in [2, n)   (E = nk/2, rewiring conserves edges)
-  WS  p = 1 - (C_obs/C0)^(1/3), C0 = 3(k-2)/(4(k-1))   (clustering moment)
-  KR  d = round(kbar)          (nd even)   (E = nd/2)
-  GRG r = sqrt(kbar / (pi*(n-1)))          (E[deg] ~ (n-1) pi r^2, 2-D)
-
-Reproducible: fixed seed (LG_TCF_SEED) drives the ego-net sampling and all
-generators; BLAS threads pinned to 1; the twitter tarball is auto-extracted if
-the .edges files are missing. Read-only w.r.t. the library; writes only under
-runs/twitter_closedform/. Findings: FINDINGS_twitter_closedform.md.
-
-Env knobs (all optional):
-  LG_TCF_SEED (12345)    LG_TCF_QUICK (0 -> full; 1 -> smoke on a few ego nets)
-  LG_TCF_MIN_NODES (50)  LG_TCF_MAX_NODES (300)  LG_TCF_MAX_NETS (30)
-  LG_TCF_N_RUNS (5)      LG_TCF_GRID_POINTS (5)
-
-  make gic-twitter-closedform        full run (~1-2 min, 30 ego nets)
-  make gic-twitter-closedform-quick  smoke (~10s, a few ego nets)
-"""
+"""Closed-form (moment-matched) baseline estimators vs fixed-interval grid"""
 from __future__ import annotations
 
 import math
@@ -45,7 +10,6 @@ import time
 import warnings
 from pathlib import Path
 
-# Pin BLAS threads BEFORE numpy import for deterministic eigvalsh across runs.
 for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
     os.environ.setdefault(_v, "1")
 
@@ -92,10 +56,6 @@ SEED = _int("LG_TCF_SEED", 12345)
 GRID_INTERVALS = {"ER": (0.01, 0.25), "BA": (1, 8), "WS_k": (2, 10), "WS_p": (0.01, 0.5)}
 
 
-# ---------------------------------------------------------------------------
-# GIC scoring
-# ---------------------------------------------------------------------------
-
 def gic_of(real_nx, model_name, gen_fn, n_runs, seed):
     """GIC = 2*KL(real_density, mean_model_density) + 2*n_params."""
     n_params = _MODEL_N_PARAMS.get(model_name, 1)
@@ -113,10 +73,6 @@ def gic_of(real_nx, model_name, gen_fn, n_runs, seed):
     scorer = GraphInformationCriterion(real_nx, model=model_name, dist="KL")
     return float(scorer.calculate_gic(model_den=avg, n_params=n_params)), n_params
 
-
-# ---------------------------------------------------------------------------
-# Generators
-# ---------------------------------------------------------------------------
 
 def _er(n, p):
     p = float(np.clip(p, 1e-6, 1.0))
@@ -148,10 +104,6 @@ def _grg(n, r):
     return lambda s: nx.random_geometric_graph(n, r, seed=s)
 
 
-# ---------------------------------------------------------------------------
-# Closed-form estimators
-# ---------------------------------------------------------------------------
-
 def closed_form_params(G):
     n = G.number_of_nodes()
     E = G.number_of_edges()
@@ -173,10 +125,6 @@ def closed_form_params(G):
                 ER=p_er, BA=m_ba, WS_k=k_ws, WS_p=p_ws, KR=d_kr, GRG=r_grg,
                 C_obs=C_obs)
 
-
-# ---------------------------------------------------------------------------
-# Grid search (fixed interval, pick min GIC = best case for grid)
-# ---------------------------------------------------------------------------
 
 def grid_best(real_nx, model_name, n, build_gen, lo, hi, n_runs, seed):
     best = (np.nan, None)
@@ -200,10 +148,6 @@ def grid_best_ws(real_nx, n, n_runs, seed):
                 best = (g, (k, round(float(p), 3)))
     return best
 
-
-# ---------------------------------------------------------------------------
-# LG scored fairly: burn-in + ensemble-mean spectral density
-# ---------------------------------------------------------------------------
 
 def _lg_burn(n):
     return max(LG_BURN_MIN, LG_BURN_PER_N * n)
@@ -250,10 +194,6 @@ def lg_gic(adj, seed):
     return best
 
 
-# ---------------------------------------------------------------------------
-# Data loading / sampling
-# ---------------------------------------------------------------------------
-
 def _ensure_data(data_dir):
     """Extract data/misc/twitter.tar.gz if the .edges files are not present."""
     if data_dir.exists() and any(data_dir.glob("*.edges")):
@@ -294,16 +234,11 @@ def _sample_files():
     allf = sorted(data_dir.glob("*.edges"))
     if not allf:
         return []
-    # Cheap pre-filter to the size window (peek node count without nx parsing).
     inwin = [f for f in allf if MIN_NODES <= _peek_size(f) <= MAX_NODES]
     rng = random.Random(SEED)
     k = min(MAX_NETS, len(inwin))
     return sorted(rng.sample(inwin, k)), len(inwin), len(allf)
 
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
 
 def main():
     out_dir = _here / "runs" / "twitter_closedform"


### PR DESCRIPTION
Removes the excessive commentary from the closed-form simulation scripts — multi-line module docstrings, section-banner comment blocks, and inline explanatory comments — leaving a **single-line docstring** per file and code that speaks for itself.

**One commit per file** (8 files):
- the 7 `run_*_closedform.py` runners (gplus, twitter, facebook-ego, animal connectomes, human connectomes, twitch, arxiv)
- `diag_lg_convergence.py`

## What's preserved
- The one-line module docstring (first line of the old docstring).
- `# noqa: E402` import directives (functional).
- The shebang.
- `#` characters inside strings (e.g. `comments="#"`, `delimiter="\t"`, `f"sub#{ri}"`) — the stripper is tokenizer-based, not a naive `split('#')`.

## Verification
- All 8 files `py_compile` cleanly.
- No leftover banner/inline comments (full grep scan).
- Smoke-ran `run_arxiv_closedform.py` (the riskiest — it has `#` inside strings) after trimming: works unchanged.

No behavior change — comments/docstrings only.