### PR TITLE
Add dyadic-cluster-robust SE library helper for offset-logit sigma

### DIFF
--- a/src/logit_graph/robust_se.py
+++ b/src/logit_graph/robust_se.py
@@ -1,0 +1,110 @@
+"""Dyadic-cluster-robust standard error for the offset-logit sigma estimate.
+
+A single observed graph gives one sigma_hat; its uncertainty cannot come from
+re-subsampling that one graph (pseudo-replication). For the intercept-only offset
+logistic regression ``logit(y_ij) = sigma + offset_ij`` the pairs share nodes and
+are not independent, so the model-based (independence) SE ``1/sqrt(A)`` is wrong.
+
+This module provides the dyadic-cluster-robust (sandwich) SE of Aronow, Samii &
+Assenova (2015): with score residuals ``s_ij = y_ij - p_ij``, bread
+``A = sum p_ij(1-p_ij)`` and node sums ``T_m = sum_{j!=m} s_mj``,
+``B = sum_m T_m^2 - sum_ij s_ij^2`` and ``Var(sigma_hat) = B / A^2``. Distinct
+dyads share at most one node, which collapses the O(n^4) double sum to O(n^2).
+At d=0 (ER, independent dyads) it reduces to the independence SE.
+"""
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import numpy as np
+from scipy.special import expit
+
+from .lg_features import FeatureMode, build_pair_dataset
+from .offset_logit import fit_offset_logit_fast
+
+
+def dyadic_robust_sigma_se(
+    offsets: np.ndarray,
+    labels: np.ndarray,
+    sigma_hat: float,
+    n: int,
+) -> tuple[float, float]:
+    """Return ``(se_robust, se_naive)`` for the offset-logit intercept sigma_hat.
+
+    ``offsets`` and ``labels`` are the per-pair feature offsets and 0/1 edge
+    indicators for all upper-triangle pairs, enumerated in row-major order
+    ``(0,1),(0,2),...,(1,2),...`` (the order produced by
+    :func:`logit_graph.lg_features.build_pair_dataset`).
+    """
+    p = expit(sigma_hat + np.asarray(offsets, dtype=np.float64))
+    s = np.asarray(labels, dtype=np.float64) - p
+    A = float(np.sum(p * (1.0 - p)))
+    if A <= 0:
+        return float("nan"), float("nan")
+    sum_s2 = float(np.sum(s * s))
+
+    # T_m = sum of score residuals over dyads incident to node m, via row slices
+    # (avoids materializing the n^2 (i,j) index arrays).
+    T = np.zeros(n, dtype=np.float64)
+    start = 0
+    for i in range(n - 1):
+        cnt = n - 1 - i
+        s_row = s[start:start + cnt]
+        T[i] += float(s_row.sum())
+        T[i + 1:] += s_row
+        start += cnt
+
+    B = float(np.sum(T * T) - sum_s2)
+    se_robust = math.sqrt(max(B, 0.0)) / A
+    se_naive = 1.0 / math.sqrt(A)
+    return se_robust, se_naive
+
+
+def fit_sigma(
+    adj: np.ndarray,
+    d: int,
+    feature_mode: FeatureMode = "incremental",
+) -> tuple[float, float, np.ndarray, np.ndarray]:
+    """Offset-logit MLE sigma_hat at radius ``d`` on all upper-triangle pairs.
+
+    Returns ``(sigma_hat, log_likelihood, offsets, labels)``.
+    """
+    offsets, labels = build_pair_dataset(adj, d=d, mode=feature_mode, layer2=True)
+    sigma, ll = fit_offset_logit_fast(offsets, labels)
+    return float(sigma), float(ll), offsets, labels
+
+
+def fit_sigma_with_robust_se(
+    adj: np.ndarray,
+    d: int,
+    feature_mode: FeatureMode = "incremental",
+) -> tuple[float, float, float]:
+    """Fit sigma_hat at ``d`` and return ``(sigma_hat, se_robust, se_naive)``."""
+    sigma, _ll, offsets, labels = fit_sigma(adj, d, feature_mode=feature_mode)
+    se_r, se_n = dyadic_robust_sigma_se(offsets, labels, sigma, adj.shape[0])
+    return sigma, se_r, se_n
+
+
+def select_d_aic(
+    adj: np.ndarray,
+    d_candidates: list[int],
+    feature_mode: FeatureMode = "incremental",
+) -> tuple[int, float, np.ndarray, np.ndarray, dict[int, float]]:
+    """AIC d-selection on the full graph (AIC = -2*ll + 2, one parameter sigma).
+
+    Returns ``(d_hat, sigma_hat, offsets, labels, aic_by_d)`` where the offsets /
+    labels / sigma_hat correspond to the selected ``d_hat`` (so the caller can
+    feed them straight to :func:`dyadic_robust_sigma_se` without recomputing).
+    """
+    best: Optional[tuple[float, int, float, np.ndarray, np.ndarray]] = None
+    aic_by_d: dict[int, float] = {}
+    for d in d_candidates:
+        sigma, ll, offsets, labels = fit_sigma(adj, d, feature_mode=feature_mode)
+        aic = -2.0 * ll + 2.0
+        aic_by_d[d] = aic
+        if best is None or aic < best[0]:
+            best = (aic, d, sigma, offsets, labels)
+    assert best is not None
+    _, d_hat, sigma_hat, offsets, labels = best
+    return d_hat, sigma_hat, offsets, labels, aic_by_d

--- a/tests/test_robust_se.py
+++ b/tests/test_robust_se.py
@@ -1,0 +1,89 @@
+"""Tests for the dyadic-cluster-robust SE of the offset-logit sigma estimate."""
+import math
+
+import numpy as np
+import networkx as nx
+import pytest
+
+from logit_graph.graph import GraphModel
+from logit_graph.robust_se import (
+    dyadic_robust_sigma_se,
+    fit_sigma,
+    fit_sigma_with_robust_se,
+    select_d_aic,
+)
+
+
+def _er(n, p, seed):
+    return nx.to_numpy_array(nx.erdos_renyi_graph(n, p, seed=seed))
+
+
+# -------------------------------------------------------------------
+# At d=0 the dyads are independent (ER) -> robust reduces to naive
+# -------------------------------------------------------------------
+
+def test_robust_reduces_to_naive_at_d0():
+    adj = _er(400, 0.05, seed=0)
+    sigma, se_r, se_n = fit_sigma_with_robust_se(adj, d=0)
+    # One realization: B fluctuates around A, so within a few percent.
+    assert math.isclose(se_r, se_n, rel_tol=0.15)
+
+
+def test_naive_se_equals_inverse_sqrt_fisher_info():
+    from scipy.special import expit
+    adj = _er(300, 0.08, seed=1)
+    sigma, _ll, offsets, labels = fit_sigma(adj, d=0)
+    p = expit(sigma + offsets)
+    A = np.sum(p * (1 - p))
+    _, se_n = dyadic_robust_sigma_se(offsets, labels, sigma, adj.shape[0])
+    assert math.isclose(se_n, 1.0 / math.sqrt(A), rel_tol=1e-9)
+
+
+# -------------------------------------------------------------------
+# d=0 robust SE matches the Monte-Carlo sampling SD of sigma_hat
+# -------------------------------------------------------------------
+
+def test_robust_se_matches_montecarlo_d0():
+    n, p, M = 300, 0.03, 150
+    rng = np.random.default_rng(7)
+    adj = _er(n, p, seed=3)
+    _, se_r, _ = fit_sigma_with_robust_se(adj, d=0)
+    mc = []
+    for _ in range(M):
+        g = _er(n, p, seed=int(rng.integers(1 << 30)))
+        s, _, _, _ = fit_sigma(g, d=0)
+        mc.append(s)
+    mc_sd = float(np.std(mc, ddof=1))
+    assert abs(se_r - mc_sd) / mc_sd < 0.3
+
+
+# -------------------------------------------------------------------
+# At d=1 (dependent dyads) the robust SE inflates beyond the naive SE
+# -------------------------------------------------------------------
+
+def test_robust_exceeds_naive_under_dependence_d1():
+    n, sigma = 120, -1.0
+    gm = GraphModel(n=n, d=1, sigma=sigma, er_p=0.2, layer2=True,
+                    feature_mode="incremental", seed=11)
+    for _ in range(25 * n):
+        gm.add_remove_edge()
+    _, se_r, se_n = fit_sigma_with_robust_se(gm.graph, d=1)
+    assert se_r > se_n
+
+
+# -------------------------------------------------------------------
+# select_d_aic
+# -------------------------------------------------------------------
+
+def test_select_d_aic_returns_candidate_and_aligned_outputs():
+    adj = _er(60, 0.2, seed=5)
+    d_hat, sigma_hat, offsets, labels, aic_by_d = select_d_aic(adj, [0, 1])
+    assert d_hat in (0, 1)
+    assert set(aic_by_d.keys()) == {0, 1}
+    assert all(np.isfinite(v) for v in aic_by_d.values())
+    n = adj.shape[0]
+    assert offsets.shape[0] == n * (n - 1) // 2
+    assert len(labels) == n * (n - 1) // 2
+    # The returned offsets correspond to d_hat: re-fitting gives the same sigma.
+    s2, _, _, _ = fit_sigma(adj, d_hat)
+    assert math.isclose(sigma_hat, s2, rel_tol=1e-9, abs_tol=1e-9)


### PR DESCRIPTION
## Why

For a **single observed graph** there is no genuine replication: σ̂ is one number, and its uncertainty cannot come from re-subsampling/bootstrapping that one graph (pseudo-replication — the variance and p-value become artifacts of the subsample design). Moreover the offset-logit pairs share nodes, so the model-based *independence* SE `1/√A` is wrong under dyadic dependence (d≥1).

This PR factors the **dyadic-cluster-robust (sandwich) SE** of Aronow–Samii–Assenova (2015) out of the inlined Twitch script (#54) into a reusable, tested library primitive. It is the foundation for the connectomes ANOVA (PR2) and the robust-Wald validation/ROC (PR3).

## What

`src/logit_graph/robust_se.py`:
- `dyadic_robust_sigma_se(offsets, labels, sigma_hat, n) -> (se_robust, se_naive)` — `A=Σ p(1−p)`, `T_m=Σ_{j≠m} s_mj` via O(n²)-time / O(n)-memory row-slicing, `B=Σ_m T_m² − Σ s²`, `Var=B/A²`. Reduces to `1/√A` at d=0.
- `fit_sigma` / `fit_sigma_with_robust_se(adj, d, feature_mode="incremental")` — offset-logit MLE σ̂ + robust SE (reuses `lg_features.build_pair_dataset` + `offset_logit.fit_offset_logit_fast`).
- `select_d_aic(adj, d_candidates, feature_mode)` — full-graph AIC d-selection returning d_hat-aligned `(d_hat, sigma_hat, offsets, labels, aic_by_d)`.

`tests/test_robust_se.py` (5 tests, fast):
1. d=0/ER `se_robust ≈ se_naive`
2. `se_naive == 1/√A` analytically
3. d=0/ER Monte-Carlo `se_robust ≈ MC sampling SD` (n=300, M=150)
4. d=1 LG `se_robust > se_naive` (dependence inflation)
5. `select_d_aic` returns a valid d with aligned outputs

## Verification
- `pytest tests/test_robust_se.py -q` → 5 passed
- Full suite → **325 passed, 2 xfailed**

No experiment or Makefile changes — those land in the follow-up PRs (connectomes, validation) which import this helper.