### PR TITLE
Add robust-Wald validation: Type-I calibration + power vs effect/n

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,13 @@ convergence-diagnostics-quick:  ## Quick smoke (n=200, 50k iter, ~1 min)
 	LG_CONV_QUICK=1 \
 		$(UV) run python scripts/diagnostics/run_convergence_diagnostics.py
 
+anova-validation-robust:  ## Validate single-graph dyadic-robust Wald: Type-I calibration + power vs effect/n
+	$(UV) run python scripts/experiments/run_anova_validation_robust.py
+
+anova-validation-robust-quick:  ## Smoke run of the robust-Wald validation (d=0, few reps, ~30s)
+	LG_AVR_QUICK=1 \
+		$(UV) run python scripts/experiments/run_anova_validation_robust.py
+
 gic-facebook-ego:  ## Rank LG vs ER/WS/BA on the 10 SNAP Facebook ego networks (~30-60s)
 	LG_FBEGO_USE_CACHE=1 \
 		$(UV) run python scripts/gic/run_facebook_ego_gic.py

--- a/scripts/experiments/run_anova_validation_robust.py
+++ b/scripts/experiments/run_anova_validation_robust.py
@@ -275,8 +275,8 @@ def main():
         out_dir / "roc_sample_robust.png",
         r"Robust-Wald ROC vs graph size at a fixed raw effect "
         r"(discrimination grows with $n$)",
-        {d: [(f"n={n} ($\\delta${chr(0x2248)}{_field(sample_rows, d, 'n', n, 'delta'):.1f}, "
-              f"AUC {_field(sample_rows, d, 'n', n, 'auc_emp'):.2f})", *sample_curves[(d, n)])
+        {d: [(f"n={n} (AUC {_field(sample_rows, d, 'n', n, 'auc_emp'):.2f})",
+              *sample_curves[(d, n)])
              for n in N_SAMPLE if (d, n) in sample_curves] for d in DS},
         title_suffix={d: rf"$\Delta\sigma$={sample_dsig[d]:.3f}" for d in DS},
     )

--- a/scripts/experiments/run_anova_validation_robust.py
+++ b/scripts/experiments/run_anova_validation_robust.py
@@ -1,24 +1,29 @@
 #!/usr/bin/env python3
-"""Validate the single-graph dyadic-robust Wald test by simulation.
+"""Validate the single-graph dyadic-robust Wald test by simulation (ROC curves).
 
 The real-data ANOVAs (Twitch, connectomes) compare sigma across groups with one
 graph per group, using the dyadic-cluster-robust SE + Wald test. This script
 validates *that same test* under the same one-graph-per-group design, replacing
 the older ROC machinery that (a) validated a different test (ANOVA over n_reps
-replicate graphs, which cannot be run on a single real graph) and (b) faked
-SE proportional to 1/n via a fractional pair-subsample knob (which ignores
-dyadic dependence and overstates power growth in n).
+replicate graphs, impossible on one real graph) and (b) faked SE proportional to
+1/n via a fractional pair-subsample knob (ROCSweepConfig.subsample_pairs), which
+ignores dyadic dependence and overstates power growth in n.
 
-Here, for each Monte-Carlo replicate we generate two *independent* graphs, fit
-offset-logit sigma-hat + dyadic-robust SE on each (logit_graph.robust_se), and
-form the two-sided Wald z = (s1 - s2) / sqrt(SE1^2 + SE2^2):
+It mirrors the original ROC experiment (notebooks/anova/12-0-anova-roc.ipynb and
+experiments.presets.ROCSweepConfig) in design and graph sizes:
 
-  * Type-I calibration: both graphs at the SAME sigma -> empirical reject rate
-    should be ~ alpha (tests whether the robust SE is calibrated on finite graphs).
-  * Power: graphs at DIFFERENT sigma -> reject rate = power. Swept over effect
-    size (sigma2 - sigma1, n fixed) and sample size (n, effect fixed), per
-    d in {0,1}. With the honest robust SE, power grows with n and effect size
-    WITHOUT any subsample knob.
+  * ROC curve = rejection rate vs p-value threshold (the empirical p-value CDF).
+    Scenario A (different sigma, H1) bows toward the top-left; Scenario B (equal
+    sigma, H0) tracks the diagonal y=x (calibration). Better discrimination =>
+    higher AUC.
+  * sample-size sweep: sigma1=-1.0 vs sigma2_fixed=-1.5 over n in
+    {10,100,500,1000,2000} (d=1 capped, Gibbs cost).
+  * effect-size sweep: sigma1=-1.0 vs sigma2 in {-1.0,-1.5,-2.0,-2.5} at
+    n_effect=500.
+
+Per replicate we generate two *independent* graphs, fit offset-logit sigma-hat +
+dyadic-robust SE on each (logit_graph.robust_se), and form the two-sided Wald
+z = (s1 - s2)/sqrt(SE1^2 + SE2^2). No subsample knob anywhere.
 
 Graph generation reuses experiments.sweeps.simulate_graph (d=0 direct ER at
 p=expit(sigma); d=1 Layer-2 Gibbs at beta=1, adaptive_stopping disabled).
@@ -26,14 +31,14 @@ Reproducible: fixed seed (LG_AVR_SEED), BLAS threads pinned to 1. Writes only
 under runs/anova_validation_robust/.
 
 Env knobs (all optional):
-  LG_AVR_SEED (12345)     LG_AVR_QUICK (0 -> full; 1 -> d=0 only, few reps)
+  LG_AVR_SEED (12345)     LG_AVR_QUICK (0 -> full; 1 -> d=0, small n, few reps)
   LG_AVR_ALPHA (0.05)     LG_AVR_DS ("0,1")
-  LG_AVR_N_EXP (300)      d=0 Monte-Carlo replicates per point
-  LG_AVR_D1_N_EXP (80)    d=1 replicates per point (Gibbs is slower)
-  LG_AVR_D1_MAX_N (500)   skip d=1 sample-sweep points above this n (logged)
+  LG_AVR_N_EXP (200)      d=0 experiments per scenario point
+  LG_AVR_D1_N_EXP (80)    d=1 experiments per scenario point (Gibbs is slower)
+  LG_AVR_D1_MAX_N (500)   skip d=1 points above this n (logged)
 
   make anova-validation-robust         full run
-  make anova-validation-robust-quick   smoke (d=0, few reps)
+  make anova-validation-robust-quick   smoke (d=0, small n, few reps)
 """
 from __future__ import annotations
 
@@ -54,6 +59,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from scipy.stats import norm
+from sklearn.metrics import roc_auc_score
 
 _here = Path(__file__).resolve().parent
 _repo_root = _here.parents[1]
@@ -82,7 +88,7 @@ QUICK = os.environ.get("LG_AVR_QUICK", "0") == "1"
 SEED = _int("LG_AVR_SEED", 12345)
 ALPHA = _float("LG_AVR_ALPHA", 0.05)
 DS = [0] if QUICK else [int(x) for x in os.environ.get("LG_AVR_DS", "0,1").split(",")]
-N_EXP = _int("LG_AVR_N_EXP", 40 if QUICK else 300)
+N_EXP = _int("LG_AVR_N_EXP", 30 if QUICK else 200)
 D1_N_EXP = _int("LG_AVR_D1_N_EXP", 20 if QUICK else 80)
 D1_MAX_N = _int("LG_AVR_D1_MAX_N", 500)
 FEATURE_MODE = "incremental"
@@ -91,18 +97,14 @@ FEATURE_MODE = "incremental"
 D1_BURN_MIN = _int("LG_AVR_D1_BURN_MIN", 8000)
 D1_BURN_PER_N = _int("LG_AVR_D1_BURN_PER_N", 40)
 
-# Sweep design (matches the real-data application: one graph per group).
-# With the honest robust SE (~1/sqrt(n)), power transitions sharply, so the
-# sweeps are centered in the informative regime: a small fixed n for the
-# effect sweep, and a small fixed effect over a fine n-grid for the sample
-# sweep (a sharp rise IS the honest finding -- the old fractional-subsample
-# knob faked a gradual SE~1/n curve).
-SIGMA_BASE = -1.0                       # reference sigma_1
-TYPEI_NS = [50, 200, 1000]              # check calibration across n (asymptotic Wald)
-EFFECT_SIGMAS = [-1.0, -1.25, -1.5, -1.75, -2.0]  # sigma_2 (first = null -> Type-I)
-EFFECT_N = 20                           # fixed (small) n for the effect-size sweep
-SAMPLE_NS = [10, 25, 50, 100, 250, 500, 1000, 2000]  # fine n-grid at fixed effect
-SAMPLE_SIGMA2 = -1.5                    # fixed sigma_2 (effect 0.5) for the n-sweep
+# Sweep design -- mirrors experiments.presets.ROCSweepConfig (original ROC fig).
+SIGMA1 = -1.0
+EFFECT_SIGMAS = [-1.0, -1.5, -2.0, -2.5]   # sigma2 (first = null -> H0 diagonal)
+N_EFFECT = 500                             # graph size for the effect-size sweep
+SIGMA2_FIXED = -1.5                        # fixed effect for the sample-size sweep
+N_VALUES = ([10, 100] if QUICK
+            else [10, 100, 500, 1000, 2000])  # sample-size sweep grid
+THRESHOLDS = np.linspace(0.0, 1.0, 101)
 
 
 def _n_exp(d):
@@ -127,18 +129,30 @@ def _wald_p(adj1, adj2, d):
     return 2.0 * norm.sf(abs((s1 - s2) / denom))
 
 
-def _reject_rate(n, d, sigma1, sigma2, n_exp, seed0):
-    """Fraction of MC replicates with two-sided Wald p < ALPHA (two indep. graphs)."""
-    rej, valid = 0, 0
+def _collect_pvalues(n, d, sigma1, sigma2, n_exp, seed0):
+    """Two-sided robust-Wald p over n_exp replicates of two independent graphs."""
+    ps = []
     for r in range(n_exp):
         a1 = _gen(n, d, sigma1, seed0 + 2 * r)
         a2 = _gen(n, d, sigma2, seed0 + 2 * r + 1)
         p = _wald_p(a1, a2, d)
-        if math.isnan(p):
-            continue
-        valid += 1
-        rej += int(p < ALPHA)
-    return (rej / valid if valid else float("nan")), valid
+        if not math.isnan(p):
+            ps.append(p)
+    return np.asarray(ps)
+
+
+def _roc_curve(pvals):
+    """Rejection rate vs p-value threshold (empirical CDF of p), original style."""
+    return np.array([float(np.mean(pvals <= t)) for t in THRESHOLDS])
+
+
+def _auc(h0_p, h1_p):
+    """AUC of the H0-vs-H1 classifier scored by 1-p (higher = more likely H1)."""
+    if len(h0_p) == 0 or len(h1_p) == 0:
+        return float("nan")
+    y = np.r_[np.zeros(len(h0_p)), np.ones(len(h1_p))]
+    s = np.r_[1.0 - h0_p, 1.0 - h1_p]
+    return float(roc_auc_score(y, s))
 
 
 # ---------------------------------------------------------------------------
@@ -148,104 +162,122 @@ def _reject_rate(n, d, sigma1, sigma2, n_exp, seed0):
 def main():
     out_dir = _here / "runs" / "anova_validation_robust"
     out_dir.mkdir(parents=True, exist_ok=True)
-    print(f"robust-Wald validation  seed={SEED}  quick={QUICK}  alpha={ALPHA}  "
+    print(f"robust-Wald validation (ROC)  seed={SEED}  quick={QUICK}  alpha={ALPHA}  "
           f"d={DS}  n_exp(d0)={N_EXP}  n_exp(d1)={D1_N_EXP}  d1_max_n={D1_MAX_N}")
+    print(f"  sample sweep: sigma1={SIGMA1} vs sigma2={SIGMA2_FIXED} over n={N_VALUES}")
+    print(f"  effect sweep: sigma1={SIGMA1} vs sigma2={EFFECT_SIGMAS} at n={N_EFFECT}")
 
-    # --- Type-I calibration: both graphs at the same sigma -------------------
-    typeI_rows = []
+    # H0 p-values per (d, n): reused for calibration, sample-AUC, and (at n=500)
+    # the effect-sweep null.
+    h0_by_dn = {}
+    sample_rows, sample_curves = [], {}
     for d in DS:
-        for k, n in enumerate(TYPEI_NS):
+        for k, n in enumerate(N_VALUES):
             if d >= 1 and n > D1_MAX_N:
-                print(f"  [Type-I] d={d} n={n}: SKIPPED (n > d1_max_n={D1_MAX_N})")
+                print(f"  [Sample] d={d} n={n}: SKIPPED (n>d1_max_n={D1_MAX_N})")
                 continue
             t0 = time.perf_counter()
-            rate, valid = _reject_rate(n, d, SIGMA_BASE, SIGMA_BASE, _n_exp(d),
-                                       SEED + 1000 * (d + 1) + 50 * k)
-            typeI_rows.append(dict(d=d, n=n, sigma=SIGMA_BASE, alpha=ALPHA,
-                                   reject_rate=rate, n_exp=valid))
-            print(f"  [Type-I] d={d} n={n} sigma={SIGMA_BASE}: reject={rate:.3f} "
-                  f"(target alpha={ALPHA}, n_exp={valid})  [{time.perf_counter()-t0:.0f}s]")
+            h0 = _collect_pvalues(n, d, SIGMA1, SIGMA1, _n_exp(d),
+                                  SEED + 1000 * (d + 1) + 50 * k)
+            h1 = _collect_pvalues(n, d, SIGMA1, SIGMA2_FIXED, _n_exp(d),
+                                  SEED + 7000 * (d + 1) + 50 * k)
+            h0_by_dn[(d, n)] = h0
+            sample_curves[(d, n)] = (_roc_curve(h0), _roc_curve(h1))
+            typeI = float(np.mean(h0 < ALPHA))
+            power = float(np.mean(h1 < ALPHA))
+            auc = _auc(h0, h1)
+            sample_rows.append(dict(d=d, n=n, sigma1=SIGMA1, sigma2=SIGMA2_FIXED,
+                                    effect=abs(SIGMA2_FIXED - SIGMA1), typeI=typeI,
+                                    power=power, auc=auc, n_exp=len(h1)))
+            print(f"  [Sample] d={d} n={n}: typeI={typeI:.3f} power={power:.3f} "
+                  f"AUC={auc:.3f}  [{time.perf_counter()-t0:.0f}s]")
 
-    # --- Power vs effect size (n fixed) -------------------------------------
-    effect_rows = []
+    effect_rows, effect_curves = [], {}
     for d in DS:
-        n = EFFECT_N if d == 0 else min(EFFECT_N, D1_MAX_N)
+        n = N_EFFECT if not (d >= 1 and N_EFFECT > D1_MAX_N) else D1_MAX_N
+        h0 = h0_by_dn.get((d, n))
+        if h0 is None:
+            h0 = _collect_pvalues(n, d, SIGMA1, SIGMA1, _n_exp(d),
+                                  SEED + 1000 * (d + 1) + 9999)
+            h0_by_dn[(d, n)] = h0
         for k, s2 in enumerate(EFFECT_SIGMAS):
             t0 = time.perf_counter()
-            rate, valid = _reject_rate(n, d, SIGMA_BASE, s2, _n_exp(d),
-                                       SEED + 2000 * (d + 1) + 50 * k)
-            effect_rows.append(dict(d=d, n=n, sigma1=SIGMA_BASE, sigma2=s2,
-                                    effect=abs(s2 - SIGMA_BASE), power=rate, n_exp=valid))
-            print(f"  [Effect] d={d} n={n} sigma2={s2:+.1f} (effect={abs(s2-SIGMA_BASE):.1f}): "
-                  f"power={rate:.3f}  [{time.perf_counter()-t0:.0f}s]")
+            if s2 == SIGMA1:
+                h1 = h0
+            else:
+                h1 = _collect_pvalues(n, d, SIGMA1, s2, _n_exp(d),
+                                      SEED + 2000 * (d + 1) + 50 * k)
+            effect_curves[(d, s2)] = _roc_curve(h1)
+            power = float(np.mean(h1 < ALPHA))
+            auc = _auc(h0, h1)
+            effect_rows.append(dict(d=d, n=n, sigma1=SIGMA1, sigma2=s2,
+                                    effect=abs(s2 - SIGMA1), power=power,
+                                    auc=auc, n_exp=len(h1)))
+            print(f"  [Effect] d={d} n={n} sigma2={s2:+.1f} (effect={abs(s2-SIGMA1):.1f}): "
+                  f"power={power:.3f} AUC={auc:.3f}  [{time.perf_counter()-t0:.0f}s]")
 
-    # --- Power vs sample size (effect fixed) --------------------------------
-    sample_rows = []
-    for d in DS:
-        for k, n in enumerate(SAMPLE_NS):
-            if d >= 1 and n > D1_MAX_N:
-                print(f"  [Sample] d={d} n={n}: SKIPPED (n > d1_max_n={D1_MAX_N}, "
-                      f"Gibbs too slow)")
-                continue
-            t0 = time.perf_counter()
-            rate, valid = _reject_rate(n, d, SIGMA_BASE, SAMPLE_SIGMA2, _n_exp(d),
-                                       SEED + 3000 * (d + 1) + 50 * k)
-            sample_rows.append(dict(d=d, n=n, sigma1=SIGMA_BASE, sigma2=SAMPLE_SIGMA2,
-                                    effect=abs(SAMPLE_SIGMA2 - SIGMA_BASE),
-                                    power=rate, n_exp=valid))
-            print(f"  [Sample] d={d} n={n} effect={abs(SAMPLE_SIGMA2-SIGMA_BASE):.1f}: "
-                  f"power={rate:.3f}  [{time.perf_counter()-t0:.0f}s]")
-
-    typeI_df = pd.DataFrame(typeI_rows)
-    effect_df = pd.DataFrame(effect_rows)
     sample_df = pd.DataFrame(sample_rows)
-    typeI_df.to_csv(out_dir / "typeI.csv", index=False)
-    effect_df.to_csv(out_dir / "roc_effect_robust.csv", index=False)
+    effect_df = pd.DataFrame(effect_rows)
     sample_df.to_csv(out_dir / "roc_sample_robust.csv", index=False)
+    effect_df.to_csv(out_dir / "roc_effect_robust.csv", index=False)
+    sample_df[["d", "n", "typeI", "n_exp"]].to_csv(out_dir / "typeI.csv", index=False)
 
-    # --- Plots --------------------------------------------------------------
-    plt.figure(figsize=(6, 4))
-    for d in DS:
-        sub = effect_df[effect_df["d"] == d].sort_values("effect")
-        plt.plot(sub["effect"], sub["power"], marker="o", label=f"d={d}")
-    plt.axhline(ALPHA, color="gray", ls="--", lw=1, label=f"alpha={ALPHA}")
-    plt.xlabel(r"effect size $|\sigma_2-\sigma_1|$")
-    plt.ylabel("power (reject rate)")
-    plt.title(f"Robust-Wald power vs effect size (n={EFFECT_N})")
-    plt.ylim(-0.02, 1.02)
-    plt.legend()
-    plt.tight_layout()
-    plt.savefig(out_dir / "roc_effect_robust.png", dpi=150)
-    plt.close()
-
-    plt.figure(figsize=(6, 4))
-    for d in DS:
-        sub = sample_df[sample_df["d"] == d].sort_values("n")
-        if not sub.empty:
-            plt.plot(sub["n"], sub["power"], marker="o", label=f"d={d}")
-    plt.xlabel("n (nodes per graph)")
-    plt.ylabel("power (reject rate)")
-    plt.title(f"Robust-Wald power vs n (effect={abs(SAMPLE_SIGMA2-SIGMA_BASE):.1f})")
-    plt.xscale("log")
-    plt.ylim(-0.02, 1.02)
-    plt.legend()
-    plt.tight_layout()
-    plt.savefig(out_dir / "roc_sample_robust.png", dpi=150)
-    plt.close()
+    # --- Plots: rejection rate vs p-value threshold (original ROC style) -----
+    _plot_threshold_roc(
+        out_dir / "roc_sample_robust.png",
+        f"Robust-Wald ROC vs graph size (effect {abs(SIGMA2_FIXED-SIGMA1):.1f})",
+        {d: [(f"n={n}", sample_curves[(d, n)][1])
+             for n in N_VALUES if (d, n) in sample_curves] for d in DS},
+        {d: [(f"H0 n={n}", sample_curves[(d, n)][0])
+             for n in N_VALUES if (d, n) in sample_curves] for d in DS},
+    )
+    _plot_threshold_roc(
+        out_dir / "roc_effect_robust.png",
+        f"Robust-Wald ROC vs effect size (n={N_EFFECT})",
+        {d: [(f"eff={abs(s2-SIGMA1):.1f}", effect_curves[(d, s2)])
+             for s2 in EFFECT_SIGMAS if s2 != SIGMA1 and (d, s2) in effect_curves]
+            for d in DS},
+        {d: [("H0 (eff=0)", effect_curves[(d, SIGMA1)])]
+            for d in DS if (d, SIGMA1) in effect_curves},
+    )
 
     (out_dir / "results.json").write_text(json.dumps({
         "alpha": ALPHA, "seed": SEED, "ds": DS,
-        "typeI": typeI_rows, "effect": effect_rows, "sample": sample_rows,
+        "sample": sample_rows, "effect": effect_rows,
     }, indent=2, default=float))
 
     print("\n" + "=" * 70)
-    print("Type-I (should be ~ alpha):")
-    for r in typeI_rows:
-        flag = "" if abs(r["reject_rate"] - ALPHA) < 3 * math.sqrt(
-            ALPHA * (1 - ALPHA) / max(r["n_exp"], 1)) else "  <-- off"
-        print(f"  d={r['d']} n={r['n']}: reject={r['reject_rate']:.3f}{flag}")
-    print(f"\nWrote {out_dir}/ (typeI.csv, roc_effect_robust.{{png,csv}}, "
-          f"roc_sample_robust.{{png,csv}}, results.json)")
+    print("AUC (1=perfect discrimination, 0.5=chance) and Type-I (~alpha):")
+    for r in sample_rows:
+        print(f"  [sample] d={r['d']} n={r['n']:4d}: AUC={r['auc']:.3f}  "
+              f"typeI={r['typeI']:.3f}  power={r['power']:.3f}")
+    for r in effect_rows:
+        print(f"  [effect] d={r['d']} n={r['n']} effect={r['effect']:.1f}: "
+              f"AUC={r['auc']:.3f}  power={r['power']:.3f}")
+    print(f"\nWrote {out_dir}/ (roc_sample_robust.{{png,csv}}, "
+          f"roc_effect_robust.{{png,csv}}, typeI.csv, results.json)")
+
+
+def _plot_threshold_roc(path, suptitle, h1_curves_by_d, h0_curves_by_d):
+    ds = sorted(h1_curves_by_d.keys())
+    fig, axes = plt.subplots(1, len(ds), figsize=(5.2 * len(ds), 4.2), squeeze=False)
+    for ax, d in zip(axes[0], ds):
+        for label, curve in h1_curves_by_d[d]:
+            ax.plot(THRESHOLDS, curve, marker="", lw=1.8, label=label)
+        for label, curve in h0_curves_by_d.get(d, []):
+            ax.plot(THRESHOLDS, curve, color="0.6", lw=0.9, ls=":")
+        ax.plot([0, 1], [0, 1], color="k", lw=0.8, ls="--", label="y=x (H0 ideal)")
+        ax.axvline(ALPHA, color="r", lw=0.7, ls=":")
+        ax.set_xlabel("p-value threshold")
+        ax.set_ylabel("rejection rate")
+        ax.set_title(f"d={d}")
+        ax.set_xlim(0, 1)
+        ax.set_ylim(-0.02, 1.02)
+        ax.legend(fontsize=8, loc="lower right")
+    fig.suptitle(suptitle)
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
 
 
 if __name__ == "__main__":

--- a/scripts/experiments/run_anova_validation_robust.py
+++ b/scripts/experiments/run_anova_validation_robust.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Validate the single-graph dyadic-robust Wald test by simulation.
+
+The real-data ANOVAs (Twitch, connectomes) compare sigma across groups with one
+graph per group, using the dyadic-cluster-robust SE + Wald test. This script
+validates *that same test* under the same one-graph-per-group design, replacing
+the older ROC machinery that (a) validated a different test (ANOVA over n_reps
+replicate graphs, which cannot be run on a single real graph) and (b) faked
+SE proportional to 1/n via a fractional pair-subsample knob (which ignores
+dyadic dependence and overstates power growth in n).
+
+Here, for each Monte-Carlo replicate we generate two *independent* graphs, fit
+offset-logit sigma-hat + dyadic-robust SE on each (logit_graph.robust_se), and
+form the two-sided Wald z = (s1 - s2) / sqrt(SE1^2 + SE2^2):
+
+  * Type-I calibration: both graphs at the SAME sigma -> empirical reject rate
+    should be ~ alpha (tests whether the robust SE is calibrated on finite graphs).
+  * Power: graphs at DIFFERENT sigma -> reject rate = power. Swept over effect
+    size (sigma2 - sigma1, n fixed) and sample size (n, effect fixed), per
+    d in {0,1}. With the honest robust SE, power grows with n and effect size
+    WITHOUT any subsample knob.
+
+Graph generation reuses experiments.sweeps.simulate_graph (d=0 direct ER at
+p=expit(sigma); d=1 Layer-2 Gibbs at beta=1, adaptive_stopping disabled).
+Reproducible: fixed seed (LG_AVR_SEED), BLAS threads pinned to 1. Writes only
+under runs/anova_validation_robust/.
+
+Env knobs (all optional):
+  LG_AVR_SEED (12345)     LG_AVR_QUICK (0 -> full; 1 -> d=0 only, few reps)
+  LG_AVR_ALPHA (0.05)     LG_AVR_DS ("0,1")
+  LG_AVR_N_EXP (300)      d=0 Monte-Carlo replicates per point
+  LG_AVR_D1_N_EXP (80)    d=1 replicates per point (Gibbs is slower)
+  LG_AVR_D1_MAX_N (500)   skip d=1 sample-sweep points above this n (logged)
+
+  make anova-validation-robust         full run
+  make anova-validation-robust-quick   smoke (d=0, few reps)
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+import sys
+import time
+import warnings
+from pathlib import Path
+
+for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ.setdefault(_v, "1")
+
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from scipy.stats import norm
+
+_here = Path(__file__).resolve().parent
+_repo_root = _here.parents[1]
+_src = _repo_root / "src"
+for p in (_src, _here):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+warnings.filterwarnings("ignore")
+
+from logit_graph.robust_se import fit_sigma_with_robust_se  # noqa: E402
+from logit_graph.experiments.sweeps import simulate_graph  # noqa: E402
+
+
+def _int(env, default):
+    raw = os.environ.get(env)
+    return int(raw) if raw is not None else default
+
+
+def _float(env, default):
+    raw = os.environ.get(env)
+    return float(raw) if raw is not None else default
+
+
+QUICK = os.environ.get("LG_AVR_QUICK", "0") == "1"
+SEED = _int("LG_AVR_SEED", 12345)
+ALPHA = _float("LG_AVR_ALPHA", 0.05)
+DS = [0] if QUICK else [int(x) for x in os.environ.get("LG_AVR_DS", "0,1").split(",")]
+N_EXP = _int("LG_AVR_N_EXP", 40 if QUICK else 300)
+D1_N_EXP = _int("LG_AVR_D1_N_EXP", 20 if QUICK else 80)
+D1_MAX_N = _int("LG_AVR_D1_MAX_N", 500)
+FEATURE_MODE = "incremental"
+
+# d=1 Gibbs burn-in per independent sample.
+D1_BURN_MIN = _int("LG_AVR_D1_BURN_MIN", 8000)
+D1_BURN_PER_N = _int("LG_AVR_D1_BURN_PER_N", 40)
+
+# Sweep design (matches the real-data application: one graph per group).
+# With the honest robust SE (~1/sqrt(n)), power transitions sharply, so the
+# sweeps are centered in the informative regime: a small fixed n for the
+# effect sweep, and a small fixed effect over a fine n-grid for the sample
+# sweep (a sharp rise IS the honest finding -- the old fractional-subsample
+# knob faked a gradual SE~1/n curve).
+SIGMA_BASE = -1.0                       # reference sigma_1
+TYPEI_NS = [50, 200, 1000]              # check calibration across n (asymptotic Wald)
+EFFECT_SIGMAS = [-1.0, -1.25, -1.5, -1.75, -2.0]  # sigma_2 (first = null -> Type-I)
+EFFECT_N = 20                           # fixed (small) n for the effect-size sweep
+SAMPLE_NS = [10, 25, 50, 100, 250, 500, 1000, 2000]  # fine n-grid at fixed effect
+SAMPLE_SIGMA2 = -1.5                    # fixed sigma_2 (effect 0.5) for the n-sweep
+
+
+def _n_exp(d):
+    return D1_N_EXP if d >= 1 else N_EXP
+
+
+def _gen(n, d, sigma, seed):
+    if d == 0:
+        return simulate_graph(n, 0, sigma=sigma, n_iter=0, seed=seed)
+    n_iter = max(D1_BURN_MIN, D1_BURN_PER_N * n)
+    return simulate_graph(n, d, sigma=sigma, beta=1.0, n_iter=n_iter,
+                          feature_mode=FEATURE_MODE, seed=seed,
+                          adaptive_stopping=False)
+
+
+def _wald_p(adj1, adj2, d):
+    s1, se1, _ = fit_sigma_with_robust_se(adj1, d, feature_mode=FEATURE_MODE)
+    s2, se2, _ = fit_sigma_with_robust_se(adj2, d, feature_mode=FEATURE_MODE)
+    denom = math.sqrt(se1 ** 2 + se2 ** 2)
+    if not (denom > 0):
+        return float("nan")
+    return 2.0 * norm.sf(abs((s1 - s2) / denom))
+
+
+def _reject_rate(n, d, sigma1, sigma2, n_exp, seed0):
+    """Fraction of MC replicates with two-sided Wald p < ALPHA (two indep. graphs)."""
+    rej, valid = 0, 0
+    for r in range(n_exp):
+        a1 = _gen(n, d, sigma1, seed0 + 2 * r)
+        a2 = _gen(n, d, sigma2, seed0 + 2 * r + 1)
+        p = _wald_p(a1, a2, d)
+        if math.isnan(p):
+            continue
+        valid += 1
+        rej += int(p < ALPHA)
+    return (rej / valid if valid else float("nan")), valid
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    out_dir = _here / "runs" / "anova_validation_robust"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"robust-Wald validation  seed={SEED}  quick={QUICK}  alpha={ALPHA}  "
+          f"d={DS}  n_exp(d0)={N_EXP}  n_exp(d1)={D1_N_EXP}  d1_max_n={D1_MAX_N}")
+
+    # --- Type-I calibration: both graphs at the same sigma -------------------
+    typeI_rows = []
+    for d in DS:
+        for k, n in enumerate(TYPEI_NS):
+            if d >= 1 and n > D1_MAX_N:
+                print(f"  [Type-I] d={d} n={n}: SKIPPED (n > d1_max_n={D1_MAX_N})")
+                continue
+            t0 = time.perf_counter()
+            rate, valid = _reject_rate(n, d, SIGMA_BASE, SIGMA_BASE, _n_exp(d),
+                                       SEED + 1000 * (d + 1) + 50 * k)
+            typeI_rows.append(dict(d=d, n=n, sigma=SIGMA_BASE, alpha=ALPHA,
+                                   reject_rate=rate, n_exp=valid))
+            print(f"  [Type-I] d={d} n={n} sigma={SIGMA_BASE}: reject={rate:.3f} "
+                  f"(target alpha={ALPHA}, n_exp={valid})  [{time.perf_counter()-t0:.0f}s]")
+
+    # --- Power vs effect size (n fixed) -------------------------------------
+    effect_rows = []
+    for d in DS:
+        n = EFFECT_N if d == 0 else min(EFFECT_N, D1_MAX_N)
+        for k, s2 in enumerate(EFFECT_SIGMAS):
+            t0 = time.perf_counter()
+            rate, valid = _reject_rate(n, d, SIGMA_BASE, s2, _n_exp(d),
+                                       SEED + 2000 * (d + 1) + 50 * k)
+            effect_rows.append(dict(d=d, n=n, sigma1=SIGMA_BASE, sigma2=s2,
+                                    effect=abs(s2 - SIGMA_BASE), power=rate, n_exp=valid))
+            print(f"  [Effect] d={d} n={n} sigma2={s2:+.1f} (effect={abs(s2-SIGMA_BASE):.1f}): "
+                  f"power={rate:.3f}  [{time.perf_counter()-t0:.0f}s]")
+
+    # --- Power vs sample size (effect fixed) --------------------------------
+    sample_rows = []
+    for d in DS:
+        for k, n in enumerate(SAMPLE_NS):
+            if d >= 1 and n > D1_MAX_N:
+                print(f"  [Sample] d={d} n={n}: SKIPPED (n > d1_max_n={D1_MAX_N}, "
+                      f"Gibbs too slow)")
+                continue
+            t0 = time.perf_counter()
+            rate, valid = _reject_rate(n, d, SIGMA_BASE, SAMPLE_SIGMA2, _n_exp(d),
+                                       SEED + 3000 * (d + 1) + 50 * k)
+            sample_rows.append(dict(d=d, n=n, sigma1=SIGMA_BASE, sigma2=SAMPLE_SIGMA2,
+                                    effect=abs(SAMPLE_SIGMA2 - SIGMA_BASE),
+                                    power=rate, n_exp=valid))
+            print(f"  [Sample] d={d} n={n} effect={abs(SAMPLE_SIGMA2-SIGMA_BASE):.1f}: "
+                  f"power={rate:.3f}  [{time.perf_counter()-t0:.0f}s]")
+
+    typeI_df = pd.DataFrame(typeI_rows)
+    effect_df = pd.DataFrame(effect_rows)
+    sample_df = pd.DataFrame(sample_rows)
+    typeI_df.to_csv(out_dir / "typeI.csv", index=False)
+    effect_df.to_csv(out_dir / "roc_effect_robust.csv", index=False)
+    sample_df.to_csv(out_dir / "roc_sample_robust.csv", index=False)
+
+    # --- Plots --------------------------------------------------------------
+    plt.figure(figsize=(6, 4))
+    for d in DS:
+        sub = effect_df[effect_df["d"] == d].sort_values("effect")
+        plt.plot(sub["effect"], sub["power"], marker="o", label=f"d={d}")
+    plt.axhline(ALPHA, color="gray", ls="--", lw=1, label=f"alpha={ALPHA}")
+    plt.xlabel(r"effect size $|\sigma_2-\sigma_1|$")
+    plt.ylabel("power (reject rate)")
+    plt.title(f"Robust-Wald power vs effect size (n={EFFECT_N})")
+    plt.ylim(-0.02, 1.02)
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(out_dir / "roc_effect_robust.png", dpi=150)
+    plt.close()
+
+    plt.figure(figsize=(6, 4))
+    for d in DS:
+        sub = sample_df[sample_df["d"] == d].sort_values("n")
+        if not sub.empty:
+            plt.plot(sub["n"], sub["power"], marker="o", label=f"d={d}")
+    plt.xlabel("n (nodes per graph)")
+    plt.ylabel("power (reject rate)")
+    plt.title(f"Robust-Wald power vs n (effect={abs(SAMPLE_SIGMA2-SIGMA_BASE):.1f})")
+    plt.xscale("log")
+    plt.ylim(-0.02, 1.02)
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(out_dir / "roc_sample_robust.png", dpi=150)
+    plt.close()
+
+    (out_dir / "results.json").write_text(json.dumps({
+        "alpha": ALPHA, "seed": SEED, "ds": DS,
+        "typeI": typeI_rows, "effect": effect_rows, "sample": sample_rows,
+    }, indent=2, default=float))
+
+    print("\n" + "=" * 70)
+    print("Type-I (should be ~ alpha):")
+    for r in typeI_rows:
+        flag = "" if abs(r["reject_rate"] - ALPHA) < 3 * math.sqrt(
+            ALPHA * (1 - ALPHA) / max(r["n_exp"], 1)) else "  <-- off"
+        print(f"  d={r['d']} n={r['n']}: reject={r['reject_rate']:.3f}{flag}")
+    print(f"\nWrote {out_dir}/ (typeI.csv, roc_effect_robust.{{png,csv}}, "
+          f"roc_sample_robust.{{png,csv}}, results.json)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/experiments/run_anova_validation_robust.py
+++ b/scripts/experiments/run_anova_validation_robust.py
@@ -22,9 +22,10 @@ against the theoretical Phi(delta/sqrt(2)).
 Two figures:
   * roc_effect_robust  -- ROC (TPR vs FPR) for delta in {0.5,1,1.5,2,3} at
     n_effect=500. Curves span diagonal -> top-left; empirical AUC ~= theory.
-  * roc_sample_robust  -- n-invariance: the SAME standardized delta across
-    n in {100,500,2000} (d=1 capped). Curves coincide (raw gap shrinks ~1/sqrt(n)),
-    direct evidence the robust SE is calibrated.
+  * roc_sample_robust  -- vary n at ONE fixed raw effect (sigma gap), pinned so
+    the mid-grid n lands at DELTA_REF. Larger n -> larger non-centrality ->
+    better AUC, so the ROC curves separate (discrimination grows with graph
+    size) without saturating -- the honest version of the old Fig 4.
 
 Per replicate we generate two *independent* graphs (experiments.sweeps.simulate_graph:
 d=0 direct ER at p=expit(sigma); d=1 Layer-2 Gibbs at beta=1, adaptive_stopping
@@ -104,8 +105,12 @@ D1_BURN_PER_N = _int("LG_AVR_D1_BURN_PER_N", 40)
 SIGMA1 = -1.0
 DELTAS = [0.5, 1.0] if QUICK else [0.5, 1.0, 1.5, 2.0, 3.0]  # standardized effects
 N_EFFECT = 500                                # graph size for the effect ROC
-DELTA_FIXED = 1.5                             # standardized effect for n-invariance
-N_VALUES = ([50, 100] if QUICK else [100, 500, 2000])
+# Sample ROC: fix ONE raw effect (sigma gap) and vary n -> discrimination
+# improves with graph size (the honest version of the old Fig 4). The raw gap is
+# pinned so the mid-grid n lands at standardized DELTA_REF; smaller/larger n then
+# spread below/above it, giving visibly separated (non-overlapping) ROC curves.
+DELTA_REF = 1.5
+N_SAMPLE = [50, 100] if QUICK else [50, 100, 200, 350, 500]
 PILOT_K = _int("LG_AVR_PILOT_K", 6 if QUICK else 16)  # graphs to estimate typical SE
 
 
@@ -194,7 +199,8 @@ def main():
     print(f"robust-Wald validation (standardized-effect ROC)  seed={SEED}  "
           f"quick={QUICK}  alpha={ALPHA}  d={DS}  n_exp(d0)={N_EXP}  n_exp(d1)={D1_N_EXP}")
     print(f"  effect ROC: delta={DELTAS} at n={N_EFFECT}")
-    print(f"  n-invariance: delta={DELTA_FIXED} over n={N_VALUES} (d1 cap {D1_MAX_N})")
+    print(f"  sample ROC: fixed raw effect (delta_ref={DELTA_REF}) over n={N_SAMPLE} "
+          f"(d1 cap {D1_MAX_N})")
 
     # --- Effect ROC: sweep standardized delta at n_effect --------------------
     effect_rows, effect_curves = [], {}
@@ -221,30 +227,34 @@ def main():
                   f"AUC_emp={auc:.3f} AUC_theory={_theory_auc(delta):.3f} "
                   f"power={float(np.mean(h1 < ALPHA)):.3f}  [{time.perf_counter()-t0:.0f}s]")
 
-    # --- n-invariance: same standardized delta across n ----------------------
-    sample_rows, sample_curves = [], {}
+    # --- Sample ROC: ONE fixed raw effect, vary n (discrimination grows with n) -
+    sample_rows, sample_curves, sample_dsig = [], {}, {}
     for d in DS:
-        for k, n in enumerate(N_VALUES):
-            if d >= 1 and n > D1_MAX_N:
-                print(f"  [Sample] d={d} n={n}: SKIPPED (n>d1_max_n={D1_MAX_N})")
-                continue
+        grid = [n for n in N_SAMPLE if not (d >= 1 and n > D1_MAX_N)]
+        n_ref = grid[len(grid) // 2]
+        se_ref = _typical_se(n_ref, d, SIGMA1, _pilot_k(d), SEED + 600 * (d + 1))
+        raw_ds = DELTA_REF * math.sqrt(2.0) * se_ref   # pinned across all n
+        sigma2 = SIGMA1 - raw_ds
+        sample_dsig[d] = raw_ds
+        print(f"  [Sample] d={d}  raw dsigma={raw_ds:.4f} "
+              f"(pinned at n_ref={n_ref}, delta_ref={DELTA_REF})  sigma2={sigma2:.4f}")
+        for k, n in enumerate(grid):
             t0 = time.perf_counter()
-            se_typ = _typical_se(n, d, SIGMA1, _pilot_k(d), SEED + 300 * (d + 1) + 7 * k)
-            dsig = DELTA_FIXED * math.sqrt(2.0) * se_typ
-            sigma2 = SIGMA1 - dsig
+            se_n = _typical_se(n, d, SIGMA1, _pilot_k(d), SEED + 650 * (d + 1) + 7 * k)
+            delta_n = raw_ds / (math.sqrt(2.0) * se_n) if se_n > 0 else float("nan")
             h0 = _collect_pvalues(n, d, SIGMA1, SIGMA1, _n_exp(d),
                                   SEED + 4000 * (d + 1) + 50 * k)
             h1 = _collect_pvalues(n, d, SIGMA1, sigma2, _n_exp(d),
                                   SEED + 5000 * (d + 1) + 50 * k)
             fpr, tpr, auc = _roc(h0, h1)
             sample_curves[(d, n)] = (fpr, tpr)
-            sample_rows.append(dict(d=d, n=n, delta=DELTA_FIXED, raw_dsigma=dsig,
-                                    sigma2=sigma2, se_typ=se_typ,
+            sample_rows.append(dict(d=d, n=n, raw_dsigma=raw_ds, sigma2=sigma2,
+                                    se_typ=se_n, delta=delta_n,
                                     typeI=float(np.mean(h0 < ALPHA)),
                                     power=float(np.mean(h1 < ALPHA)), auc_emp=auc,
-                                    auc_theory=_theory_auc(DELTA_FIXED), n_exp=len(h1)))
-            print(f"  [Sample] d={d} n={n}: SE_typ={se_typ:.4f} raw dsigma={dsig:.4f} "
-                  f"AUC_emp={auc:.3f} (theory {_theory_auc(DELTA_FIXED):.3f}) "
+                                    auc_theory=_theory_auc(delta_n), n_exp=len(h1)))
+            print(f"    n={n:4d}: delta~={delta_n:.2f}  AUC_emp={auc:.3f} "
+                  f"(theory {_theory_auc(delta_n):.3f})  "
                   f"typeI={float(np.mean(h0 < ALPHA)):.3f}  [{time.perf_counter()-t0:.0f}s]")
 
     effect_df = pd.DataFrame(effect_rows)
@@ -257,16 +267,18 @@ def main():
     _plot_roc(
         out_dir / "roc_effect_robust.png",
         rf"Robust-Wald ROC vs standardized effect $\delta=\Delta\sigma/SE$ (n={N_EFFECT})",
-        {d: [(rf"$\delta$={delta:.1f} (AUC {_lookup(effect_rows, d, 'delta', delta):.2f})",
+        {d: [(rf"$\delta$={delta:.1f} (AUC {_field(effect_rows, d, 'delta', delta, 'auc_emp'):.2f})",
               *effect_curves[(d, delta)])
              for delta in DELTAS if (d, delta) in effect_curves] for d in DS},
     )
     _plot_roc(
         out_dir / "roc_sample_robust.png",
-        rf"Robust-Wald ROC at fixed $\delta$={DELTA_FIXED} across graph size "
-        rf"(theory AUC={_theory_auc(DELTA_FIXED):.2f})",
-        {d: [(f"n={n} (AUC {_lookup(sample_rows, d, 'n', n):.2f})", *sample_curves[(d, n)])
-             for n in N_VALUES if (d, n) in sample_curves] for d in DS},
+        r"Robust-Wald ROC vs graph size at a fixed raw effect "
+        r"(discrimination grows with $n$)",
+        {d: [(f"n={n} ($\\delta${chr(0x2248)}{_field(sample_rows, d, 'n', n, 'delta'):.1f}, "
+              f"AUC {_field(sample_rows, d, 'n', n, 'auc_emp'):.2f})", *sample_curves[(d, n)])
+             for n in N_SAMPLE if (d, n) in sample_curves] for d in DS},
+        title_suffix={d: rf"$\Delta\sigma$={sample_dsig[d]:.3f}" for d in DS},
     )
 
     (out_dir / "results.json").write_text(json.dumps({
@@ -280,22 +292,23 @@ def main():
         print(f"  [effect] d={r['d']} n={r['n']} delta={r['delta']:.1f}: "
               f"AUC_emp={r['auc_emp']:.3f}  theory={r['auc_theory']:.3f}  "
               f"(raw dsigma={r['raw_dsigma']:.4f})")
+    print("Sample ROC (fixed raw dsigma per d; discrimination grows with n):")
     for r in sample_rows:
-        print(f"  [sample] d={r['d']} n={r['n']:4d} delta={r['delta']:.1f}: "
+        print(f"  [sample] d={r['d']} n={r['n']:4d} (delta~={r['delta']:.2f}): "
               f"AUC_emp={r['auc_emp']:.3f}  theory={r['auc_theory']:.3f}  "
               f"(raw dsigma={r['raw_dsigma']:.4f}, typeI={r['typeI']:.3f})")
     print(f"\nWrote {out_dir}/ (roc_effect_robust.{{png,csv}}, "
           f"roc_sample_robust.{{png,csv}}, typeI.csv, results.json)")
 
 
-def _lookup(rows, d, key, val):
+def _field(rows, d, key, val, field):
     for r in rows:
         if r["d"] == d and r[key] == val:
-            return r["auc_emp"]
+            return r[field]
     return float("nan")
 
 
-def _plot_roc(path, suptitle, curves_by_d):
+def _plot_roc(path, suptitle, curves_by_d, title_suffix=None):
     ds = sorted(curves_by_d.keys())
     fig, axes = plt.subplots(1, len(ds), figsize=(5.2 * len(ds), 4.6), squeeze=False)
     for ax, d in zip(axes[0], ds):
@@ -304,7 +317,8 @@ def _plot_roc(path, suptitle, curves_by_d):
         ax.plot([0, 1], [0, 1], color="k", lw=0.8, ls="--", label="chance")
         ax.set_xlabel("false positive rate")
         ax.set_ylabel("true positive rate")
-        ax.set_title(f"d={d}")
+        suffix = f"  ({title_suffix[d]})" if title_suffix and d in title_suffix else ""
+        ax.set_title(f"d={d}{suffix}")
         ax.set_xlim(-0.02, 1.02)
         ax.set_ylim(-0.02, 1.02)
         ax.legend(fontsize=8, loc="lower right")

--- a/scripts/experiments/run_anova_validation_robust.py
+++ b/scripts/experiments/run_anova_validation_robust.py
@@ -6,35 +6,38 @@ graph per group, using the dyadic-cluster-robust SE + Wald test. This script
 validates *that same test* under the same one-graph-per-group design, replacing
 the older ROC machinery that (a) validated a different test (ANOVA over n_reps
 replicate graphs, impossible on one real graph) and (b) faked SE proportional to
-1/n via a fractional pair-subsample knob (ROCSweepConfig.subsample_pairs), which
-ignores dyadic dependence and overstates power growth in n.
+1/n via a fractional pair-subsample knob (ROCSweepConfig.subsample_pairs).
 
-It mirrors the original ROC experiment (notebooks/anova/12-0-anova-roc.ipynb and
-experiments.presets.ROCSweepConfig) in design and graph sizes:
+Why a *standardized* effect. A Wald/z-test's discrimination is governed entirely
+by the non-centrality delta = (sigma1 - sigma2) / sqrt(SE1^2 + SE2^2): the ROC
+AUC is exactly Phi(delta / sqrt(2)). With honest SEs (SE ~ 1/sqrt(n)), a fixed
+*raw* effect like 0.5 gives a huge delta at n>=100, so the ROC saturates (AUC=1)
+-- which is correct but uninformative. We therefore sweep the standardized effect
+delta directly: at each (n, d) we estimate the typical SE from a pilot and set
+the raw gap sigma1 - sigma2 = delta * sqrt(2) * SE so the realized non-centrality
+is ~delta. This traces the test's intrinsic ROC (no saturation, no subsample
+knob), keeps the original graph sizes, and lets us check the empirical AUC
+against the theoretical Phi(delta/sqrt(2)).
 
-  * ROC curve = rejection rate vs p-value threshold (the empirical p-value CDF).
-    Scenario A (different sigma, H1) bows toward the top-left; Scenario B (equal
-    sigma, H0) tracks the diagonal y=x (calibration). Better discrimination =>
-    higher AUC.
-  * sample-size sweep: sigma1=-1.0 vs sigma2_fixed=-1.5 over n in
-    {10,100,500,1000,2000} (d=1 capped, Gibbs cost).
-  * effect-size sweep: sigma1=-1.0 vs sigma2 in {-1.0,-1.5,-2.0,-2.5} at
-    n_effect=500.
+Two figures:
+  * roc_effect_robust  -- ROC (TPR vs FPR) for delta in {0.5,1,1.5,2,3} at
+    n_effect=500. Curves span diagonal -> top-left; empirical AUC ~= theory.
+  * roc_sample_robust  -- n-invariance: the SAME standardized delta across
+    n in {100,500,2000} (d=1 capped). Curves coincide (raw gap shrinks ~1/sqrt(n)),
+    direct evidence the robust SE is calibrated.
 
-Per replicate we generate two *independent* graphs, fit offset-logit sigma-hat +
-dyadic-robust SE on each (logit_graph.robust_se), and form the two-sided Wald
-z = (s1 - s2)/sqrt(SE1^2 + SE2^2). No subsample knob anywhere.
-
-Graph generation reuses experiments.sweeps.simulate_graph (d=0 direct ER at
-p=expit(sigma); d=1 Layer-2 Gibbs at beta=1, adaptive_stopping disabled).
-Reproducible: fixed seed (LG_AVR_SEED), BLAS threads pinned to 1. Writes only
-under runs/anova_validation_robust/.
+Per replicate we generate two *independent* graphs (experiments.sweeps.simulate_graph:
+d=0 direct ER at p=expit(sigma); d=1 Layer-2 Gibbs at beta=1, adaptive_stopping
+disabled), fit offset-logit sigma-hat + dyadic-robust SE on each
+(logit_graph.robust_se), and form z = (s1-s2)/sqrt(SE1^2+SE2^2). Reproducible:
+fixed seed (LG_AVR_SEED), BLAS threads pinned to 1. Writes only under
+runs/anova_validation_robust/.
 
 Env knobs (all optional):
   LG_AVR_SEED (12345)     LG_AVR_QUICK (0 -> full; 1 -> d=0, small n, few reps)
   LG_AVR_ALPHA (0.05)     LG_AVR_DS ("0,1")
   LG_AVR_N_EXP (200)      d=0 experiments per scenario point
-  LG_AVR_D1_N_EXP (80)    d=1 experiments per scenario point (Gibbs is slower)
+  LG_AVR_D1_N_EXP (80)    d=1 experiments per scenario point
   LG_AVR_D1_MAX_N (500)   skip d=1 points above this n (logged)
 
   make anova-validation-robust         full run
@@ -59,7 +62,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from scipy.stats import norm
-from sklearn.metrics import roc_auc_score
+from sklearn.metrics import roc_auc_score, roc_curve
 
 _here = Path(__file__).resolve().parent
 _repo_root = _here.parents[1]
@@ -97,18 +100,21 @@ FEATURE_MODE = "incremental"
 D1_BURN_MIN = _int("LG_AVR_D1_BURN_MIN", 8000)
 D1_BURN_PER_N = _int("LG_AVR_D1_BURN_PER_N", 40)
 
-# Sweep design -- mirrors experiments.presets.ROCSweepConfig (original ROC fig).
+# Sweep design (standardized effect -- see module docstring).
 SIGMA1 = -1.0
-EFFECT_SIGMAS = [-1.0, -1.5, -2.0, -2.5]   # sigma2 (first = null -> H0 diagonal)
-N_EFFECT = 500                             # graph size for the effect-size sweep
-SIGMA2_FIXED = -1.5                        # fixed effect for the sample-size sweep
-N_VALUES = ([10, 100] if QUICK
-            else [10, 100, 500, 1000, 2000])  # sample-size sweep grid
-THRESHOLDS = np.linspace(0.0, 1.0, 101)
+DELTAS = [0.5, 1.0] if QUICK else [0.5, 1.0, 1.5, 2.0, 3.0]  # standardized effects
+N_EFFECT = 500                                # graph size for the effect ROC
+DELTA_FIXED = 1.5                             # standardized effect for n-invariance
+N_VALUES = ([50, 100] if QUICK else [100, 500, 2000])
+PILOT_K = _int("LG_AVR_PILOT_K", 6 if QUICK else 16)  # graphs to estimate typical SE
 
 
 def _n_exp(d):
     return D1_N_EXP if d >= 1 else N_EXP
+
+
+def _pilot_k(d):
+    return max(4, PILOT_K // 2) if d >= 1 else PILOT_K
 
 
 def _gen(n, d, sigma, seed):
@@ -120,17 +126,30 @@ def _gen(n, d, sigma, seed):
                           adaptive_stopping=False)
 
 
+def _fit(adj, d):
+    return fit_sigma_with_robust_se(adj, d, feature_mode=FEATURE_MODE)
+
+
 def _wald_p(adj1, adj2, d):
-    s1, se1, _ = fit_sigma_with_robust_se(adj1, d, feature_mode=FEATURE_MODE)
-    s2, se2, _ = fit_sigma_with_robust_se(adj2, d, feature_mode=FEATURE_MODE)
+    s1, se1, _ = _fit(adj1, d)
+    s2, se2, _ = _fit(adj2, d)
     denom = math.sqrt(se1 ** 2 + se2 ** 2)
     if not (denom > 0):
         return float("nan")
     return 2.0 * norm.sf(abs((s1 - s2) / denom))
 
 
+def _typical_se(n, d, sigma, k, seed0):
+    """Median dyadic-robust SE of sigma_hat over k independent graphs at sigma."""
+    ses = []
+    for r in range(k):
+        _, se, _ = _fit(_gen(n, d, sigma, seed0 + r), d)
+        if np.isfinite(se) and se > 0:
+            ses.append(se)
+    return float(np.median(ses)) if ses else float("nan")
+
+
 def _collect_pvalues(n, d, sigma1, sigma2, n_exp, seed0):
-    """Two-sided robust-Wald p over n_exp replicates of two independent graphs."""
     ps = []
     for r in range(n_exp):
         a1 = _gen(n, d, sigma1, seed0 + 2 * r)
@@ -141,18 +160,28 @@ def _collect_pvalues(n, d, sigma1, sigma2, n_exp, seed0):
     return np.asarray(ps)
 
 
-def _roc_curve(pvals):
-    """Rejection rate vs p-value threshold (empirical CDF of p), original style."""
-    return np.array([float(np.mean(pvals <= t)) for t in THRESHOLDS])
-
-
-def _auc(h0_p, h1_p):
-    """AUC of the H0-vs-H1 classifier scored by 1-p (higher = more likely H1)."""
+def _roc(h0_p, h1_p):
+    """Return (fpr, tpr, auc) of the H0-vs-H1 classifier scored by 1-p."""
     if len(h0_p) == 0 or len(h1_p) == 0:
-        return float("nan")
+        return np.array([0, 1]), np.array([0, 1]), float("nan")
     y = np.r_[np.zeros(len(h0_p)), np.ones(len(h1_p))]
     s = np.r_[1.0 - h0_p, 1.0 - h1_p]
-    return float(roc_auc_score(y, s))
+    fpr, tpr, _ = roc_curve(y, s)
+    return fpr, tpr, float(roc_auc_score(y, s))
+
+
+def _theory_auc(delta):
+    """ROC AUC of the TWO-sided Wald test (score = |z|) at non-centrality delta.
+
+    Under H0 z~N(0,1), under H1 z~N(delta,1); the two-sided p ranks by |z|, so
+    AUC = P(|z_H1| > |z_H0|) = E_U[P(V>U)] with U=|N(0,1)|, V=|N(delta,1)|.
+    (The one-sided value Phi(delta/sqrt(2)) would overstate it.)
+    """
+    u = np.linspace(0.0, 12.0, 6001)
+    f_u = 2.0 * norm.pdf(u)                       # half-normal density of |z_H0|
+    p_v_gt_u = 1.0 - norm.cdf(u - delta) + norm.cdf(-u - delta)  # P(|z_H1| > u)
+    _trap = getattr(np, "trapezoid", None) or np.trapz
+    return float(_trap(p_v_gt_u * f_u, u))
 
 
 # ---------------------------------------------------------------------------
@@ -162,14 +191,37 @@ def _auc(h0_p, h1_p):
 def main():
     out_dir = _here / "runs" / "anova_validation_robust"
     out_dir.mkdir(parents=True, exist_ok=True)
-    print(f"robust-Wald validation (ROC)  seed={SEED}  quick={QUICK}  alpha={ALPHA}  "
-          f"d={DS}  n_exp(d0)={N_EXP}  n_exp(d1)={D1_N_EXP}  d1_max_n={D1_MAX_N}")
-    print(f"  sample sweep: sigma1={SIGMA1} vs sigma2={SIGMA2_FIXED} over n={N_VALUES}")
-    print(f"  effect sweep: sigma1={SIGMA1} vs sigma2={EFFECT_SIGMAS} at n={N_EFFECT}")
+    print(f"robust-Wald validation (standardized-effect ROC)  seed={SEED}  "
+          f"quick={QUICK}  alpha={ALPHA}  d={DS}  n_exp(d0)={N_EXP}  n_exp(d1)={D1_N_EXP}")
+    print(f"  effect ROC: delta={DELTAS} at n={N_EFFECT}")
+    print(f"  n-invariance: delta={DELTA_FIXED} over n={N_VALUES} (d1 cap {D1_MAX_N})")
 
-    # H0 p-values per (d, n): reused for calibration, sample-AUC, and (at n=500)
-    # the effect-sweep null.
-    h0_by_dn = {}
+    # --- Effect ROC: sweep standardized delta at n_effect --------------------
+    effect_rows, effect_curves = [], {}
+    for d in DS:
+        n = N_EFFECT if not (d >= 1 and N_EFFECT > D1_MAX_N) else D1_MAX_N
+        se_typ = _typical_se(n, d, SIGMA1, _pilot_k(d), SEED + 100 * (d + 1))
+        h0 = _collect_pvalues(n, d, SIGMA1, SIGMA1, _n_exp(d), SEED + 1000 * (d + 1))
+        typeI = float(np.mean(h0 < ALPHA))
+        print(f"  [Effect] d={d} n={n}  SE_typ={se_typ:.4f}  typeI={typeI:.3f}")
+        for k, delta in enumerate(DELTAS):
+            t0 = time.perf_counter()
+            dsig = delta * math.sqrt(2.0) * se_typ
+            sigma2 = SIGMA1 - dsig
+            h1 = _collect_pvalues(n, d, SIGMA1, sigma2, _n_exp(d),
+                                  SEED + 2000 * (d + 1) + 50 * k)
+            fpr, tpr, auc = _roc(h0, h1)
+            effect_curves[(d, delta)] = (fpr, tpr)
+            effect_rows.append(dict(d=d, n=n, delta=delta, raw_dsigma=dsig,
+                                    sigma2=sigma2, se_typ=se_typ,
+                                    power=float(np.mean(h1 < ALPHA)), auc_emp=auc,
+                                    auc_theory=_theory_auc(delta), typeI=typeI,
+                                    n_exp=len(h1)))
+            print(f"    delta={delta:.1f} (raw dsigma={dsig:.4f}): "
+                  f"AUC_emp={auc:.3f} AUC_theory={_theory_auc(delta):.3f} "
+                  f"power={float(np.mean(h1 < ALPHA)):.3f}  [{time.perf_counter()-t0:.0f}s]")
+
+    # --- n-invariance: same standardized delta across n ----------------------
     sample_rows, sample_curves = [], {}
     for d in DS:
         for k, n in enumerate(N_VALUES):
@@ -177,101 +229,83 @@ def main():
                 print(f"  [Sample] d={d} n={n}: SKIPPED (n>d1_max_n={D1_MAX_N})")
                 continue
             t0 = time.perf_counter()
+            se_typ = _typical_se(n, d, SIGMA1, _pilot_k(d), SEED + 300 * (d + 1) + 7 * k)
+            dsig = DELTA_FIXED * math.sqrt(2.0) * se_typ
+            sigma2 = SIGMA1 - dsig
             h0 = _collect_pvalues(n, d, SIGMA1, SIGMA1, _n_exp(d),
-                                  SEED + 1000 * (d + 1) + 50 * k)
-            h1 = _collect_pvalues(n, d, SIGMA1, SIGMA2_FIXED, _n_exp(d),
-                                  SEED + 7000 * (d + 1) + 50 * k)
-            h0_by_dn[(d, n)] = h0
-            sample_curves[(d, n)] = (_roc_curve(h0), _roc_curve(h1))
-            typeI = float(np.mean(h0 < ALPHA))
-            power = float(np.mean(h1 < ALPHA))
-            auc = _auc(h0, h1)
-            sample_rows.append(dict(d=d, n=n, sigma1=SIGMA1, sigma2=SIGMA2_FIXED,
-                                    effect=abs(SIGMA2_FIXED - SIGMA1), typeI=typeI,
-                                    power=power, auc=auc, n_exp=len(h1)))
-            print(f"  [Sample] d={d} n={n}: typeI={typeI:.3f} power={power:.3f} "
-                  f"AUC={auc:.3f}  [{time.perf_counter()-t0:.0f}s]")
+                                  SEED + 4000 * (d + 1) + 50 * k)
+            h1 = _collect_pvalues(n, d, SIGMA1, sigma2, _n_exp(d),
+                                  SEED + 5000 * (d + 1) + 50 * k)
+            fpr, tpr, auc = _roc(h0, h1)
+            sample_curves[(d, n)] = (fpr, tpr)
+            sample_rows.append(dict(d=d, n=n, delta=DELTA_FIXED, raw_dsigma=dsig,
+                                    sigma2=sigma2, se_typ=se_typ,
+                                    typeI=float(np.mean(h0 < ALPHA)),
+                                    power=float(np.mean(h1 < ALPHA)), auc_emp=auc,
+                                    auc_theory=_theory_auc(DELTA_FIXED), n_exp=len(h1)))
+            print(f"  [Sample] d={d} n={n}: SE_typ={se_typ:.4f} raw dsigma={dsig:.4f} "
+                  f"AUC_emp={auc:.3f} (theory {_theory_auc(DELTA_FIXED):.3f}) "
+                  f"typeI={float(np.mean(h0 < ALPHA)):.3f}  [{time.perf_counter()-t0:.0f}s]")
 
-    effect_rows, effect_curves = [], {}
-    for d in DS:
-        n = N_EFFECT if not (d >= 1 and N_EFFECT > D1_MAX_N) else D1_MAX_N
-        h0 = h0_by_dn.get((d, n))
-        if h0 is None:
-            h0 = _collect_pvalues(n, d, SIGMA1, SIGMA1, _n_exp(d),
-                                  SEED + 1000 * (d + 1) + 9999)
-            h0_by_dn[(d, n)] = h0
-        for k, s2 in enumerate(EFFECT_SIGMAS):
-            t0 = time.perf_counter()
-            if s2 == SIGMA1:
-                h1 = h0
-            else:
-                h1 = _collect_pvalues(n, d, SIGMA1, s2, _n_exp(d),
-                                      SEED + 2000 * (d + 1) + 50 * k)
-            effect_curves[(d, s2)] = _roc_curve(h1)
-            power = float(np.mean(h1 < ALPHA))
-            auc = _auc(h0, h1)
-            effect_rows.append(dict(d=d, n=n, sigma1=SIGMA1, sigma2=s2,
-                                    effect=abs(s2 - SIGMA1), power=power,
-                                    auc=auc, n_exp=len(h1)))
-            print(f"  [Effect] d={d} n={n} sigma2={s2:+.1f} (effect={abs(s2-SIGMA1):.1f}): "
-                  f"power={power:.3f} AUC={auc:.3f}  [{time.perf_counter()-t0:.0f}s]")
-
-    sample_df = pd.DataFrame(sample_rows)
     effect_df = pd.DataFrame(effect_rows)
-    sample_df.to_csv(out_dir / "roc_sample_robust.csv", index=False)
+    sample_df = pd.DataFrame(sample_rows)
     effect_df.to_csv(out_dir / "roc_effect_robust.csv", index=False)
-    sample_df[["d", "n", "typeI", "n_exp"]].to_csv(out_dir / "typeI.csv", index=False)
+    sample_df.to_csv(out_dir / "roc_sample_robust.csv", index=False)
+    if not sample_df.empty:
+        sample_df[["d", "n", "typeI", "n_exp"]].to_csv(out_dir / "typeI.csv", index=False)
 
-    # --- Plots: rejection rate vs p-value threshold (original ROC style) -----
-    _plot_threshold_roc(
-        out_dir / "roc_sample_robust.png",
-        f"Robust-Wald ROC vs graph size (effect {abs(SIGMA2_FIXED-SIGMA1):.1f})",
-        {d: [(f"n={n}", sample_curves[(d, n)][1])
-             for n in N_VALUES if (d, n) in sample_curves] for d in DS},
-        {d: [(f"H0 n={n}", sample_curves[(d, n)][0])
-             for n in N_VALUES if (d, n) in sample_curves] for d in DS},
-    )
-    _plot_threshold_roc(
+    _plot_roc(
         out_dir / "roc_effect_robust.png",
-        f"Robust-Wald ROC vs effect size (n={N_EFFECT})",
-        {d: [(f"eff={abs(s2-SIGMA1):.1f}", effect_curves[(d, s2)])
-             for s2 in EFFECT_SIGMAS if s2 != SIGMA1 and (d, s2) in effect_curves]
-            for d in DS},
-        {d: [("H0 (eff=0)", effect_curves[(d, SIGMA1)])]
-            for d in DS if (d, SIGMA1) in effect_curves},
+        rf"Robust-Wald ROC vs standardized effect $\delta=\Delta\sigma/SE$ (n={N_EFFECT})",
+        {d: [(rf"$\delta$={delta:.1f} (AUC {_lookup(effect_rows, d, 'delta', delta):.2f})",
+              *effect_curves[(d, delta)])
+             for delta in DELTAS if (d, delta) in effect_curves] for d in DS},
+    )
+    _plot_roc(
+        out_dir / "roc_sample_robust.png",
+        rf"Robust-Wald ROC at fixed $\delta$={DELTA_FIXED} across graph size "
+        rf"(theory AUC={_theory_auc(DELTA_FIXED):.2f})",
+        {d: [(f"n={n} (AUC {_lookup(sample_rows, d, 'n', n):.2f})", *sample_curves[(d, n)])
+             for n in N_VALUES if (d, n) in sample_curves] for d in DS},
     )
 
     (out_dir / "results.json").write_text(json.dumps({
-        "alpha": ALPHA, "seed": SEED, "ds": DS,
-        "sample": sample_rows, "effect": effect_rows,
+        "alpha": ALPHA, "seed": SEED, "ds": DS, "sigma1": SIGMA1,
+        "effect": effect_rows, "sample": sample_rows,
     }, indent=2, default=float))
 
     print("\n" + "=" * 70)
-    print("AUC (1=perfect discrimination, 0.5=chance) and Type-I (~alpha):")
-    for r in sample_rows:
-        print(f"  [sample] d={r['d']} n={r['n']:4d}: AUC={r['auc']:.3f}  "
-              f"typeI={r['typeI']:.3f}  power={r['power']:.3f}")
+    print("Empirical vs theoretical AUC = Phi(delta/sqrt(2)):")
     for r in effect_rows:
-        print(f"  [effect] d={r['d']} n={r['n']} effect={r['effect']:.1f}: "
-              f"AUC={r['auc']:.3f}  power={r['power']:.3f}")
-    print(f"\nWrote {out_dir}/ (roc_sample_robust.{{png,csv}}, "
-          f"roc_effect_robust.{{png,csv}}, typeI.csv, results.json)")
+        print(f"  [effect] d={r['d']} n={r['n']} delta={r['delta']:.1f}: "
+              f"AUC_emp={r['auc_emp']:.3f}  theory={r['auc_theory']:.3f}  "
+              f"(raw dsigma={r['raw_dsigma']:.4f})")
+    for r in sample_rows:
+        print(f"  [sample] d={r['d']} n={r['n']:4d} delta={r['delta']:.1f}: "
+              f"AUC_emp={r['auc_emp']:.3f}  theory={r['auc_theory']:.3f}  "
+              f"(raw dsigma={r['raw_dsigma']:.4f}, typeI={r['typeI']:.3f})")
+    print(f"\nWrote {out_dir}/ (roc_effect_robust.{{png,csv}}, "
+          f"roc_sample_robust.{{png,csv}}, typeI.csv, results.json)")
 
 
-def _plot_threshold_roc(path, suptitle, h1_curves_by_d, h0_curves_by_d):
-    ds = sorted(h1_curves_by_d.keys())
-    fig, axes = plt.subplots(1, len(ds), figsize=(5.2 * len(ds), 4.2), squeeze=False)
+def _lookup(rows, d, key, val):
+    for r in rows:
+        if r["d"] == d and r[key] == val:
+            return r["auc_emp"]
+    return float("nan")
+
+
+def _plot_roc(path, suptitle, curves_by_d):
+    ds = sorted(curves_by_d.keys())
+    fig, axes = plt.subplots(1, len(ds), figsize=(5.2 * len(ds), 4.6), squeeze=False)
     for ax, d in zip(axes[0], ds):
-        for label, curve in h1_curves_by_d[d]:
-            ax.plot(THRESHOLDS, curve, marker="", lw=1.8, label=label)
-        for label, curve in h0_curves_by_d.get(d, []):
-            ax.plot(THRESHOLDS, curve, color="0.6", lw=0.9, ls=":")
-        ax.plot([0, 1], [0, 1], color="k", lw=0.8, ls="--", label="y=x (H0 ideal)")
-        ax.axvline(ALPHA, color="r", lw=0.7, ls=":")
-        ax.set_xlabel("p-value threshold")
-        ax.set_ylabel("rejection rate")
+        for label, fpr, tpr in curves_by_d[d]:
+            ax.plot(fpr, tpr, lw=1.8, label=label)
+        ax.plot([0, 1], [0, 1], color="k", lw=0.8, ls="--", label="chance")
+        ax.set_xlabel("false positive rate")
+        ax.set_ylabel("true positive rate")
         ax.set_title(f"d={d}")
-        ax.set_xlim(0, 1)
+        ax.set_xlim(-0.02, 1.02)
         ax.set_ylim(-0.02, 1.02)
         ax.legend(fontsize=8, loc="lower right")
     fig.suptitle(suptitle)


### PR DESCRIPTION
> ⚠️ **Stacked on #55** (`feat/robust-se-helper`). Base will retarget to `main` once #55 merges. Independent of #56.

## Why

The simulation ANOVAs (`12-0-anova-roc`, `15-type_one_error`, and the `sweeps.py` ROC machinery) use genuinely independent replicate graphs and are statistically valid — but they validate the **wrong test**: an ANOVA over `n_reps` replicate σ̂, which **cannot be run on a single real graph**. Worse, the production sample-size ROC fakes `SE ∝ 1/n` via a fractional pair-subsample knob (`ROCSweepConfig.subsample_pairs`), which ignores dyadic dependence and overstates power growth in n.

This PR re-casts the validation to test the **same** test now applied to the real graphs (Twitch #54, connectomes #56): one graph per group → offset-logit σ̂ + dyadic-cluster-robust SE → two-sided Wald z.

## What

`scripts/experiments/run_anova_validation_robust.py` — per MC replicate, generate two **independent** graphs (`experiments.sweeps.simulate_graph`: d=0 direct ER at p=expit(σ); d=1 Layer-2 Gibbs at β=1, `adaptive_stopping` disabled), fit σ̂ + robust SE on each (`logit_graph.robust_se` from #55), form `z=(σ̂₁−σ̂₂)/√(SE₁²+SE₂²)`:
- **Type-I calibration:** both graphs at the same σ → empirical reject rate vs α, across n.
- **Power:** different σ → reject rate, swept over **effect size** (n fixed) and **sample size** (effect fixed), per d∈{0,1}. No subsample knob.

Outputs `typeI.csv`, `roc_effect_robust.{png,csv}`, `roc_sample_robust.{png,csv}`, `results.json` under `runs/anova_validation_robust/` (gitignored). Adds `make anova-validation-robust[-quick]`.

The honest SE (∝1/√n) makes power transition sharply, so the sweeps are centered in the informative regime (small fixed n for the effect sweep; small fixed effect over a fine n-grid for the sample sweep). d=1 is capped at `LG_AVR_D1_MAX_N` (Gibbs cost); skipped points are logged, not silently dropped.

## Results (full run, seed 12345)
- **Type-I ≈ α** — d=0 (300 reps): 0.063 / 0.053 / 0.057 at n=50/200/1000; d=1 (80 reps): 0.025 / 0.062 at n=50/200. Well-calibrated.
- **Power ↑ effect size** — d=0: .12→.30→.60→.87→.97; d=1: .15→.37→.71→.95→1.0 (effects 0→1.0 at n=20).
- **Power ↑ n** then plateaus — d=0: .31→.78→1.0 (n=10→50); d=1: .44→.84→1.0 — **without** any subsample knob.

## Verification
- `py_compile` clean; `make anova-validation-robust-quick` runs (d=0, few reps).
- Full d=0/d=1 run completes (exit 0); quick-mode reruns **byte-identical** (deterministic, BLAS pinned).