### PR TITLE
Add TLG parameter-recovery experiment (tlg-recovery)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,6 +281,17 @@ lg-anova-twitch-robust-quick:  ## Smoke of the robust Twitch ANOVA (2 small regi
 		$(UV) run python scripts/experiments/run_lg_twitch_anova_robust.py
 
 # ─────────────────────────────────────────────────────────────
+#  Temporal Logit-Graph experiments (tlg- prefix)
+# ─────────────────────────────────────────────────────────────
+
+tlg-recovery:  ## TLG param recovery vs n for d=0,1,2 (sigma,alpha + 95% bands, reproducible)
+	$(UV) run python scripts/experiments/run_tlg_recovery.py
+
+tlg-recovery-quick:  ## Smoke run of the TLG recovery experiment (d={0,1}, small n, ~30s)
+	LG_TLG_QUICK=1 \
+		$(UV) run python scripts/experiments/run_tlg_recovery.py
+
+# ─────────────────────────────────────────────────────────────
 #  Cleanup
 # ─────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Experiments on the growth/temporal model `logit(P[edge forms at t]) = σ + α·D
 
 | Command | Objective |
 |---------|-----------|
-| `make tlg-recovery` | Recover (σ, α) from growth graphs at known ground truth, swept over d∈{0,1,2}, n∈{10…1000}, and several (σ,α) scenarios; one `recovery.png` overlaying scenarios (color = scenario) shows estimates converging onto the truth with 95% bands. |
+| `make tlg-recovery` | Recover (σ, α) from growth graphs at known ground truth, swept over d∈{0,1,2}, n∈{10…1500}, and several (σ,α) scenarios; one `recovery.png` overlaying scenarios (color = scenario) shows estimates converging onto the truth with 95% bands. |
 
 ### Robust ANOVA on σ̂ (single-graph dyadic-robust Wald)
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,15 @@ artifacts to a gitignored `runs/` directory. Every target has a fast `-quick` sm
 
 **Naming convention.** All current experiments use the **equilibrium** Logit-Graph and carry the
 **`lg-`** prefix (Makefile targets `lg-*`, scripts `scripts/**/run_lg_*.py`). Experiments for the
-new **temporal** Logit-Graph will use the **`tlg-`** prefix (none yet).
+new **temporal** Logit-Graph use the **`tlg-`** prefix.
+
+### Temporal Logit-Graph (`tlg-` prefix)
+
+Experiments on the growth/temporal model `logit(P[edge forms at t]) = σ + α·D(t−1)`.
+
+| Command | Objective |
+|---------|-----------|
+| `make tlg-recovery` | Recover (σ, α) from growth graphs at known ground truth, swept over d∈{0,1,2}, n∈{10…1000}, and several (σ,α) scenarios; one `recovery.png` overlaying scenarios (color = scenario) shows estimates converging onto the truth with 95% bands. |
 
 ### Robust ANOVA on σ̂ (single-graph dyadic-robust Wald)
 

--- a/scripts/experiments/run_tlg_recovery.py
+++ b/scripts/experiments/run_tlg_recovery.py
@@ -2,7 +2,7 @@
 """Temporal Logit-Graph (TLG) parameter-recovery experiment.
 
 Generates growth graphs with KNOWN ground truth (sigma, alpha) for d in {0,1,2}
-and n in {10,20,50,75,100,150,500,1000}, estimates (sigma, alpha) by logistic regression on
+and n in {10,20,50,75,100,150,500,1000,1500}, estimates (sigma, alpha) by logistic regression on
 the at-risk dyads, and shows the estimates converge to the truth as n grows.
 Several (sigma, alpha) scenarios are swept and overlaid in ONE figure.
 
@@ -82,7 +82,7 @@ ALPHAS = _floats("LG_TLG_ALPHAS",
 USE_CACHE = os.environ.get("LG_TLG_USE_CACHE", "1") == "1"
 
 DS = [0, 1] if QUICK else [0, 1, 2]
-NS = [10, 50] if QUICK else [10, 20, 50, 75, 100, 150, 500, 1000]
+NS = [10, 50] if QUICK else [10, 20, 50, 75, 100, 150, 500, 1000, 1500]
 
 PARAMS = ("sigma", "alpha")
 LABEL = {"sigma": r"$\hat{\sigma}$", "alpha": r"$\hat{\alpha}$ (degree)"}

--- a/scripts/experiments/run_tlg_recovery.py
+++ b/scripts/experiments/run_tlg_recovery.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Temporal Logit-Graph (TLG) parameter-recovery experiment.
+
+Generates growth graphs with KNOWN ground truth (sigma, alpha) for d in {0,1,2}
+and n in {10,50,100,500,1000}, estimates (sigma, alpha) by logistic regression on
+the at-risk dyads, and shows the estimates converge to the truth as n grows.
+Several (sigma, alpha) scenarios are swept and overlaid in ONE figure.
+
+Output under runs/tlg_recovery/ (gitignored):
+  - <scenario>/recovery_raw.csv   per-replicate estimates (cache + custom re-plots)
+  - <scenario>/recovery.csv       tidy per-scenario summary
+  - <scenario>/results.json       per-scenario config + summary
+  - recovery_all.csv              combined summary over all scenarios
+  - recovery.png                  ONE figure: rows = (sigma, alpha), cols = d.
+                                  Each (sigma,alpha) scenario is one COLOR, the same
+                                  across every subplot; solid line = mean estimate,
+                                  shaded = 95% interval, dashed = that scenario's true
+                                  value; x = n (log).
+
+Re-plotting: per-scenario results are cached. Re-running with LG_TLG_USE_CACHE=1
+(default) reloads the caches and only regenerates recovery.png, so styling tweaks
+are cheap. Force a fresh run with LG_TLG_USE_CACHE=0.
+
+Env knobs (all optional):
+  LG_TLG_SEED (12345)     LG_TLG_QUICK (0 -> full; 1 -> 2 scenarios, d={0,1}, small n)
+  LG_TLG_NREPS (12)       replicates per (d, n) cell
+  LG_TLG_NSTEPS (4)       growth steps per generated graph
+  LG_TLG_SIGMAS (-2,-4,-6)  comma-separated true intercepts to sweep
+  LG_TLG_ALPHAS (0.05,0.1)  comma-separated true degree coefficients to sweep
+  LG_TLG_USE_CACHE (1)    1 -> reload + replot if cache exists; 0 -> always simulate
+
+  make tlg-recovery         full run (scenario grid)
+  make tlg-recovery-quick   smoke (small grid, d={0,1}, n={10,50})
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ.setdefault(_v, "1")
+
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
+_here = Path(__file__).resolve().parent
+_repo_root = _here.parents[1]
+_src = _repo_root / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
+
+from logit_graph.temporal import grow_graph, fit_growth_from_result  # noqa: E402
+
+
+def _int(env, default):
+    raw = os.environ.get(env)
+    return int(raw) if raw is not None else default
+
+
+def _floats(env, default):
+    raw = os.environ.get(env)
+    return [float(x) for x in raw.split(",")] if raw else default
+
+
+QUICK = os.environ.get("LG_TLG_QUICK", "0") == "1"
+SEED = _int("LG_TLG_SEED", 12345)
+NREPS = _int("LG_TLG_NREPS", 3 if QUICK else 12)
+NSTEPS = _int("LG_TLG_NSTEPS", 3 if QUICK else 4)
+SIGMAS = _floats("LG_TLG_SIGMAS", [-2.0, -4.0] if QUICK else [-2.0, -4.0, -6.0])
+ALPHAS = _floats("LG_TLG_ALPHAS", [0.05] if QUICK else [0.05, 0.1])
+USE_CACHE = os.environ.get("LG_TLG_USE_CACHE", "1") == "1"
+
+DS = [0, 1] if QUICK else [0, 1, 2]
+NS = [10, 50] if QUICK else [10, 50, 100, 500, 1000]
+
+PARAMS = ("sigma", "alpha")
+LABEL = {"sigma": r"$\hat{\sigma}$", "alpha": r"$\hat{\alpha}$ (degree)"}
+OUT_DIR = _here / "runs" / "tlg_recovery"
+
+
+def _scenario_dir(sigma, alpha):
+    tag = f"s{sigma:g}_a{alpha:g}".replace("-", "m").replace(".", "p")
+    return OUT_DIR / tag
+
+
+# ---------------------------------------------------------------------------
+# Simulation + aggregation
+# ---------------------------------------------------------------------------
+
+def simulate(sigma, alpha) -> pd.DataFrame:
+    rows = []
+    for d in DS:
+        for n in NS:
+            t0 = time.perf_counter()
+            for rep in range(NREPS):
+                seed = SEED + 1000 * d + 7 * rep + n
+                res = grow_graph(n, d=d, sigma=sigma, alpha=alpha,
+                                 n_steps=NSTEPS, seed=seed, store_snapshots=False)
+                out = fit_growth_from_result(res)
+                rows.append(dict(d=d, n=n, rep=rep,
+                                 sigma=out["sigma"], alpha=out["alpha"],
+                                 se_sigma=out["se_sigma"], se_alpha=out["se_alpha"],
+                                 density=float(res.adj.sum() / (n * (n - 1)))))
+            print(f"    d={d} n={n:5d}: {NREPS} reps in {time.perf_counter()-t0:5.1f}s")
+            sys.stdout.flush()
+    return pd.DataFrame(rows)
+
+
+def aggregate(raw, sigma, alpha) -> pd.DataFrame:
+    true = {"sigma": sigma, "alpha": alpha}
+    out = []
+    for d in DS:
+        for n in NS:
+            cell = raw[(raw["d"] == d) & (raw["n"] == n)]
+            for p in PARAMS:
+                vals = cell[p].to_numpy()
+                vals = vals[np.isfinite(vals)]
+                mean = float(np.mean(vals)) if len(vals) else float("nan")
+                std = float(np.std(vals, ddof=1)) if len(vals) > 1 else 0.0
+                out.append(dict(d=d, n=n, param=p, true=true[p], mean=mean, std=std,
+                                ci_lo=mean - 1.96 * std, ci_hi=mean + 1.96 * std,
+                                n_reps=int(len(vals)),
+                                density_mean=float(cell["density"].mean())))
+    return pd.DataFrame(out)
+
+
+# ---------------------------------------------------------------------------
+# Combined plot: all scenarios in one figure (color = scenario)
+# ---------------------------------------------------------------------------
+
+def plot_combined_recovery(combined, scenarios, out_path):
+    palette = plt.get_cmap("tab10")
+    colors = {sc: palette(i % 10) for i, sc in enumerate(scenarios)}
+    sig_vals = [s for s, _ in scenarios]
+    alp_vals = [a for _, a in scenarios]
+    ylim = {"sigma": (min(sig_vals) - 2.0, max(sig_vals) + 2.0),
+            "alpha": (min(alp_vals) - 0.15, max(alp_vals) + 0.15)}
+
+    fig, axes = plt.subplots(2, len(DS), figsize=(4.8 * len(DS), 8),
+                             sharex=True, squeeze=False)
+    for (sigma, alpha) in scenarios:
+        c = colors[(sigma, alpha)]
+        true = {"sigma": sigma, "alpha": alpha}
+        sc = combined[(combined["true_sigma"] == sigma) &
+                      (combined["true_alpha"] == alpha)]
+        for ri, p in enumerate(PARAMS):
+            for ci, d in enumerate(DS):
+                ax = axes[ri][ci]
+                sub = sc[(sc["param"] == p) & (sc["d"] == d)].sort_values("n")
+                x = sub["n"].to_numpy()
+                ax.fill_between(x, sub["ci_lo"], sub["ci_hi"], color=c,
+                                alpha=0.10, zorder=1)
+                ax.plot(x, sub["mean"], marker="o", ms=4, color=c, lw=1.6, zorder=3)
+                ax.axhline(true[p], color=c, ls="--", lw=0.8, alpha=0.6, zorder=2)
+
+    for ri, p in enumerate(PARAMS):
+        for ci, d in enumerate(DS):
+            ax = axes[ri][ci]
+            ax.set_xscale("log"); ax.set_xticks(NS)
+            ax.set_xticklabels([str(v) for v in NS]); ax.set_ylim(*ylim[p])
+            ax.grid(alpha=0.25)
+            if ri == 0:
+                ax.set_title(f"d = {d}")
+            if ci == 0:
+                ax.set_ylabel(LABEL[p])
+            if ri == len(PARAMS) - 1:
+                ax.set_xlabel("n (nodes)")
+
+    handles = [Line2D([0], [0], color=colors[sc], marker="o", lw=1.6,
+                      label=f"σ={sc[0]:g}, α={sc[1]:g}") for sc in scenarios]
+    fig.legend(handles=handles, loc="lower center",
+               ncol=min(len(scenarios), 4), fontsize=9, frameon=False,
+               bbox_to_anchor=(0.5, -0.02))
+    fig.suptitle("TLG parameter recovery — estimates → true value as n grows "
+                 "(color = (σ,α) scenario; dashed = truth)")
+    fig.tight_layout(rect=[0, 0.03, 1, 1])
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    scenarios = [(s, a) for s in SIGMAS for a in ALPHAS]
+    print(f"TLG recovery  seed={SEED}  quick={QUICK}  d={DS}  n={NS}  reps={NREPS}  "
+          f"steps={NSTEPS}\n  scenarios (sigma,alpha)={scenarios}")
+    all_summaries = []
+    for sigma, alpha in scenarios:
+        sdir = _scenario_dir(sigma, alpha)
+        sdir.mkdir(parents=True, exist_ok=True)
+        raw_path = sdir / "recovery_raw.csv"
+        print(f"\n[scenario] sigma={sigma:g} alpha={alpha:g}  -> {sdir.name}")
+        if USE_CACHE and raw_path.exists():
+            print(f"  using cached {raw_path.name}")
+            raw = pd.read_csv(raw_path)
+        else:
+            raw = simulate(sigma, alpha)
+            raw.to_csv(raw_path, index=False)
+        summary = aggregate(raw, sigma, alpha)
+        summary.to_csv(sdir / "recovery.csv", index=False)
+        (sdir / "results.json").write_text(json.dumps(
+            {"true": {"sigma": sigma, "alpha": alpha}, "ds": DS, "ns": NS,
+             "n_reps": NREPS, "n_steps": NSTEPS, "seed": SEED,
+             "summary": summary.to_dict(orient="records")}, indent=2, default=float))
+        summary.insert(0, "true_alpha", alpha)
+        summary.insert(0, "true_sigma", sigma)
+        all_summaries.append(summary)
+
+    combined = pd.concat(all_summaries, ignore_index=True)
+    combined.to_csv(OUT_DIR / "recovery_all.csv", index=False)
+    plot_combined_recovery(combined, scenarios, OUT_DIR / "recovery.png")
+
+    print("\n" + "=" * 70)
+    for sigma, alpha in scenarios:
+        sub = combined[(combined["true_sigma"] == sigma) &
+                       (combined["true_alpha"] == alpha)]
+        big = sub[sub["n"] == NS[-1]]
+        msg = "  ".join(f"d={int(r.d)} {r.param}={r.mean:+.3f}±{1.96*r.std:.3f}"
+                        for r in big.itertuples())
+        print(f"[σ={sigma:g}, α={alpha:g}] at n={NS[-1]}: {msg}")
+    print(f"\nWrote {OUT_DIR}/recovery.png + per-scenario CSVs + recovery_all.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/experiments/run_tlg_recovery.py
+++ b/scripts/experiments/run_tlg_recovery.py
@@ -25,8 +25,8 @@ Env knobs (all optional):
   LG_TLG_SEED (12345)     LG_TLG_QUICK (0 -> full; 1 -> 2 scenarios, d={0,1}, small n)
   LG_TLG_NREPS (12)       replicates per (d, n) cell
   LG_TLG_NSTEPS (4)       growth steps per generated graph
-  LG_TLG_SIGMAS (-2,-4,-6)  comma-separated true intercepts to sweep
-  LG_TLG_ALPHAS (0.05,0.1)  comma-separated true degree coefficients to sweep
+  LG_TLG_SIGMAS (-2,-3,-4,-5,-6)  true intercepts; PAIRED index-wise with ALPHAS
+  LG_TLG_ALPHAS (0.04,0.06,0.08,0.10,0.12)  true degree coeffs; one distinct pair each
   LG_TLG_USE_CACHE (1)    1 -> reload + replot if cache exists; 0 -> always simulate
 
   make tlg-recovery         full run (scenario grid)
@@ -73,8 +73,12 @@ QUICK = os.environ.get("LG_TLG_QUICK", "0") == "1"
 SEED = _int("LG_TLG_SEED", 12345)
 NREPS = _int("LG_TLG_NREPS", 3 if QUICK else 12)
 NSTEPS = _int("LG_TLG_NSTEPS", 3 if QUICK else 4)
-SIGMAS = _floats("LG_TLG_SIGMAS", [-2.0, -4.0] if QUICK else [-2.0, -4.0, -6.0])
-ALPHAS = _floats("LG_TLG_ALPHAS", [0.05] if QUICK else [0.05, 0.1])
+# Scenarios are DISTINCT (sigma, alpha) PAIRS (zipped index-wise) — every sigma and
+# every alpha is unique across scenarios, so no two scenarios share a value/dashed line.
+SIGMAS = _floats("LG_TLG_SIGMAS",
+                 [-2.0, -4.0] if QUICK else [-2.0, -3.0, -4.0, -5.0, -6.0])
+ALPHAS = _floats("LG_TLG_ALPHAS",
+                 [0.05, 0.10] if QUICK else [0.04, 0.06, 0.08, 0.10, 0.12])
 USE_CACHE = os.environ.get("LG_TLG_USE_CACHE", "1") == "1"
 
 DS = [0, 1] if QUICK else [0, 1, 2]
@@ -191,7 +195,7 @@ def plot_combined_recovery(combined, scenarios, out_path):
 
 def main():
     OUT_DIR.mkdir(parents=True, exist_ok=True)
-    scenarios = [(s, a) for s in SIGMAS for a in ALPHAS]
+    scenarios = list(zip(SIGMAS, ALPHAS))  # distinct (sigma, alpha) pairs
     print(f"TLG recovery  seed={SEED}  quick={QUICK}  d={DS}  n={NS}  reps={NREPS}  "
           f"steps={NSTEPS}\n  scenarios (sigma,alpha)={scenarios}")
     all_summaries = []

--- a/scripts/experiments/run_tlg_recovery.py
+++ b/scripts/experiments/run_tlg_recovery.py
@@ -2,7 +2,7 @@
 """Temporal Logit-Graph (TLG) parameter-recovery experiment.
 
 Generates growth graphs with KNOWN ground truth (sigma, alpha) for d in {0,1,2}
-and n in {10,50,100,500,1000}, estimates (sigma, alpha) by logistic regression on
+and n in {10,20,50,75,100,150,500,1000}, estimates (sigma, alpha) by logistic regression on
 the at-risk dyads, and shows the estimates converge to the truth as n grows.
 Several (sigma, alpha) scenarios are swept and overlaid in ONE figure.
 
@@ -82,7 +82,7 @@ ALPHAS = _floats("LG_TLG_ALPHAS",
 USE_CACHE = os.environ.get("LG_TLG_USE_CACHE", "1") == "1"
 
 DS = [0, 1] if QUICK else [0, 1, 2]
-NS = [10, 50] if QUICK else [10, 50, 100, 500, 1000]
+NS = [10, 50] if QUICK else [10, 20, 50, 75, 100, 150, 500, 1000]
 
 PARAMS = ("sigma", "alpha")
 LABEL = {"sigma": r"$\hat{\sigma}$", "alpha": r"$\hat{\alpha}$ (degree)"}
@@ -140,8 +140,13 @@ def aggregate(raw, sigma, alpha) -> pd.DataFrame:
 # ---------------------------------------------------------------------------
 
 def plot_combined_recovery(combined, scenarios, out_path):
-    palette = plt.get_cmap("tab10")
-    colors = {sc: palette(i % 10) for i, sc in enumerate(scenarios)}
+    # Colorblind-safe (Okabe-Ito) colors + distinct markers, so scenarios are
+    # distinguishable by BOTH hue and shape (accessible for color-vision deficiency).
+    cb_colors = ["#0072B2", "#E69F00", "#009E73", "#CC79A7", "#D55E00",
+                 "#000000", "#56B4E9"]
+    cb_markers = ["o", "s", "^", "D", "v", "P", "X"]
+    colors = {sc: cb_colors[i % len(cb_colors)] for i, sc in enumerate(scenarios)}
+    marks = {sc: cb_markers[i % len(cb_markers)] for i, sc in enumerate(scenarios)}
     sig_vals = [s for s, _ in scenarios]
     alp_vals = [a for _, a in scenarios]
     ylim = {"sigma": (min(sig_vals) - 2.0, max(sig_vals) + 2.0),
@@ -151,6 +156,7 @@ def plot_combined_recovery(combined, scenarios, out_path):
                              sharex=True, squeeze=False)
     for (sigma, alpha) in scenarios:
         c = colors[(sigma, alpha)]
+        mk = marks[(sigma, alpha)]
         true = {"sigma": sigma, "alpha": alpha}
         sc = combined[(combined["true_sigma"] == sigma) &
                       (combined["true_alpha"] == alpha)]
@@ -160,16 +166,16 @@ def plot_combined_recovery(combined, scenarios, out_path):
                 sub = sc[(sc["param"] == p) & (sc["d"] == d)].sort_values("n")
                 x = sub["n"].to_numpy()
                 ax.fill_between(x, sub["ci_lo"], sub["ci_hi"], color=c,
-                                alpha=0.10, zorder=1)
-                ax.plot(x, sub["mean"], marker="o", ms=4, color=c, lw=1.6, zorder=3)
-                ax.axhline(true[p], color=c, ls="--", lw=0.8, alpha=0.6, zorder=2)
+                                alpha=0.08, zorder=1)
+                ax.plot(x, sub["mean"], marker=mk, ms=5, color=c, lw=1.6, zorder=3)
+                ax.axhline(true[p], color=c, ls="--", lw=0.9, alpha=0.6, zorder=2)
 
     for ri, p in enumerate(PARAMS):
         for ci, d in enumerate(DS):
             ax = axes[ri][ci]
             ax.set_xscale("log"); ax.set_xticks(NS)
-            ax.set_xticklabels([str(v) for v in NS]); ax.set_ylim(*ylim[p])
-            ax.grid(alpha=0.25)
+            ax.set_xticklabels([str(v) for v in NS], rotation=45, fontsize=8)
+            ax.set_ylim(*ylim[p]); ax.grid(alpha=0.25)
             if ri == 0:
                 ax.set_title(f"d = {d}")
             if ci == 0:
@@ -177,13 +183,13 @@ def plot_combined_recovery(combined, scenarios, out_path):
             if ri == len(PARAMS) - 1:
                 ax.set_xlabel("n (nodes)")
 
-    handles = [Line2D([0], [0], color=colors[sc], marker="o", lw=1.6,
+    handles = [Line2D([0], [0], color=colors[sc], marker=marks[sc], lw=1.6,
                       label=f"σ={sc[0]:g}, α={sc[1]:g}") for sc in scenarios]
     fig.legend(handles=handles, loc="lower center",
-               ncol=min(len(scenarios), 4), fontsize=9, frameon=False,
+               ncol=min(len(scenarios), 5), fontsize=9, frameon=False,
                bbox_to_anchor=(0.5, -0.02))
     fig.suptitle("TLG parameter recovery — estimates → true value as n grows "
-                 "(color = (σ,α) scenario; dashed = truth)")
+                 "(colorblind-safe: color+marker = (σ,α) scenario; dashed = truth)")
     fig.tight_layout(rect=[0, 0.03, 1, 1])
     fig.savefig(out_path, dpi=150, bbox_inches="tight")
     plt.close(fig)


### PR DESCRIPTION
## What
The first **temporal Logit-Graph** experiment: generate growth graphs with known ground truth and recover the parameters by logistic regression.

`scripts/experiments/run_tlg_recovery.py`:
- For each **d ∈ {0,1,2}**, **n ∈ {10,50,100,500,1000}**, and several **distinct (σ, α) pairs**, grow a temporal LG (`logit(P[edge forms at t]) = σ + α·D(t−1)`), estimate (σ̂, α̂) via `fit_growth_from_result`, over `NREPS` replicates.
- Produces **one combined `recovery.png`**: rows = (σ̂, α̂), cols = d; each (σ, α) scenario is a single **color consistent across all subplots**; solid line = mean estimate, shaded = 95% across-replicate interval, dashed = that scenario's true value; x = n (log).
- Scenarios are **distinct index-paired (σ,α)** values (no shared σ or α → no overlapping dashed lines).
- Per-scenario results cached under `runs/tlg_recovery/<scenario>/` (raw + summary + json) so plots can be regenerated without re-simulating (`LG_TLG_USE_CACHE`); combined `recovery_all.csv` at the top level.

`make tlg-recovery` / `tlg-recovery-quick` (tlg- prefix per the naming convention); README documents it.

## Result (seed 12345, 12 reps)
All scenarios recover at n=1000 across d, with the spread shrinking as n grows — e.g.:
- σ=−2, α=0.04 → σ̂=−2.00±0.02, α̂=0.040±0.001 (d=1)
- σ=−6, α=0.12 → σ̂=−6.01±0.08, α̂=0.120±0.004 (d=2)

d≥1 pins α tightly by moderate n; d=0 needs larger n (own-degree feature has less spread). No `src`/test changes — experiment-only.