### PR TITLE
Add until_convergence (ESD-KL stopping) option to TLG grow_graph + evaluation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,13 @@ tlg-convergence-diagnostics-quick:  ## Smoke run of the TLG convergence diagnost
 	LG_TLGC_QUICK=1 \
 		$(UV) run python scripts/diagnostics/run_tlg_convergence_diagnostics.py
 
+tlg-esd-stop-eval:  ## Evaluate ESD-KL convergence stopping (until_convergence): stop-step + bias vs n, tol sensitivity
+	$(UV) run python scripts/diagnostics/run_tlg_esd_stop_eval.py
+
+tlg-esd-stop-eval-quick:  ## Smoke run of the ESD-stop evaluation (~30s)
+	LG_ESS_QUICK=1 \
+		$(UV) run python scripts/diagnostics/run_tlg_esd_stop_eval.py
+
 # ─────────────────────────────────────────────────────────────
 #  Cleanup
 # ─────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Experiments on the growth/temporal model `logit(P[edge forms at t]) = σ + α·D
 |---------|-----------|
 | `make tlg-recovery` | Recover (σ, α) from growth graphs at known ground truth, swept over d∈{0,1,2}, n∈{10…1500}, and several (σ,α) scenarios; one `recovery.png` overlaying scenarios (color = scenario) shows estimates converging onto the truth with 95% bands. |
 | `make tlg-convergence-diagnostics` | Convergence of the add+remove TLG (`allow_removal=True`): 8 chains from different initial ER densities mix to the same stationary distribution — Laplacian-spectrum / edge-count / degree-KS / adjacency-ESD-KL vs growth step all converge to a moderate-density reference. |
+| `make tlg-esd-stop-eval` | Evaluate `grow_graph(until_convergence=True)`, which stops once the consecutive-snapshot adjacency-ESD KL stays below `esd_tol`: stop-step vs n, bias of the stopped graph vs a long stationary draw (KS vs noise floor), and `esd_tol` sensitivity. |
 
 ### Robust ANOVA on σ̂ (single-graph dyadic-robust Wald)
 

--- a/scripts/diagnostics/run_tlg_esd_stop_eval.py
+++ b/scripts/diagnostics/run_tlg_esd_stop_eval.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Evaluate ESD-KL convergence stopping for the temporal Logit-Graph.
+
+``grow_graph(until_convergence=True)`` stops once the adjacency-ESD KL divergence
+between consecutive snapshots stays below ``esd_tol`` for ``patience`` steps. This
+script asks: **is that a good idea?** — i.e. does it stop at the right place (the
+stopped graph already looks like the stationary distribution, no bias), how does the
+stop-step scale with n, and how sensitive is it to the tolerance.
+
+For each n we run REPS chains with ``until_convergence=True`` (cap = STEPS) and:
+  1. record the stop step and whether it converged before the cap;
+  2. validate against a long fixed-run reference (one stationary draw): compare the
+     stopped graph's degree distribution (KS) and adjacency ESD (KL) to the
+     reference, and to a second independent reference (the noise floor). If
+     stopped-vs-ref ~ ref-vs-ref, early stopping added no bias -> good idea.
+
+Also prints an esd_tol sensitivity table at one n.
+
+Plots three panels:
+  (a) stop step vs n (mean, min-max);
+  (b) degree-KS(stopped vs reference) vs n, with the ref-vs-ref noise-floor band;
+  (c) example consecutive ESD-KL traces with the stop step marked.
+
+Env knobs (all optional):
+  LG_ESS_NS (100,200,400,750)   LG_ESS_D (0)   LG_ESS_SIGMA (-2.0)  LG_ESS_ALPHA (0.05)
+  LG_ESS_STEPS (60) cap         LG_ESS_TOL (0.01)   LG_ESS_PATIENCE (3)
+  LG_ESS_REPS (8)               LG_ESS_SEED (0)     LG_ESS_QUICK (1 -> small grid)
+
+  make tlg-esd-stop-eval         full run
+  make tlg-esd-stop-eval-quick   smoke
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ.setdefault(_v, "1")
+
+import numpy as np
+import pandas as pd
+from scipy.stats import ks_2samp
+
+_repo_root = Path(__file__).resolve().parents[2]
+_src = _repo_root / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
+
+from logit_graph.temporal import grow_graph, _adjacency_esd_kl  # noqa: E402
+
+OUT_DIR = Path(__file__).resolve().parent / "runs" / "tlg_esd_stop"
+
+
+def _int(name, default):
+    raw = os.environ.get(name)
+    return int(raw) if raw is not None else default
+
+
+def _float(name, default):
+    raw = os.environ.get(name)
+    return float(raw) if raw is not None else default
+
+
+def _ints(name, default):
+    raw = os.environ.get(name)
+    return [int(x) for x in raw.split(",")] if raw else default
+
+
+def _reference(n, d, sigma, alpha, steps, seed):
+    """One long fixed-run draw from the stationary distribution."""
+    return grow_graph(n, d=d, sigma=sigma, alpha=alpha, n_steps=steps, seed=seed,
+                      store_snapshots=False).adj
+
+
+def main():
+    quick = os.environ.get("LG_ESS_QUICK", "0") == "1"
+    NS = _ints("LG_ESS_NS", [100, 200] if quick else [100, 200, 400, 750])
+    d = _int("LG_ESS_D", 0)
+    sigma = _float("LG_ESS_SIGMA", -2.0)
+    alpha = _float("LG_ESS_ALPHA", 0.05)
+    steps = _int("LG_ESS_STEPS", 30 if quick else 60)
+    tol = _float("LG_ESS_TOL", 1e-2)
+    patience = _int("LG_ESS_PATIENCE", 3)
+    reps = _int("LG_ESS_REPS", 4 if quick else 8)
+    seed0 = _int("LG_ESS_SEED", 0)
+    print(f"ESD-stop eval  mode={'QUICK' if quick else 'FULL'}  n={NS} d={d} "
+          f"sigma={sigma} alpha={alpha} cap={steps} tol={tol} patience={patience} "
+          f"reps={reps}")
+
+    rows = []
+    traces = {}  # n -> (trace, stop_step) for one example rep
+    for n in NS:
+        # Two independent long references: ref vs ref2 gives the noise floor.
+        ref = _reference(n, d, sigma, alpha, steps, seed0 + 9991)
+        ref2 = _reference(n, d, sigma, alpha, steps, seed0 + 9992)
+        floor_ks, _ = ks_2samp(ref.sum(1), ref2.sum(1))
+        floor_kl = _adjacency_esd_kl(ref, ref2)
+
+        for r in range(reps):
+            res = grow_graph(n, d=d, sigma=sigma, alpha=alpha, n_steps=steps,
+                             seed=seed0 + 1 + r, until_convergence=True,
+                             esd_tol=tol, patience=patience, store_snapshots=False)
+            p = res.params
+            ks, _ = ks_2samp(res.adj.sum(1), ref.sum(1))
+            kl = _adjacency_esd_kl(res.adj, ref)
+            rows.append(dict(n=n, rep=r, converged=p["converged"],
+                             stop_step=p["n_steps_run"], cap=steps,
+                             ks_vs_ref=float(ks), kl_vs_ref=kl,
+                             floor_ks=float(floor_ks), floor_kl=floor_kl,
+                             density=float(res.adj.sum() / (n * (n - 1)))))
+            if r == 0:
+                traces[n] = (p["esd_kl_trace"], p["n_steps_run"])
+        sub = [x for x in rows if x["n"] == n]
+        conv = np.mean([x["converged"] for x in sub])
+        steps_arr = np.array([x["stop_step"] for x in sub])
+        ks_arr = np.array([x["ks_vs_ref"] for x in sub])
+        print(f"  n={n:4d}: converged {conv*100:3.0f}%  stop_step "
+              f"{steps_arr.mean():4.1f} [{steps_arr.min()}-{steps_arr.max()}]  "
+              f"KS(stop,ref)={ks_arr.mean():.3f}  floor_KS={floor_ks:.3f}")
+
+    df = pd.DataFrame(rows)
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    df.to_csv(OUT_DIR / "esd_stop_eval.csv", index=False)
+
+    # ---- esd_tol sensitivity at the largest n -------------------------------
+    n_sens = NS[-1]
+    ref = _reference(n_sens, d, sigma, alpha, steps, seed0 + 9991)
+    print(f"\nesd_tol sensitivity at n={n_sens} (patience={patience}):")
+    for t in (5e-2, 2e-2, 1e-2, 5e-3, 1e-3):
+        ss, kk = [], []
+        for r in range(reps):
+            res = grow_graph(n_sens, d=d, sigma=sigma, alpha=alpha, n_steps=steps,
+                             seed=seed0 + 1 + r, until_convergence=True,
+                             esd_tol=t, patience=patience, store_snapshots=False)
+            ss.append(res.params["n_steps_run"])
+            ks, _ = ks_2samp(res.adj.sum(1), ref.sum(1))
+            kk.append(ks)
+        print(f"  tol={t:6.4f}: stop_step {np.mean(ss):4.1f}  KS(stop,ref)={np.mean(kk):.3f}")
+
+    _plot(df, traces, n=NS, sigma=sigma, alpha=alpha, tol=tol, out_dir=OUT_DIR)
+    print(f"\nWrote {OUT_DIR}/ (esd_stop_eval.csv, esd_stop_eval.png)")
+
+
+def _plot(df, traces, *, n, sigma, alpha, tol, out_dir):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, axes = plt.subplots(1, 3, figsize=(16, 4.6))
+    cmap = plt.cm.viridis
+    ns = sorted(df["n"].unique())
+    colors = {nn: cmap(i / max(1, len(ns) - 1)) for i, nn in enumerate(ns)}
+
+    # (a) stop step vs n
+    ax = axes[0]
+    g = df.groupby("n")["stop_step"]
+    mean = g.mean()
+    ax.plot(mean.index, mean.values, "o-", color="#0072B2", lw=1.8)
+    ax.fill_between(mean.index, g.min().values, g.max().values, color="#0072B2",
+                    alpha=0.15)
+    ax.set_xscale("log"); ax.set_xticks(ns); ax.set_xticklabels([str(v) for v in ns])
+    ax.set_xlabel("n (nodes)"); ax.set_ylabel("stop step")
+    ax.set_title("(a) steps to convergence vs n"); ax.grid(alpha=0.25)
+
+    # (b) KS(stop, ref) vs n with noise-floor band
+    ax = axes[1]
+    g2 = df.groupby("n")
+    ks_mean = g2["ks_vs_ref"].mean()
+    floor = g2["floor_ks"].first()
+    ax.plot(ks_mean.index, ks_mean.values, "o-", color="#D55E00", lw=1.8,
+            label="KS(stopped, reference)")
+    ax.plot(floor.index, floor.values, "s--", color="#000000", lw=1.2,
+            label="noise floor  KS(ref, ref$_2$)")
+    ax.set_xscale("log"); ax.set_xticks(ns); ax.set_xticklabels([str(v) for v in ns])
+    ax.set_xlabel("n (nodes)"); ax.set_ylabel("degree-distribution KS")
+    ax.set_title("(b) stopped graph vs stationary draw"); ax.grid(alpha=0.25)
+    ax.legend(fontsize=8)
+
+    # (c) example ESD-KL traces with stop marked
+    ax = axes[2]
+    for nn in ns:
+        tr, stop = traces[nn]
+        x = np.arange(1, len(tr) + 1)
+        ax.plot(x, tr, "-", color=colors[nn], lw=1.4, label=f"n={nn}")
+        ax.scatter([stop], [tr[stop - 1]], color=colors[nn], s=40, zorder=5,
+                   edgecolor="k", linewidth=0.5)
+    ax.axhline(tol, color="grey", ls=":", lw=1.0, label=f"tol={tol:g}")
+    ax.set_yscale("log"); ax.set_xlabel("growth step")
+    ax.set_ylabel(r"consecutive ESD-KL  $D_{\mathrm{KL}}(\rho_t\|\rho_{t-1})$")
+    ax.set_title("(c) ESD-KL trace (● = stop)"); ax.grid(alpha=0.25)
+    ax.legend(fontsize=8)
+
+    fig.suptitle(f"TLG ESD-KL convergence stopping — $\\sigma={sigma:g}$, "
+                 f"$\\alpha={alpha:g}$, tol={tol:g} (● marks early stop)", y=1.02)
+    fig.tight_layout()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_dir / "esd_stop_eval.png", dpi=200, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved {out_dir / 'esd_stop_eval.png'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/logit_graph/temporal.py
+++ b/src/logit_graph/temporal.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 
 import numpy as np
 from scipy.special import expit
+from scipy.stats import entropy
 import statsmodels.api as sm
 
 from .lg_features import FeatureMode, build_pair_dataset
@@ -36,6 +37,24 @@ from .offset_logit import aic_from_offset_fit
 
 # The feature carrying alpha (the degree slope).
 DEGREE_MODE: FeatureMode = "bounded"
+
+
+def _adjacency_esd_kl(cur: np.ndarray, prev: np.ndarray, nbins: int = 50) -> float:
+    """KL divergence between two graphs' adjacency eigenvalue spectral densities.
+
+    Both eigenvalue spectra are histogrammed on common bins spanning their combined
+    range; KL is computed with a 1e-10 floor (as in the convergence diagnostics).
+    """
+    ec = np.linalg.eigvalsh(cur)
+    ep = np.linalg.eigvalsh(prev)
+    lo = float(min(ec.min(), ep.min()))
+    hi = float(max(ec.max(), ep.max()))
+    if hi <= lo:
+        return 0.0
+    bins = np.linspace(lo, hi, nbins + 1)
+    hc, _ = np.histogram(ec, bins=bins, density=True)
+    hp, _ = np.histogram(ep, bins=bins, density=True)
+    return float(entropy(hc + 1e-10, hp + 1e-10))
 
 
 @dataclass
@@ -81,6 +100,10 @@ def grow_graph(
     record_design: bool = True,
     store_snapshots: bool = True,
     allow_removal: bool = True,
+    until_convergence: bool = False,
+    esd_tol: float = 1e-2,
+    patience: int = 3,
+    esd_nbins: int = 50,
 ) -> GrowthResult:
     """Grow a temporal Logit-Graph from a sparse ER seed (degree-only model).
 
@@ -97,6 +120,16 @@ def grow_graph(
     at-risk non-edges (outcome = formed?) and the graph grows monotonically toward
     saturation. With ``record_design`` the per-step dyads (D, outcome) are pooled into
     ``GrowthResult.X/y`` for estimation.
+
+    Stopping. By default the chain runs for exactly ``n_steps``. With
+    ``until_convergence=True`` it instead runs *until mixed* — ``n_steps`` becomes a
+    safety cap and the loop stops early once the adjacency-ESD KL divergence between
+    consecutive snapshots stays below ``esd_tol`` for ``patience`` consecutive steps
+    (the spectrum has stopped changing). ``GrowthResult.params`` then carries
+    ``n_steps_run``, ``converged``, and the per-step ``esd_kl_trace``. The criterion
+    is reliable for moderately large graphs (n ≳ 300); for small graphs the ESD itself
+    fluctuates between independent draws, so the noise floor is high and convergence
+    may not trigger before the cap.
     """
     rng = np.random.default_rng(seed)
     rows, cols = np.triu_indices(n, k=1)
@@ -110,7 +143,13 @@ def grow_graph(
     Xs: list[np.ndarray] = []
     ys: list[np.ndarray] = []
 
-    for _ in range(n_steps):
+    esd_kl_trace: list[float] = []
+    below = 0
+    converged = False
+    n_steps_run = n_steps
+
+    for step in range(n_steps):
+        prev_adj = adj.copy() if until_convergence else None
         D, labels = _degree_feature(adj, d, degree_mode)
         p = expit(sigma + alpha * D)
         draw = rng.random(p.shape[0]) < p
@@ -136,13 +175,24 @@ def grow_graph(
         if store_snapshots:
             snapshots.append(adj.copy())
 
+        if until_convergence:
+            kl = _adjacency_esd_kl(adj, prev_adj, esd_nbins)
+            esd_kl_trace.append(kl)
+            below = below + 1 if kl < esd_tol else 0
+            if below >= patience:
+                converged = True
+                n_steps_run = step + 1
+                break
+
     X = np.vstack(Xs) if Xs else np.empty((0, 1), dtype=np.float64)
     y = np.concatenate(ys) if ys else np.empty(0, dtype=np.int8)
-    return GrowthResult(
-        adj=adj, X=X, y=y, snapshots=snapshots,
-        params=dict(n=n, d=d, sigma=sigma, alpha=alpha, n_steps=n_steps,
-                    degree_mode=degree_mode, p0=p0, allow_removal=allow_removal),
-    )
+    params = dict(n=n, d=d, sigma=sigma, alpha=alpha, n_steps=n_steps,
+                  degree_mode=degree_mode, p0=p0, allow_removal=allow_removal)
+    if until_convergence:
+        params.update(until_convergence=True, esd_tol=esd_tol, patience=patience,
+                      n_steps_run=n_steps_run, converged=converged,
+                      esd_kl_trace=esd_kl_trace)
+    return GrowthResult(adj=adj, X=X, y=y, snapshots=snapshots, params=params)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -112,6 +112,33 @@ def test_removal_recovers_params():
     assert large.std() < small.std()
 
 
+def test_until_convergence_stops_early_and_records_trace():
+    """until_convergence stops before the cap once the ESD spectrum settles, and
+    records the convergence metadata; the fixed-step path is unchanged."""
+    cap = 60
+    res = grow_graph(400, d=0, sigma=-2.0, alpha=0.05, n_steps=cap, seed=7,
+                     until_convergence=True, esd_tol=1e-2, patience=3)
+    p = res.params
+    assert p["converged"] is True
+    assert p["n_steps_run"] < cap
+    assert len(p["esd_kl_trace"]) == p["n_steps_run"]
+    # the last `patience` recorded KL values are all below the tolerance
+    assert all(v < 1e-2 for v in p["esd_kl_trace"][-3:])
+
+    # fixed-step mode carries no convergence keys (backward compatible)
+    fixed = grow_graph(400, d=0, sigma=-2.0, alpha=0.05, n_steps=5, seed=7)
+    assert "converged" not in fixed.params
+
+
+def test_until_convergence_still_recovers_params():
+    """Stopping early at the ESD plateau does not bias estimation."""
+    res = grow_graph(400, d=0, sigma=-2.0, alpha=0.05, n_steps=60, seed=11,
+                     until_convergence=True)
+    out = fit_growth_from_result(res)
+    assert abs(out["sigma"] - (-2.0)) < 0.3
+    assert abs(out["alpha"] - 0.05) < 0.03
+
+
 def test_equilibrium_path_untouched():
     """Sanity: the equilibrium API still imports and runs (additive change)."""
     from logit_graph import simulate_graph


### PR DESCRIPTION
## What

Adds an `until_convergence` option to the core `grow_graph` so the temporal Logit-Graph can run **either for a fixed number of iterations (default) or until convergence**, judged by the **adjacency-ESD KL divergence**.

- `grow_graph(..., until_convergence=True, esd_tol=1e-2, patience=3)`: `n_steps` becomes a safety cap; the loop stops early once the consecutive-snapshot adjacency-ESD KL stays below `esd_tol` for `patience` steps.
- `GrowthResult.params` then carries `n_steps_run`, `converged`, and the per-step `esd_kl_trace`.
- Fixed-step mode is **unchanged** (no extra params, no per-step eigendecomposition — the cost is only paid when you opt in).

## Is it a good idea? (simulations)

`scripts/diagnostics/run_tlg_esd_stop_eval.py` (+ `make tlg-esd-stop-eval[-quick]`) evaluates it: stop-step vs n, bias of the stopped graph vs a long stationary draw (degree-KS vs the ref-vs-ref noise floor), and `esd_tol` sensitivity.

Full run (σ=−2, α=0.05, cap=60, tol=0.01, patience=3, 8 reps):

| n | converged | stop step | KS(stopped, ref) | noise floor KS |
|---|---|---|---|---|
| 100 | 0%   | 60 (cap)     | 0.122 | 0.150 |
| 200 | 38%  | 46.6 [19–60] | 0.098 | 0.040 |
| 400 | 100% | 5.2 [5–6]    | 0.059 | 0.068 |
| 750 | 100% | 5.0 [5–5]    | 0.046 | 0.029 |

`esd_tol` sensitivity at n=750: stop-step is 4–5 for **every** tol from 0.05 down to 0.001 — essentially insensitive.

**Verdict:** for moderately large graphs (n ≳ 400) it's a clear win — it stops within ~5 steps as soon as the chain mixes, is insensitive to the exact tolerance, and the stopped graph sits on the noise floor (i.e. statistically indistinguishable from a long stationary draw → **no bias from stopping early**). For small graphs (n ≲ 200) the per-draw ESD itself fluctuates, so the noise floor is high and the default `tol=0.01` is too strict — it safely falls back to the cap. A looser, n-aware tolerance recovers early stopping there.

## Tests

`test_until_convergence_stops_early_and_records_trace`, `test_until_convergence_still_recovers_params`; fixed-step mode asserted unchanged. Full suite green.

`runs/` is gitignored — no artifacts committed.