### PR TITLE
Split multidataset latent-TLG GIC into per-dataset scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,34 @@ tlg-twitch-gic-quick:  ## Smoke run of the TLG Twitch GIC experiment (PTBR, tiny
 	LG_TLGT_QUICK=1 \
 		$(UV) run python scripts/closedform/run_tlg_twitch_gic.py
 
+tlg-twitch-latent-gic:  ## Latent-TLG GIC (degree+community+latent) vs ER/BA/WS/KR/GRG/SBM on Twitch
+	$(UV) run python scripts/closedform/run_tlg_twitch_latent_gic.py
+
+tlg-twitter-latent-gic:  ## Latent-TLG GIC on a Twitter ego network
+	$(UV) run python scripts/closedform/run_tlg_twitter_latent_gic.py
+
+tlg-facebook-latent-gic:  ## Latent-TLG GIC on a Facebook ego network
+	$(UV) run python scripts/closedform/run_tlg_facebook_latent_gic.py
+
+tlg-arxiv-latent-gic:  ## Latent-TLG GIC on the arXiv HEP-Th citation network (BFS subgraph)
+	$(UV) run python scripts/closedform/run_tlg_arxiv_latent_gic.py
+
+tlg-gplus-latent-gic:  ## Latent-TLG GIC on a Google+ ego network (BFS subgraph)
+	$(UV) run python scripts/closedform/run_tlg_gplus_latent_gic.py
+
+tlg-connectome-latent-gic:  ## Latent-TLG GIC on an animal connectome (C. elegans)
+	$(UV) run python scripts/closedform/run_tlg_connectome_latent_gic.py
+
+tlg-human-latent-gic:  ## Latent-TLG GIC on a human connectome (OASIS3 brain)
+	$(UV) run python scripts/closedform/run_tlg_human_latent_gic.py
+
+tlg-all-latent-gic:  ## Latent-TLG GIC across all datasets + combined cross-dataset KL-rank summary
+	$(UV) run python scripts/closedform/run_tlg_all_latent_gic.py
+
+tlg-all-latent-gic-quick:  ## Smoke run of the latent-TLG GIC across all datasets (tiny)
+	LG_TLM_QUICK=1 \
+		$(UV) run python scripts/closedform/run_tlg_all_latent_gic.py
+
 tlg-convergence-diagnostics:  ## TLG (add+remove) convergence: chains from different initial densities mix to the same stationary distribution
 	$(UV) run python scripts/diagnostics/run_tlg_convergence_diagnostics.py
 

--- a/scripts/closedform/run_tlg_all_latent_gic.py
+++ b/scripts/closedform/run_tlg_all_latent_gic.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Run the latent-TLG GIC experiment across ALL datasets and write a combined ranking.
+
+Convenience orchestrator over the per-dataset entry points (run_tlg_<dataset>_latent_gic.py):
+runs every dataset in tlg_latent_gic_common.DATASETS (or LG_TLM_DATASETS) and writes, in
+addition to each dataset's table/plot, a cross-dataset KL-rank summary and a TLG-vs-SBM
+head-to-head under runs/tlg_latent_gic/.
+
+  make tlg-all-latent-gic        full run (all datasets + summary)
+  make tlg-all-latent-gic-quick  smoke
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import tlg_latent_gic_common as C  # noqa: E402
+
+if __name__ == "__main__":
+    C.run_all()

--- a/scripts/closedform/run_tlg_arxiv_latent_gic.py
+++ b/scripts/closedform/run_tlg_arxiv_latent_gic.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Latent-TLG GIC experiment on the arXiv HEP-Th citation network (BFS subgraph) (one representative graph).
+
+Fits the unified, identifiable TLG (degree + coarse/fine Louvain community + latent
+adjacency-spectral-embedding feature) and ranks it against ER/BA/WS/KR/GRG/SBM by the
+spectral GIC / raw KL, using the fair ensemble-mean estimator. Model, optimizations and
+estimator live in tlg_latent_gic_common; this entry point only selects the dataset.
+
+Writes runs/tlg_latent_gic/arxiv_table.csv + arxiv_gic_bar.png (gitignored). Env knobs
+(shared): LG_TLM_{QUICK,NRUNS,CAP,K,SEARCH,KLIST,KERNELS,FINE_RES,FAST_SPECTRAL,SEED}.
+
+  make tlg-arxiv-latent-gic        full run
+  make tlg-arxiv-latent-gic-quick  smoke
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import tlg_latent_gic_common as C  # noqa: E402
+
+if __name__ == "__main__":
+    C.run_one("arxiv", C.DATASETS["arxiv"])

--- a/scripts/closedform/run_tlg_connectome_latent_gic.py
+++ b/scripts/closedform/run_tlg_connectome_latent_gic.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Latent-TLG GIC experiment on the animal connectome (C. elegans, graphml) (one representative graph).
+
+Fits the unified, identifiable TLG (degree + coarse/fine Louvain community + latent
+adjacency-spectral-embedding feature) and ranks it against ER/BA/WS/KR/GRG/SBM by the
+spectral GIC / raw KL, using the fair ensemble-mean estimator. Model, optimizations and
+estimator live in tlg_latent_gic_common; this entry point only selects the dataset.
+
+Writes runs/tlg_latent_gic/connectome_table.csv + connectome_gic_bar.png (gitignored). Env knobs
+(shared): LG_TLM_{QUICK,NRUNS,CAP,K,SEARCH,KLIST,KERNELS,FINE_RES,FAST_SPECTRAL,SEED}.
+
+  make tlg-connectome-latent-gic        full run
+  make tlg-connectome-latent-gic-quick  smoke
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import tlg_latent_gic_common as C  # noqa: E402
+
+if __name__ == "__main__":
+    C.run_one("connectome", C.DATASETS["connectome"])

--- a/scripts/closedform/run_tlg_facebook_latent_gic.py
+++ b/scripts/closedform/run_tlg_facebook_latent_gic.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Latent-TLG GIC experiment on the Facebook ego network (SNAP) (one representative graph).
+
+Fits the unified, identifiable TLG (degree + coarse/fine Louvain community + latent
+adjacency-spectral-embedding feature) and ranks it against ER/BA/WS/KR/GRG/SBM by the
+spectral GIC / raw KL, using the fair ensemble-mean estimator. Model, optimizations and
+estimator live in tlg_latent_gic_common; this entry point only selects the dataset.
+
+Writes runs/tlg_latent_gic/facebook_table.csv + facebook_gic_bar.png (gitignored). Env knobs
+(shared): LG_TLM_{QUICK,NRUNS,CAP,K,SEARCH,KLIST,KERNELS,FINE_RES,FAST_SPECTRAL,SEED}.
+
+  make tlg-facebook-latent-gic        full run
+  make tlg-facebook-latent-gic-quick  smoke
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import tlg_latent_gic_common as C  # noqa: E402
+
+if __name__ == "__main__":
+    C.run_one("facebook", C.DATASETS["facebook"])

--- a/scripts/closedform/run_tlg_gplus_latent_gic.py
+++ b/scripts/closedform/run_tlg_gplus_latent_gic.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Latent-TLG GIC experiment on the Google+ ego network (SNAP, BFS subgraph) (one representative graph).
+
+Fits the unified, identifiable TLG (degree + coarse/fine Louvain community + latent
+adjacency-spectral-embedding feature) and ranks it against ER/BA/WS/KR/GRG/SBM by the
+spectral GIC / raw KL, using the fair ensemble-mean estimator. Model, optimizations and
+estimator live in tlg_latent_gic_common; this entry point only selects the dataset.
+
+Writes runs/tlg_latent_gic/gplus_table.csv + gplus_gic_bar.png (gitignored). Env knobs
+(shared): LG_TLM_{QUICK,NRUNS,CAP,K,SEARCH,KLIST,KERNELS,FINE_RES,FAST_SPECTRAL,SEED}.
+
+  make tlg-gplus-latent-gic        full run
+  make tlg-gplus-latent-gic-quick  smoke
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import tlg_latent_gic_common as C  # noqa: E402
+
+if __name__ == "__main__":
+    C.run_one("gplus", C.DATASETS["gplus"])

--- a/scripts/closedform/run_tlg_human_latent_gic.py
+++ b/scripts/closedform/run_tlg_human_latent_gic.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Latent-TLG GIC experiment on the human connectome (OASIS3 brain, graphml) (one representative graph).
+
+Fits the unified, identifiable TLG (degree + coarse/fine Louvain community + latent
+adjacency-spectral-embedding feature) and ranks it against ER/BA/WS/KR/GRG/SBM by the
+spectral GIC / raw KL, using the fair ensemble-mean estimator. Model, optimizations and
+estimator live in tlg_latent_gic_common; this entry point only selects the dataset.
+
+Writes runs/tlg_latent_gic/human_table.csv + human_gic_bar.png (gitignored). Env knobs
+(shared): LG_TLM_{QUICK,NRUNS,CAP,K,SEARCH,KLIST,KERNELS,FINE_RES,FAST_SPECTRAL,SEED}.
+
+  make tlg-human-latent-gic        full run
+  make tlg-human-latent-gic-quick  smoke
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import tlg_latent_gic_common as C  # noqa: E402
+
+if __name__ == "__main__":
+    C.run_one("human", C.DATASETS["human"])

--- a/scripts/closedform/run_tlg_twitch_latent_gic.py
+++ b/scripts/closedform/run_tlg_twitch_latent_gic.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Latent-TLG GIC experiment on the Twitch PTBR social network (one representative graph).
+
+Fits the unified, identifiable TLG (degree + coarse/fine Louvain community + latent
+adjacency-spectral-embedding feature) and ranks it against ER/BA/WS/KR/GRG/SBM by the
+spectral GIC / raw KL, using the fair ensemble-mean estimator. Model, optimizations and
+estimator live in tlg_latent_gic_common; this entry point only selects the dataset.
+
+Writes runs/tlg_latent_gic/twitch_table.csv + twitch_gic_bar.png (gitignored). Env knobs
+(shared): LG_TLM_{QUICK,NRUNS,CAP,K,SEARCH,KLIST,KERNELS,FINE_RES,FAST_SPECTRAL,SEED}.
+
+  make tlg-twitch-latent-gic        full run
+  make tlg-twitch-latent-gic-quick  smoke
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import tlg_latent_gic_common as C  # noqa: E402
+
+if __name__ == "__main__":
+    C.run_one("twitch", C.DATASETS["twitch"])

--- a/scripts/closedform/run_tlg_twitter_latent_gic.py
+++ b/scripts/closedform/run_tlg_twitter_latent_gic.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Latent-TLG GIC experiment on the Twitter ego network (SNAP) (one representative graph).
+
+Fits the unified, identifiable TLG (degree + coarse/fine Louvain community + latent
+adjacency-spectral-embedding feature) and ranks it against ER/BA/WS/KR/GRG/SBM by the
+spectral GIC / raw KL, using the fair ensemble-mean estimator. Model, optimizations and
+estimator live in tlg_latent_gic_common; this entry point only selects the dataset.
+
+Writes runs/tlg_latent_gic/twitter_table.csv + twitter_gic_bar.png (gitignored). Env knobs
+(shared): LG_TLM_{QUICK,NRUNS,CAP,K,SEARCH,KLIST,KERNELS,FINE_RES,FAST_SPECTRAL,SEED}.
+
+  make tlg-twitter-latent-gic        full run
+  make tlg-twitter-latent-gic-quick  smoke
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import tlg_latent_gic_common as C  # noqa: E402
+
+if __name__ == "__main__":
+    C.run_one("twitter", C.DATASETS["twitter"])

--- a/scripts/closedform/tlg_latent_gic_common.py
+++ b/scripts/closedform/tlg_latent_gic_common.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
-"""Fit a representative network from each dataset with the unified Temporal Logit-Graph
-(TLG) and rank families by the spectral GIC / raw KL.
+"""Shared machinery for the per-dataset latent-TLG GIC experiments.
+
+This module holds the unified Temporal Logit-Graph (TLG) fit + the baseline families +
+the (lossless) performance optimizations; the per-dataset entry points
+(run_tlg_<dataset>_latent_gic.py) only supply a loader and call :func:`run_one`. Run all
+datasets + a combined ranking with run_tlg_all_latent_gic.py.
+
+Fit a representative network from a dataset with the unified Temporal Logit-Graph (TLG)
+and rank families by the spectral GIC / raw KL.
 
 The TLG here is the IDENTIFIABLE, SBM-beating model with three exogenous feature groups
 (all recoverable by MLE in the add+remove Bernoulli model — validated on synthetic data;
@@ -86,7 +93,7 @@ from logit_graph.lg_features import build_pair_dataset  # noqa: E402
 from logit_graph.sbm import generate_sbm_from_real  # noqa: E402
 import run_tlg_twitch_gic as tw  # noqa: E402  (closed_form_params, _baseline_generators, _community_feature)
 
-OUT_DIR = _here / "runs" / "tlg_multidataset_gic"
+OUT_DIR = _here / "runs" / "tlg_latent_gic"
 DATA = _repo_root / "data"
 
 
@@ -351,10 +358,10 @@ def baseline_gic(G, gen_fn, n_params, real_den, scorer):
 
 
 # --------------------------------------------------------------------------- driver
-def process_dataset(name):
+def process_dataset(name, loader):
     t0 = time.perf_counter()
     try:
-        G = DATASETS[name]()
+        G = loader()
     except Exception as ex:
         log(f"  {name}: load failed ({ex}) — skipping")
         return None
@@ -408,20 +415,58 @@ def process_dataset(name):
             "gic_penalty", "n_params", "edges", "density", "clustering",
             "assortativity", "param"]
     df[cols].to_csv(OUT_DIR / f"{name}_table.csv", index=False)
+    _plot_bar(df, name, OUT_DIR / f"{name}_gic_bar.png")
     log(df[cols].to_string(index=False))
     log(f"  ({time.perf_counter()-t0:.1f}s)")
     return df[cols]
 
 
-def main():
-    sel = os.environ.get("LG_TLM_DATASETS")
-    names = sel.split(",") if sel else list(DATASETS)
-    log(f"TLG multi-dataset GIC (unified D+community+latent, fair ensemble-mean KL)  "
-        f"quick={QUICK} datasets={names} NRUNS={NRUNS} cap={CAP} K={TLG_K} "
-        f"search={SEARCH} klist={KLIST} seed={SEED}")
+# --------------------------------------------------------------------------- plot
+CB = {"TLG": "#0072B2", "ER": "#E69F00", "BA": "#009E73", "WS": "#CC79A7",
+      "KR": "#D55E00", "GRG": "#56B4E9", "SBM": "#000000"}
+
+
+def _plot_bar(df, name, out_path):
+    """GIC by family (ranked; stacked 2*KL fit + 2*n_params penalty terms)."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    m = df[df["model"] != "Real"].sort_values("gic")
+    fig, ax = plt.subplots(figsize=(8, 4.6))
+    x = range(len(m))
+    ax.bar(x, m["gic_fit"], color=[CB.get(mm, "#888") for mm in m["model"]],
+           label="2·KL (fit)")
+    ax.bar(x, m["gic_penalty"], bottom=m["gic_fit"], color="#cccccc",
+           label="2·n_params (penalty)", edgecolor="white")
+    ax.set_xticks(list(x)); ax.set_xticklabels(m["model"])
+    ax.set_ylabel("GIC  (= 2·KL + 2·n_params)")
+    ax.set_title(f"{name}: GIC by family (lower = better; stacked terms)")
+    ax.legend(fontsize=9); ax.grid(alpha=0.25, axis="y")
+    for i, (_, r) in enumerate(m.iterrows()):
+        ax.text(i, r["gic"], f"{r['gic']:.2f}", ha="center", va="bottom", fontsize=8)
+    fig.tight_layout(); fig.savefig(out_path, dpi=200, bbox_inches="tight")
+    plt.close(fig)
+
+
+# --------------------------------------------------------------------------- runners
+def run_one(name, loader):
+    """Run the latent-TLG GIC comparison for a single dataset (the per-dataset entry
+    point). Writes <name>_table.csv + <name>_gic_bar.png under OUT_DIR."""
+    log(f"latent-TLG GIC [{name}] (unified D+community+latent, fair ensemble-mean KL)  "
+        f"quick={QUICK} NRUNS={NRUNS} cap={CAP} K={TLG_K} search={SEARCH} "
+        f"kernels={KERNELS} klist={KLIST} fast_spectral={FAST_SPECTRAL} seed={SEED}")
+    return process_dataset(name, loader)
+
+
+def run_all(names=None):
+    """Run every selected dataset and write a combined cross-dataset KL-rank summary."""
+    names = names or (os.environ.get("LG_TLM_DATASETS").split(",")
+                      if os.environ.get("LG_TLM_DATASETS") else list(DATASETS))
+    log(f"latent-TLG GIC [ALL] datasets={names} quick={QUICK} NRUNS={NRUNS} cap={CAP} "
+        f"K={TLG_K} search={SEARCH} kernels={KERNELS} klist={KLIST} seed={SEED}")
     tables = []
     for name in names:
-        t = process_dataset(name)
+        t = process_dataset(name, DATASETS[name])
         if t is not None:
             tables.append(t)
     if not tables:
@@ -453,7 +498,3 @@ def main():
         log(f"  {ds:12} TLG={t:.4f} SBM={s:.4f} -> {w}")
     log(f"  TLG beats SBM on {nwin}/{len(wins)} datasets (raw KL)")
     log(f"\nWrote {OUT_DIR}/")
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## What

Splits the monolithic `run_tlg_multidataset_gic.py` into **one runnable script per dataset**, mirroring the `run_lg_<dataset>_closedform.py` layout, while keeping all the (lossless) performance optimizations from #73. One PR.

## Structure

- **`tlg_latent_gic_common.py`** (renamed from `run_tlg_multidataset_gic.py`) — now an importable library holding the unified latent-TLG fit, the baseline families, the estimator, and the optimizations. `process_dataset(name, loader)` takes a loader; `run_one(name, loader)` runs a single dataset; `run_all()` runs every dataset + the combined cross-dataset summary. Adds a per-dataset GIC bar plot (stacked 2·KL + 2·n_params), matching the original closed-form scripts.
- **7 per-dataset entry scripts** — `run_tlg_{twitch,twitter,facebook,arxiv,gplus,connectome,human}_latent_gic.py`, each ~20 lines that select the dataset and call `run_one`.
- **`run_tlg_all_latent_gic.py`** — convenience orchestrator (`run_all`) preserving the combined KL-rank summary + TLG-vs-SBM tally.
- **Makefile** — `tlg-<dataset>-latent-gic` for each, plus `tlg-all-latent-gic[-quick]`.

## Why a shared module (not 7 self-contained copies)

The original `run_lg_*` scripts are self-contained, but the TLG machinery is ~350 identical lines across datasets — 7 verbatim copies would mean fixing every bug 7×. A shared module + thin entry points gives the same "one run per dataset" UX without the duplication.

## Optimizations preserved

Unchanged from #73 and now shared by every per-dataset script:
- Separable d=1 degree feature (vectorized; validated bit-identical, maxdiff 0).
- ASE eigendecomposition computed once per graph.
- Opt-in `LG_TLM_FAST_SPECTRAL` direct-adjacency Laplacian for the KPM path.

## Validation

- `run_tlg_human_latent_gic.py` reproduces the monolith's numbers exactly (human dot k=8 KL=0.6072, full table identical) and writes `human_table.csv` + `human_gic_bar.png`.
- `run_tlg_all_latent_gic.py` on `human,twitter` produces the per-dataset tables, the combined KL-rank pivot, and the TLG-vs-SBM tally (2/2).

## Notes
- Output under `runs/tlg_latent_gic/` (gitignored): `<dataset>_table.csv`, `<dataset>_gic_bar.png`, and (from the all-runner) `all_tables.csv` + `summary_kl_rank.csv`.
- Shared env knobs unchanged: `LG_TLM_{QUICK,NRUNS,CAP,K,SEARCH,KLIST,KERNELS,FINE_RES,FAST_SPECTRAL,SEED,DATASETS}`.