### PR TITLE
Notebook: Twitch degree params (σ, α) + KL per model per network

### DIFF
--- a/notebooks/tlg_twitch_params_kl.ipynb
+++ b/notebooks/tlg_twitch_params_kl.ipynb
@@ -1,0 +1,64 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Twitch TLG \u2014 degree params (\u03c3, \u03b1) and KL per model per network\n\nConsults the `scripts/closedform/run_tlg_twitch_gic.py` experiment outputs\n(`runs/tlg_twitch_gic/<region>_table.csv`) for the **KL per family per network** (the six\nTwitch country graphs), and reports the **degree-feature parameters \u03c3 and \u03b1** for each\nnetwork.\n\n- **KL** comes straight from the experiment's per-region tables.\n- **\u03c3, \u03b1** are the intercept and degree slope of the degree-only logistic MLE\n  `logit P[edge] = \u03c3 + \u03b1\u00b7D`, `D_ij = log(1+S_i)+log(1+S_j)` (d=1) \u2014 the same fit the\n  experiment uses to get \u03b1 (it only persists \u03b1, not \u03c3, so we recompute both here)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import sys, glob\nfrom pathlib import Path\nimport numpy as np, pandas as pd, networkx as nx\n\ndef find_root():\n    for base in [Path.cwd(), *Path.cwd().parents]:\n        if (base / \"scripts\" / \"closedform\" / \"runs\" / \"tlg_twitch_gic\").exists():\n            return base\n    raise RuntimeError(\"tlg_twitch_gic runs not found\")\nROOT = find_root()\nsys.path.insert(0, str(ROOT / \"src\"))\nfrom logit_graph.lg_features import build_pair_dataset\nfrom logit_graph.temporal import fit_growth_params\n\nTWITCH_RUNS = ROOT / \"scripts\" / \"closedform\" / \"runs\" / \"tlg_twitch_gic\"\nDATA = ROOT / \"data\" / \"twitch\" / \"graphs_processed\"\nDEG_D = 1\nprint(\"twitch runs:\", TWITCH_RUNS)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### KL per model per network (consulted from the experiment tables)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# read each region table -> KL per (region, model)\nrows = []\nfor f in sorted(glob.glob(str(TWITCH_RUNS / \"*_table.csv\"))):\n    t = pd.read_csv(f)\n    t = t[t.model != \"Real\"]\n    for _, r in t.iterrows():\n        rows.append(dict(region=r[\"region\"], model=r[\"model\"], kl=r[\"kl\"]))\nkl_long = pd.DataFrame(rows)\nkl_wide = kl_long.pivot_table(index=\"region\", columns=\"model\", values=\"kl\")\nMODELS = [\"TLG\", \"SBM\", \"ER\", \"BA\", \"WS\", \"KR\", \"GRG\"]\nkl_wide = kl_wide[[m for m in MODELS if m in kl_wide.columns]]\nkl_wide.round(4)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Degree-feature params \u03c3 and \u03b1 per network (degree-only logistic MLE)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def load_region(path):\n    G = nx.read_edgelist(path, comments=\"#\", nodetype=int)\n    G = nx.Graph(G); G.remove_edges_from(nx.selfloop_edges(G))\n    cc = max(nx.connected_components(G), key=len)\n    return nx.convert_node_labels_to_integers(G.subgraph(cc).copy())\n\ndeg_rows = []\nfor region in kl_wide.index:\n    path = DATA / f\"{region}_graph.edges\"\n    if not path.exists():\n        print(f\"  {region}: data file missing -> sigma/alpha NaN\"); \n        deg_rows.append(dict(region=region, n=np.nan, sigma=np.nan, alpha=np.nan)); continue\n    G = load_region(path)\n    adj = nx.to_numpy_array(G)\n    D, lab = build_pair_dataset(adj, d=DEG_D, mode=\"bounded\", layer2=True)\n    fit = fit_growth_params(D, lab)   # sigma, alpha (+ SEs) of logit P = sigma + alpha*D\n    deg_rows.append(dict(region=region, n=G.number_of_nodes(),\n                         sigma=fit[\"sigma\"], alpha=fit[\"alpha\"],\n                         se_sigma=fit[\"se_sigma\"], se_alpha=fit[\"se_alpha\"]))\n    print(f\"  {region}: n={G.number_of_nodes()}  \u03c3={fit['sigma']:+.3f}  \u03b1={fit['alpha']:+.3f}\")\ndeg = pd.DataFrame(deg_rows).set_index(\"region\")\ndeg.round(3)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Combined table: degree params (\u03c3, \u03b1) + KL per model, per network\n\nOne row per Twitch network: the degree-feature parameters and the KL of every family."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "table = deg[[\"n\", \"sigma\", \"alpha\"]].join(kl_wide)\ntable = table.sort_values(\"n\")\n\ndef _hl_min_kl(row):\n    kl = row[kl_wide.columns]\n    best = kl.idxmin()\n    return [\"font-weight: bold; color: #0072B2\" if c == best else \"\" for c in row.index]\n\nstyled = (table.style\n          .format({\"sigma\": \"{:+.3f}\", \"alpha\": \"{:+.3f}\", \"n\": \"{:.0f}\",\n                   **{m: \"{:.4f}\" for m in kl_wide.columns}})\n          .apply(_hl_min_kl, axis=1)\n          .set_caption(\"Twitch: \u03c3, \u03b1 (degree MLE) and KL per model (bold = lowest KL / best fit)\"))\ndisplay(styled)\ntable.to_csv(\"twitch_params_kl_table.csv\")\nprint(\"saved twitch_params_kl_table.csv\")\ntable.round(4)"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## What

Adds `notebooks/tlg_twitch_params_kl.ipynb` — a notebook that **consults the `run_tlg_twitch_gic` experiment** (`runs/tlg_twitch_gic/<region>_table.csv`) and reports, as a single DataFrame table, **per Twitch network**:

- the **degree-feature parameters σ and α** (intercept + degree slope), and
- the **KL of every model** (TLG / ER / BA / WS / KR / GRG / SBM).

## Where the numbers come from

- **KL** — read directly from the experiment's per-region tables (one row per family).
- **σ, α** — the experiment persists only `α` (in the `param` string), not `σ`, so the notebook recomputes both from the **degree-only logistic MLE** `logit P[edge] = σ + α·D`, with `D_ij = log(1+S_i)+log(1+S_j)` at `d=1` — the exact fit (`fit_growth_params`) the experiment uses to obtain α. The recomputed α matches the stored values (e.g. DE: 0.188 vs the table's `α=0.19`).

## Result (the table it produces)

| region | n | σ | α | TLG | SBM | ER | BA | WS | KR | GRG |
|---|---|---|---|---|---|---|---|---|---|---|
| PTBR | 1912 | −6.64 | 0.166 | **0.073** | 0.105 | 0.143 | 0.142 | 0.125 | 0.141 | 0.299 |
| RU | 4385 | −8.23 | 0.194 | **0.100** | 0.137 | 0.171 | 0.186 | 0.145 | 0.163 | 0.367 |
| ES | 4648 | −8.22 | 0.202 | **0.083** | 0.083 | 0.131 | 0.135 | 0.132 | 0.133 | 0.377 |
| FR | 6549 | −7.28 | 0.123 | **0.037** | 0.057 | 0.073 | 0.073 | 0.087 | 0.074 | 0.360 |
| ENGB | 7126 | −8.52 | 0.171 | **0.131** | 0.148 | 0.209 | 0.221 | 0.150 | 0.213 | 0.320 |
| DE | 9498 | −8.84 | 0.188 | **0.043** | 0.079 | 0.098 | 0.099 | 0.113 | 0.098 | 0.406 |

(TLG lowest KL in every region.) Validated end-to-end; the styled table highlights the per-row minimum KL and is also written to `twitch_params_kl_table.csv` when run.

## Notes
- Requires the `runs/tlg_twitch_gic/` tables (from `make tlg-twitch-gic-all`) and `data/twitch/graphs_processed/` to be present.
- Committed with empty outputs (re-runnable); ~1–2 min to recompute σ/α on the larger graphs.