### PR TITLE
ROC plots: drop the Wald-test label from the titles

### DIFF
--- a/scripts/experiments/run_tlg_roc_experiments.py
+++ b/scripts/experiments/run_tlg_roc_experiments.py
@@ -324,7 +324,7 @@ def _plot(df, sweep, out_path):
                      f"$|\\Delta\\alpha|={abs(ALPHA2_SAMPLE-ALPHA1):g}$")
     title = ("TLG ROC: effect size" if sweep == "effect"
              else "TLG ROC: sample size")
-    fig.suptitle(f"{title} ({METHOD} test; null = chance diagonal){fixed_txt}",
+    fig.suptitle(f"{title} (null = chance diagonal){fixed_txt}",
                  y=1.01)
     fig.tight_layout()
     fig.savefig(out_path, dpi=200, bbox_inches="tight")


### PR DESCRIPTION
Removes the '(wald test; ...)' mention from the `roc_effect` / `roc_sample` suptitles in `run_tlg_roc_experiments.py`, keeping '(null = chance diagonal)'. Plot-only change — the experiment data is unchanged; the plots were regenerated from the cached p-values (`LG_TLGROC_USE_CACHE=1`, no re-simulation). Titles now read 'TLG ROC: effect size (null = chance diagonal)' and 'TLG ROC: sample size (null = chance diagonal) — |Δσ|=0.1, |Δα|=0.02'.