### PR TITLE
Dim-red experiment: per-family graph ensembles vs real Twitch graphs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,9 @@ tlg-identifiability-quick:  ## Smoke run of the latent-TLG identifiability exper
 	LG_TLI_QUICK=1 \
 		$(UV) run python scripts/experiments/run_tlg_latent_identifiability.py
 
+tlg-dimred-twitch:  ## Dim-red (PCA/t-SNE/UMAP per Twitch network) of per-family graph ensembles vs the real graph in structural-feature space
+	$(UV) run python scripts/dim_red/run_tlg_dimred_twitch.py
+
 tlg-roc:  ## TLG ROC: group-difference tests on sigma AND alpha (effect-size + sample-size; single-graph Wald SE)
 	$(UV) run python scripts/experiments/run_tlg_roc_experiments.py
 

--- a/Makefile
+++ b/Makefile
@@ -298,8 +298,11 @@ tlg-identifiability-quick:  ## Smoke run of the latent-TLG identifiability exper
 	LG_TLI_QUICK=1 \
 		$(UV) run python scripts/experiments/run_tlg_latent_identifiability.py
 
-tlg-dimred-twitch:  ## Dim-red (PCA/t-SNE/UMAP per Twitch network) of per-family graph ensembles vs the real graph in structural-feature space
-	$(UV) run python scripts/dim_red/run_tlg_dimred_twitch.py
+tlg-dimred-twitch:  ## Dim-red (PCA/t-SNE/UMAP per network) of per-family graph ensembles vs the real Twitch graphs in structural-feature space
+	LG_DR_DATASET=twitch $(UV) run python scripts/dim_red/run_tlg_dimred.py
+
+tlg-dimred-connectome:  ## Same dim-red experiment on the animal connectomes dataset
+	LG_DR_DATASET=connectome $(UV) run python scripts/dim_red/run_tlg_dimred.py
 
 tlg-roc:  ## TLG ROC: group-difference tests on sigma AND alpha (effect-size + sample-size; single-graph Wald SE)
 	$(UV) run python scripts/experiments/run_tlg_roc_experiments.py

--- a/scripts/diagnostics/replot_tlg_convergence.py
+++ b/scripts/diagnostics/replot_tlg_convergence.py
@@ -1,0 +1,51 @@
+"""Re-plot the TLG convergence diagnostics from the cached CSV (no experiment rerun).
+
+Reads runs/tlg_convergence/convergence.csv and regenerates the 3-panel figure with an
+updated, cleaner title, writing straight to the paper's image folder.
+"""
+import sys
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+
+CSV = Path(__file__).parent / "runs" / "tlg_convergence" / "convergence.csv"
+OUT = Path(sys.argv[1])  # destination PNG path
+
+# Simulation parameters (from the cached run; not re-estimated here).
+N, D, SIGMA, ALPHA = 200, 0, -2, 0.05
+
+df = pd.read_csv(CSV)
+cmap = plt.cm.viridis
+markers = ["o", "s", "^", "D", "v", "P", "X", "*"]
+p0s = sorted(df["p0"].unique())
+colors = {p: cmap(i / max(1, len(p0s) - 1)) for i, p in enumerate(p0s)}
+
+panels = [("spec_dist", "Spectral distance to reference", "(a) Laplacian spectrum"),
+          ("ks", "KS statistic (degree dist.)", "(b) Degree distribution"),
+          ("esd_kl", r"$D_{\mathrm{KL}}(\rho_t \,\|\, \rho_{\mathrm{ref}})$",
+           "(c) Adjacency ESD divergence")]
+
+fig, axes = plt.subplots(1, 3, figsize=(16, 4.6))
+for ax, (key, ylabel, title) in zip(axes, panels):
+    for i, p in enumerate(p0s):
+        sub = df[df["p0"] == p].sort_values("step")
+        ax.plot(sub["step"], sub[key], color=colors[p],
+                marker=markers[i % len(markers)], markevery=max(1, len(sub) // 8),
+                ms=5, alpha=0.85, label=f"$p_0={p:g}$")
+    ax.set_xlabel("growth step")
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.grid(alpha=0.25)
+    ax.legend(fontsize=8, title="Initial ER $p_0$", title_fontsize=8)
+
+fig.suptitle(
+    f"MCMC convergence: $n={N}$, $d={D}$, $\\sigma={SIGMA:g}$, $\\alpha={ALPHA:g}$; "
+    f"{len(p0s)} chains from different initial densities", y=1.03)
+fig.tight_layout()
+OUT.parent.mkdir(parents=True, exist_ok=True)
+fig.savefig(OUT, dpi=200, bbox_inches="tight")
+plt.close(fig)
+print(f"Saved {OUT}")

--- a/scripts/dim_red/run_tlg_dimred.py
+++ b/scripts/dim_red/run_tlg_dimred.py
@@ -32,9 +32,10 @@ Output under runs/tlg_dimred_<DATASET>/ (gitignored):
                         beside one dim-red embedding (LG_DR_DIST_METHOD) of the focus network
 
 Env: LG_DR_DATASET (twitch), LG_DR_NETWORKS (subset; default all), LG_DR_NREPS (10),
-LG_DR_FAMILIES (ER,BA,WS,KR,GRG,SBM,TLG), LG_DR_COLINEAR_THRESH (0.85), LG_DR_VIF_THRESH (5),
-LG_DR_MAIN_METHOD (t-SNE), LG_DR_FOCUS_REGION (network in the distance fig; default first),
-LG_DR_SEED (12345), LG_DR_TSNE_PERPLEXITY (30).
+LG_DR_FAMILIES (ER,BA,WS,KR,GRG,SBM,TLG), LG_DR_FEATURE_MODE (balanced | vif; default
+balanced = one representative per structural family), LG_DR_COLINEAR_THRESH (0.85),
+LG_DR_VIF_THRESH (5), LG_DR_MAIN_METHOD (t-SNE), LG_DR_DIST_METHOD (UMAP), LG_DR_FOCUS_REGION
+(network in the distance fig; default first), LG_DR_SEED (12345), LG_DR_TSNE_PERPLEXITY (30).
 """
 from __future__ import annotations
 
@@ -105,6 +106,22 @@ PERPLEXITY = _float("LG_DR_TSNE_PERPLEXITY", 30.0)
 MAIN_METHOD = os.environ.get("LG_DR_MAIN_METHOD", "t-SNE")  # method for the main figure
 FOCUS_REGION = os.environ.get("LG_DR_FOCUS_REGION", "")     # network shown in the distance fig
 DIST_METHOD = os.environ.get("LG_DR_DIST_METHOD", "UMAP")   # the single embedding shown there
+FEATURE_MODE = os.environ.get("LG_DR_FEATURE_MODE", "balanced")  # "balanced" | "vif"
+
+# Structural families -> candidate members (preference order). "balanced" selection forces
+# ONE representative per family so every structural axis is represented (in particular the
+# community/clustering axes that a purely statistical VIF prune can silently delete) -- fair
+# to all community-aware models, not tuned for any one family.
+_FEATURE_FAMILIES = {
+    "degree_level":        ["avg_degree", "density"],
+    "degree_heterogeneity": ["degree_cv", "degree_gini", "degree_skew", "degree_kurt",
+                             "leaf_frac"],
+    "mixing":              ["assortativity", "avg_neighbor_deg"],
+    "clustering":          ["clustering", "transitivity", "triangle_density"],
+    "community":           ["modularity", "n_comm_norm"],
+    "cohesion":            ["max_core", "mean_core", "frac_in_lcc"],
+    "spectral":            ["algebraic_conn", "spectral_gap", "spectral_radius"],
+}
 
 
 def log(*a):
@@ -307,6 +324,17 @@ def _prune_colinear(F, thresh):
             break
         cur.remove(worst)
     return cur
+
+
+def _select_balanced(F):
+    """One representative per structural family (first candidate present), so every axis --
+    including community/modularity and clustering -- is represented. Returns (keep, mapping)."""
+    keep, mapping = [], {}
+    for fam, members in _FEATURE_FAMILIES.items():
+        for m in members:
+            if m in F.columns:
+                keep.append(m); mapping[fam] = m; break
+    return keep, mapping
 
 
 # Explicit colorblind-safe (Okabe-Ito) color + marker per family. The two models of
@@ -583,7 +611,10 @@ def dimred(records):
     OUT.mkdir(parents=True, exist_ok=True)
     pd.concat([meta, F], axis=1).to_csv(OUT / "features.csv", index=False)
 
-    keep = _prune_colinear(F, THRESH)
+    if FEATURE_MODE == "vif":
+        keep = _prune_colinear(F, THRESH); mapping = None
+    else:
+        keep, mapping = _select_balanced(F)
     (OUT / "kept_features.txt").write_text("\n".join(keep))
     # diagnostics: max pairwise |corr| and max VIF AMONG THE KEPT features
     from sklearn.preprocessing import StandardScaler
@@ -591,10 +622,12 @@ def dimred(records):
     kept_corr = Zk.corr().abs()
     max_pair = (kept_corr.where(~np.eye(len(keep), dtype=bool)).max().max())
     max_vif = max(_vif(Zk).values())
-    log(f"\nfeatures: {F.shape[1]} candidates -> {len(keep)} non-colinear "
-        f"(|Pearson|<{THRESH} + VIF<{VIF_THRESH}); kept max|corr|={max_pair:.2f} "
-        f"max VIF={max_vif:.2f}:")
-    log("  " + ", ".join(keep))
+    log(f"\nfeatures [{FEATURE_MODE}]: {F.shape[1]} candidates -> {len(keep)} kept; "
+        f"max|corr|={max_pair:.2f} max VIF={max_vif:.2f}")
+    if mapping:
+        log("  " + ", ".join(f"{fam}={feat}" for fam, feat in mapping.items()))
+    else:
+        log("  " + ", ".join(keep))
 
     # colinearity heatmaps: candidates (before) and the kept set (after)
     fig, axx = plt.subplots(1, 2, figsize=(17, 8))

--- a/scripts/dim_red/run_tlg_dimred.py
+++ b/scripts/dim_red/run_tlg_dimred.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""Family-fingerprint dimensionality-reduction experiment on Twitch.
+"""Family-fingerprint dimensionality-reduction experiment (LG_DR_DATASET: twitch, connectome,
+...; any dataset tlg_latent_gic_common knows).
 
-For each Twitch country graph (largest CC, BFS-capped to ~1500 nodes — the same subgraph
+For each network of the dataset (largest CC, BFS-capped to ~1500 nodes — the same subgraph
 the closed-form / latent-TLG experiments use), we:
 
   1. Estimate each family's parameters with the SAME closed-form estimation as
@@ -13,11 +14,11 @@ the closed-form / latent-TLG experiments use), we:
      then iteratively drop the highest-VIF feature until every feature has VIF<VIF_THRESH.
   3. Cache every cell (estimated params, features, n, edges, seed) so reruns resume.
   4. Embed (PCA/t-SNE/UMAP, fit PER NETWORK on StandardScaler-normalized features) and plot
-     each family as its DENSITY REGION (2-sigma covariance ellipse); only the real graph is
-     drawn as a point (★). The embeddings are fit per network so the strong per-region
+     each family as its DENSITY REGION (2-sigma covariance ellipse) + its points; the real
+     graph is the highlighted ★. The embeddings are fit per network so the strong per-network
      structure differences don't split a family into separate sub-clusters.
 
-Output under runs/tlg_dimred_twitch/ (gitignored):
+Output under runs/tlg_dimred_<DATASET>/ (gitignored):
   cache/<region>_<family>_<rep>.json   per-graph record (resumable)
   features.csv          all graphs x (raw features + meta)
   kept_features.txt     the non-colinear feature subset; colinearity.png (candidates vs kept)
@@ -25,11 +26,14 @@ Output under runs/tlg_dimred_twitch/ (gitignored):
   dimred_main.{png,pdf} MAIN figure: one panel per network (LG_DR_MAIN_METHOD), family
                         density regions + real ★ + dashed line to nearest family centroid
   dimred_per_graph.{png,pdf}  supplement: rows = network, cols = PCA/t-SNE/UMAP
-  dimred_distance.{png,pdf} + distance_to_real.csv  QUANTITATIVE: distance from the real
-                        graph to each family centroid (heatmap, closest boxed; mean-rank bar)
+  dimred_distance.{png,pdf} + distance_to_real.csv  QUANTITATIVE: heatmap of the distance
+                        from the real graph to each family centroid (raw Euclidean in the
+                        standardized feature space, NOT a dim-red result; closest boxed),
+                        beside one dim-red embedding (LG_DR_DIST_METHOD) of the focus network
 
-Env: LG_DR_REGIONS (all 6), LG_DR_NREPS (10), LG_DR_FAMILIES (ER,BA,WS,KR,GRG,SBM,TLG),
-LG_DR_COLINEAR_THRESH (0.85), LG_DR_VIF_THRESH (5.0), LG_DR_MAIN_METHOD (t-SNE),
+Env: LG_DR_DATASET (twitch), LG_DR_NETWORKS (subset; default all), LG_DR_NREPS (10),
+LG_DR_FAMILIES (ER,BA,WS,KR,GRG,SBM,TLG), LG_DR_COLINEAR_THRESH (0.85), LG_DR_VIF_THRESH (5),
+LG_DR_MAIN_METHOD (t-SNE), LG_DR_FOCUS_REGION (network in the distance fig; default first),
 LG_DR_SEED (12345), LG_DR_TSNE_PERPLEXITY (30).
 """
 from __future__ import annotations
@@ -67,11 +71,6 @@ except Exception:
 import tlg_latent_gic_common as C  # noqa: E402  (loaders, latent-TLG sampler pieces, baselines)
 from logit_graph.sbm import generate_sbm_from_real  # noqa: E402
 
-OUT = _here / "runs" / "tlg_dimred_twitch"
-CACHE = OUT / "cache"
-DATA = _repo_root / "data" / "twitch" / "graphs_processed"
-
-
 def _int(env, d):
     v = os.environ.get(env); return int(v) if v else d
 
@@ -80,7 +79,23 @@ def _float(env, d):
     v = os.environ.get(env); return float(v) if v else d
 
 
-REGIONS = (os.environ.get("LG_DR_REGIONS") or "PTBR,RU,ES,ENGB,FR,DE").split(",")
+def _net_label(nid):
+    """Short display label for a network id (strip the '_graph' suffix Twitch files carry)."""
+    return nid[:-6] if nid.endswith("_graph") else nid
+
+
+# Dataset selection (any dataset tlg_latent_gic_common knows: twitch, connectome, ...). The
+# networks, loaders and the cached latent-TLG fits all come from C's dataset machinery.
+DATASET = os.environ.get("LG_DR_DATASET", "twitch")
+_NETS = C._sweep_enumerate(DATASET)              # (id, kind, arg, nmin, nmax) per network
+_sel = os.environ.get("LG_DR_NETWORKS")
+if _sel:
+    _want = set(_sel.split(","))
+    _NETS = [t for t in _NETS if t[0] in _want or _net_label(t[0]) in _want]
+NET_ORDER = [_net_label(t[0]) for t in _NETS]    # display labels, in order
+OUT = _here / "runs" / f"tlg_dimred_{DATASET}"
+CACHE = OUT / "cache"
+
 NREPS = _int("LG_DR_NREPS", 10)
 FAMILIES = (os.environ.get("LG_DR_FAMILIES") or "ER,BA,WS,KR,GRG,SBM,TLG").split(",")
 THRESH = _float("LG_DR_COLINEAR_THRESH", 0.85)   # pairwise |Pearson| pre-prune cutoff
@@ -89,6 +104,7 @@ SEED = _int("LG_DR_SEED", 12345)
 PERPLEXITY = _float("LG_DR_TSNE_PERPLEXITY", 30.0)
 MAIN_METHOD = os.environ.get("LG_DR_MAIN_METHOD", "t-SNE")  # method for the main figure
 FOCUS_REGION = os.environ.get("LG_DR_FOCUS_REGION", "")     # network shown in the distance fig
+DIST_METHOD = os.environ.get("LG_DR_DIST_METHOD", "UMAP")   # the single embedding shown there
 
 
 def log(*a):
@@ -164,18 +180,13 @@ def features(G):
 
 
 # --------------------------------------------------------------------------- generators
-def _load_region(region):
-    """Same BFS-capped largest-CC subgraph the closed-form / latent experiments use."""
-    return C._edges(str(DATA / f"{region}_graph.edges"))
-
-
-def _tlg_sampler(G, region):
-    """Reconstruct the cached latent-TLG fit for this region and return (sample_fn, params).
+def _tlg_sampler(G, net_id):
+    """Reconstruct the cached latent-TLG fit for this network and return (sample_fn, params).
     sample_fn(seed) -> nx.Graph by growing to E_real with the fitted (d,kernel,k,coeffs).
     Falls back to fitting fresh if the sweep cache is absent."""
     n = G.number_of_nodes(); adj = nx.to_numpy_array(G); e = G.number_of_edges()
     rows, cols = np.triu_indices(n, 1)
-    cache = C._out_dir("twitch") / "cache" / f"{region}_graph.json"
+    cache = C._out_dir(DATASET) / "cache" / f"{net_id}.json"
     if cache.exists():
         d = json.loads(cache.read_text()); sel = d["tlg_selected"]
         b = next(t for t in d["tlg_trace"]
@@ -200,7 +211,7 @@ def _tlg_sampler(G, region):
     return sample, params
 
 
-def _family_setup(G, region):
+def _family_setup(G, net_id):
     """Return {family: (sample_fn(seed)->Graph, est_params_dict)} for all families."""
     cf = C.tw.closed_form_params(G)
     gens = C.tw._baseline_generators(G, cf)
@@ -212,7 +223,7 @@ def _family_setup(G, region):
         setup[fam] = ((lambda s, gf=gen_fn: gf(s)), est[fam])
     _, sbm_np = generate_sbm_from_real(G, seed=SEED)
     setup["SBM"] = ((lambda s: generate_sbm_from_real(G, seed=s)[0]), {"n_params": int(sbm_np)})
-    tlg_fn, tlg_params = _tlg_sampler(G, region)
+    tlg_fn, tlg_params = _tlg_sampler(G, net_id)
     setup["TLG"] = (tlg_fn, tlg_params)
     return {f: setup[f] for f in FAMILIES if f in setup}
 
@@ -237,16 +248,21 @@ def _cell(region, family, rep, gen_fn, est_params):
 
 def generate_and_feature():
     records = []
-    for region in REGIONS:
+    for nid, kind, arg, nmin, nmax in _NETS:
+        label = _net_label(nid)
         t0 = time.perf_counter()
-        G = _load_region(region)
-        log(f"\n=== {region}: n={G.number_of_nodes()} E={G.number_of_edges()} ===")
-        # real graph
-        records.append(_cell(region, "real", 0, G, {}))
-        setup = _family_setup(G, region)
+        try:
+            G = C._sweep_load(kind, arg)
+        except Exception as ex:
+            log(f"  {label}: load failed ({ex}) — skipping"); continue
+        if not (nmin < G.number_of_nodes() < nmax):
+            log(f"  {label}: n={G.number_of_nodes()} out of range — skipping"); continue
+        log(f"\n=== {label}: n={G.number_of_nodes()} E={G.number_of_edges()} ===")
+        records.append(_cell(label, "real", 0, G, {}))   # real graph
+        setup = _family_setup(G, nid)
         for family, (gen_fn, est) in setup.items():
             for rep in range(NREPS):
-                records.append(_cell(region, family, rep, gen_fn, est))
+                records.append(_cell(label, family, rep, gen_fn, est))
             log(f"  {family:4} x{NREPS} done")
         log(f"  ({time.perf_counter()-t0:.1f}s)")
     return records
@@ -363,7 +379,7 @@ def _grid_figure(meta, F, keep):
     except Exception:
         has_umap = False
     methods = ["PCA", "t-SNE"] + (["UMAP"] if has_umap else [])
-    regions = [r for r in REGIONS if r in set(meta["region"])]
+    regions = [r for r in NET_ORDER if r in set(meta["region"])]
     fams = [f for f in FAMILIES if f in set(meta["family"])]
     color = {f: _fam_color(f) for f in fams}
 
@@ -385,10 +401,12 @@ def _grid_figure(meta, F, keep):
         region_embeds[region] = (emb, sub)
         for ci, method in enumerate(methods):
             ax = axes[ri][ci]; e = emb[method]
-            for f in fams:                       # families: density region only (no points)
+            for f in fams:                       # families: density region + the points
                 m = (sub["family"] == f).values
                 _cov_ellipse(ax, e[m, 0], e[m, 1], color[f])
-            m = (sub["family"] == "real").values   # real graph: the only plotted point
+                ax.scatter(e[m, 0], e[m, 1], s=13, alpha=0.75, color=color[f],
+                           marker=_fam_marker(f), edgecolors="white", linewidths=0.2, zorder=3)
+            m = (sub["family"] == "real").values   # real graph: the highlighted star
             ax.scatter(e[m, 0], e[m, 1], s=300, marker="*", color="black",
                        edgecolors="white", linewidths=1.2, zorder=6)
             ax.tick_params(labelbottom=False, labelleft=False, length=0)
@@ -435,9 +453,11 @@ def _main_figure(region_embeds, method):
         ax = axes.flat[idx]
         e, sub = region_embeds[region][0][method], region_embeds[region][1]
         cents = {}
-        for f in fams:                          # families: density region only (no points)
+        for f in fams:                          # families: density region + the points
             m = (sub["family"] == f).values
             _cov_ellipse(ax, e[m, 0], e[m, 1], color[f])
+            ax.scatter(e[m, 0], e[m, 1], s=16, alpha=0.75, color=color[f],
+                       marker=_fam_marker(f), edgecolors="white", linewidths=0.2, zorder=3)
             cents[f] = e[m].mean(0)
         m = (sub["family"] == "real").values
         rp = e[m][0]
@@ -470,7 +490,7 @@ def _distance_figure(meta, F, keep, region_embeds):
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
     from sklearn.preprocessing import StandardScaler
-    regions = [r for r in REGIONS if r in set(meta["region"])]
+    regions = [r for r in NET_ORDER if r in set(meta["region"])]
     fams = [f for f in FAMILIES if f in set(meta["family"])]
     color = {f: _fam_color(f) for f in fams}
     D = np.full((len(regions), len(fams)), np.nan)
@@ -494,13 +514,13 @@ def _distance_figure(meta, F, keep, region_embeds):
 
     focus = FOCUS_REGION if FOCUS_REGION in region_embeds else regions[0]
     emb, sub = region_embeds[focus]
-    methods = list(emb)
+    method = DIST_METHOD if DIST_METHOD in emb else list(emb)[-1]
 
-    fig = plt.figure(figsize=(14, max(7.5, 2.6 * len(methods))))
-    gs = fig.add_gridspec(len(methods), 2, width_ratios=[2.0, 1.35],
-                          wspace=0.16, hspace=0.28)
-    # left: distance heatmap (spans all rows)
-    axh = fig.add_subplot(gs[:, 0])
+    fig = plt.figure(figsize=(14, max(5.5, 0.55 * len(regions) + 2.2)))
+    gs = fig.add_gridspec(1, 2, width_ratios=[1.7, 1.25], wspace=0.14)
+    # left: distance heatmap (NOT a dim-red result -- raw Euclidean distance in the
+    # standardized 7-D feature space, real graph -> family centroid)
+    axh = fig.add_subplot(gs[0, 0])
     H = Ddf[order]
     im = axh.imshow(H.values, aspect="auto", cmap="viridis")
     axh.set_xticks(range(len(order))); axh.set_xticklabels(order)
@@ -520,26 +540,29 @@ def _distance_figure(meta, F, keep, region_embeds):
     axh.set_title("Distance from real graph to each family centroid\n"
                   "(standardized feature space; red box = closest; dotted = focus network)")
     fig.colorbar(im, ax=axh, shrink=.85, label="Euclidean distance", pad=0.02)
-    # right: the dim-red embeddings for the focus network (stacked, one per method)
-    for mi, method in enumerate(methods):
-        ax = fig.add_subplot(gs[mi, 1])
-        e = emb[method]; cents = {}
-        for f in fams:
-            m = (sub["family"] == f).values
-            _cov_ellipse(ax, e[m, 0], e[m, 1], color[f]); cents[f] = e[m].mean(0)
-        m = (sub["family"] == "real").values; rp = e[m][0]
-        nearest = min(fams, key=lambda f: np.linalg.norm(rp - cents[f]))
-        ax.plot([rp[0], cents[nearest][0]], [rp[1], cents[nearest][1]], color="black",
-                lw=0.9, ls="--", alpha=0.6, zorder=4)
-        ax.scatter(rp[0], rp[1], s=240, marker="*", color="black", edgecolors="white",
-                   linewidths=1.1, zorder=6)
-        ax.set_title(method, fontsize=11, fontweight="bold")
-        ax.tick_params(labelbottom=False, labelleft=False, length=0); ax.grid(alpha=.18, lw=.5)
+    # right: ONE dim-red embedding for the focus network
+    ax = fig.add_subplot(gs[0, 1])
+    e = emb[method]; cents = {}
+    for f in fams:
+        m = (sub["family"] == f).values
+        _cov_ellipse(ax, e[m, 0], e[m, 1], color[f])
+        ax.scatter(e[m, 0], e[m, 1], s=24, alpha=0.78, color=color[f], marker=_fam_marker(f),
+                   edgecolors="white", linewidths=0.3, zorder=3)
+        cents[f] = e[m].mean(0)
+    m = (sub["family"] == "real").values; rp = e[m][0]
+    nearest = min(fams, key=lambda f: np.linalg.norm(rp - cents[f]))
+    ax.plot([rp[0], cents[nearest][0]], [rp[1], cents[nearest][1]], color="black",
+            lw=1.0, ls="--", alpha=0.6, zorder=4)
+    ax.scatter(rp[0], rp[1], s=320, marker="*", color="black", edgecolors="white",
+               linewidths=1.3, zorder=6)
+    ax.set_title(f"{focus} — {method}  (nearest: {nearest})", fontsize=12, fontweight="bold")
+    ax.tick_params(labelbottom=False, labelleft=False, length=0); ax.grid(alpha=.18, lw=.5)
     fig.legend(handles=_legend_handles(fams), loc="lower center", ncol=len(fams) + 1,
-               frameon=False, bbox_to_anchor=(0.5, -0.02))
-    fig.suptitle(f"Distance-to-real (left) and the dim-red embeddings for the {focus} "
-                 f"network (right; family density regions, ★ = real graph)", fontsize=14, y=1.0)
-    fig.tight_layout(rect=[0, 0.04, 1, 0.97])
+               frameon=False, bbox_to_anchor=(0.5, -0.03))
+    fig.suptitle(f"Distance-to-real (left) and the {method} embedding for the {focus} "
+                 f"network (right; family density regions + points, ★ = real graph)",
+                 fontsize=14, y=1.0)
+    fig.tight_layout(rect=[0, 0.05, 1, 0.97])
     for ext in ("png", "pdf"):
         fig.savefig(OUT / f"dimred_distance.{ext}", dpi=300, bbox_inches="tight")
     plt.close(fig)
@@ -597,7 +620,7 @@ def dimred(records):
 
 
 def main():
-    log(f"TLG dim-red [twitch]: regions={REGIONS} families={FAMILIES} nreps={NREPS} "
+    log(f"TLG dim-red [{DATASET}]: networks={len(NET_ORDER)} families={FAMILIES} nreps={NREPS} "
         f"colinear_thresh={THRESH} seed={SEED}")
     records = generate_and_feature()
     dimred(records)

--- a/scripts/dim_red/run_tlg_dimred_twitch.py
+++ b/scripts/dim_red/run_tlg_dimred_twitch.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Family-fingerprint dimensionality-reduction experiment on Twitch.
+
+For each Twitch country graph (largest CC, BFS-capped to ~1500 nodes — the same subgraph
+the closed-form / latent-TLG experiments use), we:
+
+  1. Estimate each family's parameters with the SAME closed-form estimation as
+     scripts/closedform (ER/BA/WS/KR/GRG via moment matching, SBM via Louvain, TLG via the
+     latent degree+community+latent-ASE fit — reused from the cached sweep when available,
+     else fit fresh), and GENERATE n=10 graphs per family.
+  2. Compute ~20 candidate graph-level structural features per graph (generated + real),
+     then prune to a NON-COLINEAR subset (greedy |Pearson|<thresh) of ~10-20.
+  3. Cache every cell (estimated params, features, n, edges, seed) so reruns resume.
+  4. Embed all graphs in 2D with PCA, t-SNE and UMAP and plot the per-family clusters with
+     the real graphs highlighted.
+
+Output under runs/tlg_dimred_twitch/ (gitignored):
+  cache/<region>_<family>_<rep>.json   per-graph record (resumable)
+  features.csv          all graphs x (raw features + meta)
+  kept_features.txt     the non-colinear feature subset used for the embeddings
+  colinearity.png       feature correlation heatmap (candidates)
+  embeddings.csv        2D coords (region, family, rep, method, x, y) per graph
+  dimred_per_graph.png / .pdf   rows = Twitch network, cols = PCA/t-SNE/UMAP (fit per
+                                network so families don't split by region), ★ = real graph
+
+Env: LG_DR_REGIONS (all 6), LG_DR_NREPS (10), LG_DR_FAMILIES (ER,BA,WS,KR,GRG,SBM,TLG),
+LG_DR_COLINEAR_THRESH (0.9), LG_DR_SEED (12345), LG_DR_TSNE_PERPLEXITY (30).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import warnings
+from pathlib import Path
+
+for _v in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ.setdefault(_v, "1")
+
+import numpy as np
+import networkx as nx
+import pandas as pd
+import scipy.sparse as sp
+import scipy.sparse.linalg as sla
+from scipy.stats import skew, kurtosis
+
+_here = Path(__file__).resolve().parent
+_repo_root = _here.parents[1]
+_closedform = _repo_root / "scripts" / "closedform"
+for p in (_repo_root / "src", _closedform, _here):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+warnings.filterwarnings("ignore")
+try:
+    sys.stdout.reconfigure(line_buffering=True)
+except Exception:
+    pass
+
+import tlg_latent_gic_common as C  # noqa: E402  (loaders, latent-TLG sampler pieces, baselines)
+from logit_graph.sbm import generate_sbm_from_real  # noqa: E402
+
+OUT = _here / "runs" / "tlg_dimred_twitch"
+CACHE = OUT / "cache"
+DATA = _repo_root / "data" / "twitch" / "graphs_processed"
+
+
+def _int(env, d):
+    v = os.environ.get(env); return int(v) if v else d
+
+
+def _float(env, d):
+    v = os.environ.get(env); return float(v) if v else d
+
+
+REGIONS = (os.environ.get("LG_DR_REGIONS") or "PTBR,RU,ES,ENGB,FR,DE").split(",")
+NREPS = _int("LG_DR_NREPS", 10)
+FAMILIES = (os.environ.get("LG_DR_FAMILIES") or "ER,BA,WS,KR,GRG,SBM,TLG").split(",")
+THRESH = _float("LG_DR_COLINEAR_THRESH", 0.9)
+SEED = _int("LG_DR_SEED", 12345)
+PERPLEXITY = _float("LG_DR_TSNE_PERPLEXITY", 30.0)
+
+
+def log(*a):
+    print(*a, flush=True)
+
+
+# --------------------------------------------------------------------------- features
+def _gini(x):
+    x = np.sort(np.asarray(x, float))
+    n = len(x)
+    if n == 0 or x.sum() == 0:
+        return 0.0
+    return float((2 * np.arange(1, n + 1) - n - 1).dot(x) / (n * x.sum()))
+
+
+def _spectral(G):
+    """Largest adjacency eigenvalue (normalized by mean degree), Fiedler value (algebraic
+    connectivity) and normalized-Laplacian spectral gap, via sparse eigsh (dense fallback)."""
+    n = G.number_of_nodes()
+    A = nx.to_scipy_sparse_array(G, dtype=float, format="csr")
+    deg = np.asarray(A.sum(1)).ravel()
+    kbar = deg.mean() if deg.mean() else 1.0
+    out = dict(spectral_radius=np.nan, algebraic_conn=np.nan, spectral_gap=np.nan)
+    try:
+        out["spectral_radius"] = float(sla.eigsh(A, k=1, which="LA",
+                                                 return_eigenvectors=False)[0]) / kbar
+    except Exception:
+        pass
+    try:
+        Ln = sp.csgraph.laplacian(A, normed=True)
+        if n <= 1200:
+            ev = np.linalg.eigvalsh(Ln.toarray()); ev.sort()
+        else:
+            ev = np.sort(sla.eigsh(Ln, k=4, which="SA", return_eigenvectors=False))
+        out["algebraic_conn"] = float(ev[1])
+        out["spectral_gap"] = float(ev[2] - ev[1])
+    except Exception:
+        pass
+    return out
+
+
+def features(G):
+    """~20 candidate graph-level structural features (size-normalized where natural)."""
+    n = G.number_of_nodes(); E = G.number_of_edges()
+    deg = np.array([d for _, d in G.degree], float)
+    f = {}
+    f["density"] = 2.0 * E / (n * (n - 1)) if n > 1 else 0.0
+    f["avg_degree"] = float(deg.mean()) if n else 0.0
+    f["clustering"] = nx.average_clustering(G)
+    f["transitivity"] = nx.transitivity(G)
+    try:
+        f["assortativity"] = float(nx.degree_assortativity_coefficient(G))
+    except Exception:
+        f["assortativity"] = 0.0
+    f["degree_cv"] = float(deg.std() / deg.mean()) if deg.mean() else 0.0
+    f["degree_skew"] = float(skew(deg)) if n > 2 else 0.0
+    f["degree_kurt"] = float(kurtosis(deg)) if n > 3 else 0.0
+    f["degree_gini"] = _gini(deg)
+    f["leaf_frac"] = float(np.mean(deg == 1))
+    part = nx.community.louvain_communities(G, seed=SEED)
+    f["modularity"] = nx.community.modularity(G, part)
+    f["n_comm_norm"] = len(part) / n
+    core = np.array(list(nx.core_number(G).values()), float)
+    f["max_core"] = float(core.max()) if len(core) else 0.0
+    f["mean_core"] = float(core.mean()) if len(core) else 0.0
+    f["avg_neighbor_deg"] = (float(np.mean(list(nx.average_neighbor_degree(G).values())))
+                             / deg.mean()) if deg.mean() else 0.0
+    tri = sum(nx.triangles(G).values()) / 3.0
+    f["triangle_density"] = tri / (n * (n - 1) * (n - 2) / 6.0) if n > 2 else 0.0
+    f["frac_in_lcc"] = (len(max(nx.connected_components(G), key=len)) / n) if E else 0.0
+    f.update(_spectral(G))
+    return f
+
+
+# --------------------------------------------------------------------------- generators
+def _load_region(region):
+    """Same BFS-capped largest-CC subgraph the closed-form / latent experiments use."""
+    return C._edges(str(DATA / f"{region}_graph.edges"))
+
+
+def _tlg_sampler(G, region):
+    """Reconstruct the cached latent-TLG fit for this region and return (sample_fn, params).
+    sample_fn(seed) -> nx.Graph by growing to E_real with the fitted (d,kernel,k,coeffs).
+    Falls back to fitting fresh if the sweep cache is absent."""
+    n = G.number_of_nodes(); adj = nx.to_numpy_array(G); e = G.number_of_edges()
+    rows, cols = np.triu_indices(n, 1)
+    cache = C._out_dir("twitch") / "cache" / f"{region}_graph.json"
+    if cache.exists():
+        d = json.loads(cache.read_text()); sel = d["tlg_selected"]
+        b = next(t for t in d["tlg_trace"]
+                 if (t["d"], t["kernel"], t["k"]) == (sel["d"], sel["kernel"], sel["k"]))
+    else:
+        sc = C.GraphInformationCriterion(G, model="LG", dist="KL")
+        rd, _ = sc.compute_spectral_density(G)
+        fit = C.fit_tlg(G, sc, rd); sel = fit["selected"]
+        b = next(t for t in fit["trace"]
+                 if (t["d"], t["kernel"], t["k"]) == (sel["d"], sel["kernel"], sel["k"]))
+    params = dict(d=sel["d"], kernel=sel["kernel"], k=sel["k"],
+                  alpha=b["alpha"], gc=b["gc"], gf=b["gf"], lam=b["lam"])
+    Bc, _ = C.tw._community_feature(G, rows, cols, C.SEED, 1.0)
+    Bf, _ = C.tw._community_feature(G, rows, cols, C.SEED, C.FINE_RES)
+    w, U = np.linalg.eigh(adj)
+    L = C._latent_from_eig(w, U, params["k"], rows, cols, params["kernel"])
+
+    def sample(seed):
+        A = C._grow_one(n, rows, cols, params["alpha"], params["gc"], params["gf"],
+                        params["lam"], Bc, Bf, L, e, seed, params["d"])
+        return nx.from_numpy_array(A)
+    return sample, params
+
+
+def _family_setup(G, region):
+    """Return {family: (sample_fn(seed)->Graph, est_params_dict)} for all families."""
+    cf = C.tw.closed_form_params(G)
+    gens = C.tw._baseline_generators(G, cf)
+    est = dict(ER={"p": cf["ER"]}, BA={"m": cf["BA"]}, WS={"k": cf["WS_k"], "p": cf["WS_p"]},
+               KR={"d": cf["KR"]}, GRG={"r": cf["GRG"]})
+    setup = {}
+    for fam in ("ER", "BA", "WS", "KR", "GRG"):
+        gen_fn = gens[fam][0]
+        setup[fam] = ((lambda s, gf=gen_fn: gf(s)), est[fam])
+    _, sbm_np = generate_sbm_from_real(G, seed=SEED)
+    setup["SBM"] = ((lambda s: generate_sbm_from_real(G, seed=s)[0]), {"n_params": int(sbm_np)})
+    tlg_fn, tlg_params = _tlg_sampler(G, region)
+    setup["TLG"] = (tlg_fn, tlg_params)
+    return {f: setup[f] for f in FAMILIES if f in setup}
+
+
+# --------------------------------------------------------------------------- driver
+def _cell(region, family, rep, gen_fn, est_params):
+    cf_path = CACHE / f"{region}_{family}_{rep}.json"
+    if cf_path.exists():
+        try:
+            return json.loads(cf_path.read_text())
+        except Exception:
+            pass
+    seed = SEED + 1009 * rep
+    G = gen_fn(seed) if family != "real" else gen_fn
+    rec = dict(region=region, family=family, rep=rep, seed=seed,
+               n=G.number_of_nodes(), edges=G.number_of_edges(),
+               est_params=est_params, features=features(G))
+    CACHE.mkdir(parents=True, exist_ok=True)
+    cf_path.write_text(json.dumps(rec))
+    return rec
+
+
+def generate_and_feature():
+    records = []
+    for region in REGIONS:
+        t0 = time.perf_counter()
+        G = _load_region(region)
+        log(f"\n=== {region}: n={G.number_of_nodes()} E={G.number_of_edges()} ===")
+        # real graph
+        records.append(_cell(region, "real", 0, G, {}))
+        setup = _family_setup(G, region)
+        for family, (gen_fn, est) in setup.items():
+            for rep in range(NREPS):
+                records.append(_cell(region, family, rep, gen_fn, est))
+            log(f"  {family:4} x{NREPS} done")
+        log(f"  ({time.perf_counter()-t0:.1f}s)")
+    return records
+
+
+# --------------------------------------------------------------------------- dim-red
+def _prune_colinear(F, thresh):
+    """Greedy: keep a feature unless |corr| >= thresh with an already-kept one. Orders by
+    descending variance so the most informative features are kept first."""
+    order = F.var().sort_values(ascending=False).index.tolist()
+    corr = F.corr().abs()
+    keep = []
+    for c in order:
+        if all(corr.loc[c, k] < thresh for k in keep):
+            keep.append(c)
+    return keep
+
+
+# Okabe-Ito colorblind-safe palette + distinct markers, one per family.
+_OKABE = ["#0072B2", "#E69F00", "#009E73", "#D55E00", "#CC79A7", "#56B4E9", "#F0E442"]
+_MARKERS = ["o", "s", "^", "D", "v", "P", "X"]
+
+
+def _cov_ellipse(ax, x, y, color, nstd=2.0):
+    """2-sigma covariance ellipse of a family's point cloud (cluster footprint)."""
+    from matplotlib.patches import Ellipse
+    if len(x) < 3:
+        return
+    cov = np.cov(x, y)
+    vals, vecs = np.linalg.eigh(cov)
+    o = vals.argsort()[::-1]
+    vals, vecs = vals[o], vecs[:, o]
+    ang = np.degrees(np.arctan2(vecs[1, 0], vecs[0, 0]))
+    w, h = 2 * nstd * np.sqrt(np.maximum(vals, 1e-12))
+    ax.add_patch(Ellipse((x.mean(), y.mean()), w, h, angle=ang, facecolor=color,
+                         alpha=0.13, edgecolor=color, lw=1.0, zorder=1))
+
+
+def _grid_figure(meta, F, keep):
+    """Publication figure: rows = Twitch networks, columns = PCA / t-SNE / UMAP, each
+    embedding fit ON THAT NETWORK'S GRAPHS ONLY (so the per-region structure differences
+    don't split each family into separate sub-clusters). Per-family covariance ellipses +
+    distinct color/marker, real graph as a star. 300-dpi PNG + vector PDF."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from sklearn.preprocessing import StandardScaler
+    from sklearn.decomposition import PCA
+    from sklearn.manifold import TSNE
+    plt.rcParams.update({"font.size": 12, "axes.titlesize": 14, "legend.fontsize": 11,
+                         "font.family": "DejaVu Sans", "axes.linewidth": 0.9,
+                         "pdf.fonttype": 42, "ps.fonttype": 42})
+    has_umap = True
+    try:
+        import umap
+    except Exception:
+        has_umap = False
+    methods = ["PCA", "t-SNE"] + (["UMAP"] if has_umap else [])
+    regions = [r for r in REGIONS if r in set(meta["region"])]
+    fams = [f for f in FAMILIES if f in set(meta["family"])]
+    color = {f: _OKABE[i % len(_OKABE)] for i, f in enumerate(fams)}
+    marker = {f: _MARKERS[i % len(_MARKERS)] for i, f in enumerate(fams)}
+
+    fig, axes = plt.subplots(len(regions), len(methods),
+                             figsize=(4.8 * len(methods), 4.3 * len(regions)), squeeze=False)
+    emb_rows = []
+    for ri, region in enumerate(regions):
+        mask = (meta["region"] == region).values
+        sub = meta[mask].reset_index(drop=True)
+        Xr = StandardScaler().fit_transform(F[keep].values[mask])
+        per = min(PERPLEXITY, max(5.0, (len(Xr) - 1) / 3))
+        emb = {"PCA": PCA(2, random_state=SEED).fit_transform(Xr),
+               "t-SNE": TSNE(2, random_state=SEED, init="pca", perplexity=per).fit_transform(Xr)}
+        if has_umap:
+            emb["UMAP"] = umap.UMAP(n_components=2, random_state=SEED,
+                                    n_neighbors=min(15, len(Xr) - 1),
+                                    min_dist=0.1).fit_transform(Xr)
+        for ci, method in enumerate(methods):
+            ax = axes[ri][ci]; e = emb[method]
+            for f in fams:
+                m = (sub["family"] == f).values
+                _cov_ellipse(ax, e[m, 0], e[m, 1], color[f])
+                ax.scatter(e[m, 0], e[m, 1], s=26, alpha=0.8, color=color[f],
+                           marker=marker[f], edgecolors="white", linewidths=0.3,
+                           zorder=3, label=f)
+            m = (sub["family"] == "real").values
+            ax.scatter(e[m, 0], e[m, 1], s=300, marker="*", color="black",
+                       edgecolors="white", linewidths=1.2, zorder=6, label="real (Twitch)")
+            ax.tick_params(labelbottom=False, labelleft=False, length=0)
+            ax.grid(alpha=0.18, lw=0.5)
+            if ri == 0:
+                ax.set_title(method, fontweight="bold")
+            if ci == 0:
+                ax.set_ylabel(region, fontweight="bold", fontsize=13, labelpad=8)
+            for j in range(len(e)):
+                emb_rows.append(dict(region=region, family=sub["family"][j],
+                                     rep=int(sub["rep"][j]), method=method,
+                                     x=float(e[j, 0]), y=float(e[j, 1])))
+    handles, labels = axes[0][0].get_legend_handles_labels()
+    fig.legend(handles, labels, loc="lower center", ncol=len(fams) + 1, frameon=False,
+               bbox_to_anchor=(0.5, -0.004), handletextpad=0.3, columnspacing=1.1)
+    fig.suptitle("Per-Twitch-network graph-family clusters in structural-feature space "
+                 "(rows = network, cols = embedding; ★ = real graph)", y=1.0, fontsize=15)
+    fig.tight_layout(rect=[0, 0.022, 1, 0.99])
+    for ext in ("png", "pdf"):
+        fig.savefig(OUT / f"dimred_per_graph.{ext}", dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    pd.DataFrame(emb_rows).to_csv(OUT / "embeddings.csv", index=False)
+
+
+def dimred(records):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    meta = pd.DataFrame([{k: r[k] for k in ("region", "family", "rep", "n", "edges")}
+                         for r in records])
+    F = pd.DataFrame([r["features"] for r in records])
+    F = F.dropna(axis=1, how="any")                 # drop features undefined on any graph
+    OUT.mkdir(parents=True, exist_ok=True)
+    pd.concat([meta, F], axis=1).to_csv(OUT / "features.csv", index=False)
+
+    keep = _prune_colinear(F, THRESH)
+    (OUT / "kept_features.txt").write_text("\n".join(keep))
+    log(f"\nfeatures: {F.shape[1]} candidates -> {len(keep)} non-colinear (|corr|<{THRESH}):")
+    log("  " + ", ".join(keep))
+
+    # colinearity heatmap (candidates)
+    corr = F.corr()
+    fig, ax = plt.subplots(figsize=(11, 9))
+    im = ax.imshow(corr.values, cmap="coolwarm", vmin=-1, vmax=1)
+    ax.set_xticks(range(len(corr))); ax.set_xticklabels(corr.columns, rotation=90, fontsize=7)
+    ax.set_yticks(range(len(corr))); ax.set_yticklabels(corr.columns, fontsize=7)
+    ax.set_title("Candidate feature colinearity (|corr|>%.2f pruned)" % THRESH)
+    fig.colorbar(im, shrink=.8); fig.tight_layout()
+    fig.savefig(OUT / "colinearity.png", dpi=150); plt.close(fig)
+
+    _grid_figure(meta, F, keep)   # one PCA/t-SNE/UMAP per Twitch network (rows), no mixing
+    log(f"\nWrote {OUT}/")
+
+
+def main():
+    log(f"TLG dim-red [twitch]: regions={REGIONS} families={FAMILIES} nreps={NREPS} "
+        f"colinear_thresh={THRESH} seed={SEED}")
+    records = generate_and_feature()
+    dimred(records)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dim_red/run_tlg_dimred_twitch.py
+++ b/scripts/dim_red/run_tlg_dimred_twitch.py
@@ -9,22 +9,28 @@ the closed-form / latent-TLG experiments use), we:
      latent degree+community+latent-ASE fit — reused from the cached sweep when available,
      else fit fresh), and GENERATE n=10 graphs per family.
   2. Compute ~20 candidate graph-level structural features per graph (generated + real),
-     then prune to a NON-COLINEAR subset (greedy |Pearson|<thresh) of ~10-20.
+     then prune to a NON-COLINEAR subset: drop one of any pair with |Pearson|>=THRESH,
+     then iteratively drop the highest-VIF feature until every feature has VIF<VIF_THRESH.
   3. Cache every cell (estimated params, features, n, edges, seed) so reruns resume.
-  4. Embed all graphs in 2D with PCA, t-SNE and UMAP and plot the per-family clusters with
-     the real graphs highlighted.
+  4. Embed (PCA/t-SNE/UMAP, fit PER NETWORK on StandardScaler-normalized features) and plot
+     each family as its DENSITY REGION (2-sigma covariance ellipse); only the real graph is
+     drawn as a point (★). The embeddings are fit per network so the strong per-region
+     structure differences don't split a family into separate sub-clusters.
 
 Output under runs/tlg_dimred_twitch/ (gitignored):
   cache/<region>_<family>_<rep>.json   per-graph record (resumable)
   features.csv          all graphs x (raw features + meta)
-  kept_features.txt     the non-colinear feature subset used for the embeddings
-  colinearity.png       feature correlation heatmap (candidates)
+  kept_features.txt     the non-colinear feature subset; colinearity.png (candidates vs kept)
   embeddings.csv        2D coords (region, family, rep, method, x, y) per graph
-  dimred_per_graph.png / .pdf   rows = Twitch network, cols = PCA/t-SNE/UMAP (fit per
-                                network so families don't split by region), ★ = real graph
+  dimred_main.{png,pdf} MAIN figure: one panel per network (LG_DR_MAIN_METHOD), family
+                        density regions + real ★ + dashed line to nearest family centroid
+  dimred_per_graph.{png,pdf}  supplement: rows = network, cols = PCA/t-SNE/UMAP
+  dimred_distance.{png,pdf} + distance_to_real.csv  QUANTITATIVE: distance from the real
+                        graph to each family centroid (heatmap, closest boxed; mean-rank bar)
 
 Env: LG_DR_REGIONS (all 6), LG_DR_NREPS (10), LG_DR_FAMILIES (ER,BA,WS,KR,GRG,SBM,TLG),
-LG_DR_COLINEAR_THRESH (0.9), LG_DR_SEED (12345), LG_DR_TSNE_PERPLEXITY (30).
+LG_DR_COLINEAR_THRESH (0.85), LG_DR_VIF_THRESH (5.0), LG_DR_MAIN_METHOD (t-SNE),
+LG_DR_SEED (12345), LG_DR_TSNE_PERPLEXITY (30).
 """
 from __future__ import annotations
 
@@ -77,9 +83,11 @@ def _float(env, d):
 REGIONS = (os.environ.get("LG_DR_REGIONS") or "PTBR,RU,ES,ENGB,FR,DE").split(",")
 NREPS = _int("LG_DR_NREPS", 10)
 FAMILIES = (os.environ.get("LG_DR_FAMILIES") or "ER,BA,WS,KR,GRG,SBM,TLG").split(",")
-THRESH = _float("LG_DR_COLINEAR_THRESH", 0.9)
+THRESH = _float("LG_DR_COLINEAR_THRESH", 0.85)   # pairwise |Pearson| pre-prune cutoff
+VIF_THRESH = _float("LG_DR_VIF_THRESH", 5.0)      # max variance-inflation factor kept
 SEED = _int("LG_DR_SEED", 12345)
 PERPLEXITY = _float("LG_DR_TSNE_PERPLEXITY", 30.0)
+MAIN_METHOD = os.environ.get("LG_DR_MAIN_METHOD", "t-SNE")  # method for the main figure
 
 
 def log(*a):
@@ -244,26 +252,72 @@ def generate_and_feature():
 
 
 # --------------------------------------------------------------------------- dim-red
+def _vif(Z):
+    """Variance inflation factor per column of a standardized DataFrame Z. VIF_j =
+    1/(1-R_j^2) where R_j^2 is from regressing column j on all the others. Catches
+    multicolinearity (a feature being a linear combination of several others), not just
+    pairwise correlation."""
+    from sklearn.linear_model import LinearRegression
+    cols = list(Z.columns)
+    out = {}
+    for c in cols:
+        others = [o for o in cols if o != c]
+        if not others:
+            out[c] = 1.0; continue
+        r2 = LinearRegression().fit(Z[others].values, Z[c].values).score(
+            Z[others].values, Z[c].values)
+        out[c] = np.inf if r2 >= 1 - 1e-12 else 1.0 / (1.0 - r2)
+    return out
+
+
 def _prune_colinear(F, thresh):
-    """Greedy: keep a feature unless |corr| >= thresh with an already-kept one. Orders by
-    descending variance so the most informative features are kept first."""
+    """Remove colinearity in two passes: (1) drop one of any pair with |Pearson| >= thresh
+    (keep the higher-variance one); (2) iteratively drop the highest-VIF feature until every
+    remaining feature has VIF < VIF_THRESH. Returns the non-colinear feature subset."""
+    from sklearn.preprocessing import StandardScaler
     order = F.var().sort_values(ascending=False).index.tolist()
     corr = F.corr().abs()
     keep = []
     for c in order:
         if all(corr.loc[c, k] < thresh for k in keep):
             keep.append(c)
-    return keep
+    Z = pd.DataFrame(StandardScaler().fit_transform(F[keep].values), columns=keep)
+    cur = list(keep)
+    while len(cur) > 2:
+        vifs = _vif(Z[cur])
+        worst = max(vifs, key=vifs.get)
+        if vifs[worst] < VIF_THRESH:
+            break
+        cur.remove(worst)
+    return cur
 
 
-# Okabe-Ito colorblind-safe palette + distinct markers, one per family.
-_OKABE = ["#0072B2", "#E69F00", "#009E73", "#D55E00", "#CC79A7", "#56B4E9", "#F0E442"]
-_MARKERS = ["o", "s", "^", "D", "v", "P", "X"]
+# Explicit colorblind-safe (Okabe-Ito) color + marker per family. The two models of
+# interest (TLG, SBM) get strong, high-contrast colors; baselines are muted.
+_FAM_STYLE = {
+    "ER":  ("#999999", "o"),   # gray
+    "BA":  ("#E69F00", "s"),   # orange
+    "WS":  ("#009E73", "^"),   # green
+    "KR":  ("#56B4E9", "D"),   # sky blue
+    "GRG": ("#CC79A7", "v"),   # pink
+    "SBM": ("#0072B2", "P"),   # strong blue
+    "TLG": ("#D55E00", "X"),   # strong vermillion (the model of interest)
+}
+
+
+def _fam_color(f):
+    return _FAM_STYLE.get(f, ("#777777", "o"))[0]
+
+
+def _fam_marker(f):
+    return _FAM_STYLE.get(f, ("#777777", "o"))[1]
 
 
 def _cov_ellipse(ax, x, y, color, nstd=2.0):
-    """2-sigma covariance ellipse of a family's point cloud (cluster footprint)."""
+    """2-sigma covariance ellipse = a family's density region (translucent fill + solid
+    edge). This is the family's representation in the figure (the points are not drawn)."""
     from matplotlib.patches import Ellipse
+    from matplotlib.colors import to_rgba
     if len(x) < 3:
         return
     cov = np.cov(x, y)
@@ -272,8 +326,20 @@ def _cov_ellipse(ax, x, y, color, nstd=2.0):
     vals, vecs = vals[o], vecs[:, o]
     ang = np.degrees(np.arctan2(vecs[1, 0], vecs[0, 0]))
     w, h = 2 * nstd * np.sqrt(np.maximum(vals, 1e-12))
-    ax.add_patch(Ellipse((x.mean(), y.mean()), w, h, angle=ang, facecolor=color,
-                         alpha=0.13, edgecolor=color, lw=1.0, zorder=1))
+    ax.add_patch(Ellipse((x.mean(), y.mean()), w, h, angle=ang,
+                         facecolor=to_rgba(color, 0.22), edgecolor=color, lw=1.8, zorder=1))
+
+
+def _legend_handles(fams):
+    """Legend: a filled patch (density region) per family + a star for the real graph."""
+    from matplotlib.patches import Patch
+    from matplotlib.lines import Line2D
+    from matplotlib.colors import to_rgba
+    h = [Patch(facecolor=to_rgba(_fam_color(f), 0.30), edgecolor=_fam_color(f), lw=1.6,
+               label=f) for f in fams]
+    h.append(Line2D([], [], marker="*", color="black", markersize=15, ls="none",
+                    markeredgecolor="white", label="real (Twitch)"))
+    return h
 
 
 def _grid_figure(meta, F, keep):
@@ -298,12 +364,12 @@ def _grid_figure(meta, F, keep):
     methods = ["PCA", "t-SNE"] + (["UMAP"] if has_umap else [])
     regions = [r for r in REGIONS if r in set(meta["region"])]
     fams = [f for f in FAMILIES if f in set(meta["family"])]
-    color = {f: _OKABE[i % len(_OKABE)] for i, f in enumerate(fams)}
-    marker = {f: _MARKERS[i % len(_MARKERS)] for i, f in enumerate(fams)}
+    color = {f: _fam_color(f) for f in fams}
 
     fig, axes = plt.subplots(len(regions), len(methods),
                              figsize=(4.8 * len(methods), 4.3 * len(regions)), squeeze=False)
     emb_rows = []
+    region_embeds = {}
     for ri, region in enumerate(regions):
         mask = (meta["region"] == region).values
         sub = meta[mask].reset_index(drop=True)
@@ -315,17 +381,15 @@ def _grid_figure(meta, F, keep):
             emb["UMAP"] = umap.UMAP(n_components=2, random_state=SEED,
                                     n_neighbors=min(15, len(Xr) - 1),
                                     min_dist=0.1).fit_transform(Xr)
+        region_embeds[region] = (emb, sub)
         for ci, method in enumerate(methods):
             ax = axes[ri][ci]; e = emb[method]
-            for f in fams:
+            for f in fams:                       # families: density region only (no points)
                 m = (sub["family"] == f).values
                 _cov_ellipse(ax, e[m, 0], e[m, 1], color[f])
-                ax.scatter(e[m, 0], e[m, 1], s=26, alpha=0.8, color=color[f],
-                           marker=marker[f], edgecolors="white", linewidths=0.3,
-                           zorder=3, label=f)
-            m = (sub["family"] == "real").values
+            m = (sub["family"] == "real").values   # real graph: the only plotted point
             ax.scatter(e[m, 0], e[m, 1], s=300, marker="*", color="black",
-                       edgecolors="white", linewidths=1.2, zorder=6, label="real (Twitch)")
+                       edgecolors="white", linewidths=1.2, zorder=6)
             ax.tick_params(labelbottom=False, labelleft=False, length=0)
             ax.grid(alpha=0.18, lw=0.5)
             if ri == 0:
@@ -336,16 +400,127 @@ def _grid_figure(meta, F, keep):
                 emb_rows.append(dict(region=region, family=sub["family"][j],
                                      rep=int(sub["rep"][j]), method=method,
                                      x=float(e[j, 0]), y=float(e[j, 1])))
-    handles, labels = axes[0][0].get_legend_handles_labels()
-    fig.legend(handles, labels, loc="lower center", ncol=len(fams) + 1, frameon=False,
-               bbox_to_anchor=(0.5, -0.004), handletextpad=0.3, columnspacing=1.1)
-    fig.suptitle("Per-Twitch-network graph-family clusters in structural-feature space "
+    fig.legend(handles=_legend_handles(fams), loc="lower center", ncol=len(fams) + 1,
+               frameon=False, bbox_to_anchor=(0.5, -0.004), handletextpad=0.4,
+               columnspacing=1.1)
+    fig.suptitle("Per-Twitch-network family density regions in structural-feature space "
                  "(rows = network, cols = embedding; ★ = real graph)", y=1.0, fontsize=15)
     fig.tight_layout(rect=[0, 0.022, 1, 0.99])
     for ext in ("png", "pdf"):
         fig.savefig(OUT / f"dimred_per_graph.{ext}", dpi=300, bbox_inches="tight")
     plt.close(fig)
     pd.DataFrame(emb_rows).to_csv(OUT / "embeddings.csv", index=False)
+    return region_embeds
+
+
+def _main_figure(region_embeds, method):
+    """Clean single-method main figure: one panel per Twitch network (2 columns), with
+    per-family covariance ellipses + a thin line from the real graph to its nearest family
+    centroid. 300-dpi PNG + vector PDF."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    plt.rcParams.update({"font.size": 12, "font.family": "DejaVu Sans",
+                         "pdf.fonttype": 42, "ps.fonttype": 42})
+    regions = list(region_embeds)
+    if not regions or method not in region_embeds[regions[0]][0]:
+        return
+    fams = [f for f in FAMILIES if f in set(region_embeds[regions[0]][1]["family"])]
+    color = {f: _fam_color(f) for f in fams}
+    ncol = 2
+    nrow = int(np.ceil(len(regions) / ncol))
+    fig, axes = plt.subplots(nrow, ncol, figsize=(6.2 * ncol, 5.4 * nrow), squeeze=False)
+    for idx, region in enumerate(regions):
+        ax = axes.flat[idx]
+        e, sub = region_embeds[region][0][method], region_embeds[region][1]
+        cents = {}
+        for f in fams:                          # families: density region only (no points)
+            m = (sub["family"] == f).values
+            _cov_ellipse(ax, e[m, 0], e[m, 1], color[f])
+            cents[f] = e[m].mean(0)
+        m = (sub["family"] == "real").values
+        rp = e[m][0]
+        nearest = min(fams, key=lambda f: np.linalg.norm(rp - cents[f]))
+        ax.plot([rp[0], cents[nearest][0]], [rp[1], cents[nearest][1]], color="black",
+                lw=1.0, ls="--", alpha=0.6, zorder=4)
+        ax.scatter(rp[0], rp[1], s=360, marker="*", color="black", edgecolors="white",
+                   linewidths=1.3, zorder=6)               # real graph: the only point
+        ax.set_title(f"{region}  (nearest: {nearest})", fontweight="bold")
+        ax.tick_params(labelbottom=False, labelleft=False, length=0); ax.grid(alpha=0.18, lw=0.5)
+    for j in range(len(regions), nrow * ncol):
+        axes.flat[j].axis("off")
+    fig.legend(handles=_legend_handles(fams), loc="lower center", ncol=len(fams) + 1,
+               frameon=False, bbox_to_anchor=(0.5, -0.01))
+    fig.suptitle(f"Twitch family density regions per network ({method}; "
+                 f"dashed line: real → nearest family centroid)", fontsize=15, y=1.0)
+    fig.tight_layout(rect=[0, 0.03, 1, 0.99])
+    for ext in ("png", "pdf"):
+        fig.savefig(OUT / f"dimred_main.{ext}", dpi=300, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _distance_figure(meta, F, keep):
+    """Quantitative result: per network, Euclidean distance (standardized feature space)
+    from the real graph to each family centroid -> heatmap (closest boxed) + mean-rank bar.
+    Writes distance_to_real.csv and dimred_distance.{png,pdf}; prints the summary."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from sklearn.preprocessing import StandardScaler
+    regions = [r for r in REGIONS if r in set(meta["region"])]
+    fams = [f for f in FAMILIES if f in set(meta["family"])]
+    D = np.full((len(regions), len(fams)), np.nan)
+    for ri, region in enumerate(regions):
+        mask = (meta["region"] == region).values
+        Z = StandardScaler().fit_transform(F[keep].values[mask])
+        sm = meta[mask].reset_index(drop=True)
+        real = Z[(sm["family"] == "real").values]
+        if not len(real):
+            continue
+        for ci, f in enumerate(fams):
+            pts = Z[(sm["family"] == f).values]
+            if len(pts):
+                D[ri, ci] = float(np.linalg.norm(real[0] - pts.mean(0)))
+    Ddf = pd.DataFrame(D, index=regions, columns=fams)
+    Ddf.to_csv(OUT / "distance_to_real.csv")
+    ranks = Ddf.rank(axis=1, method="min")
+    mean_rank = ranks.mean(0).sort_values()
+    order = mean_rank.index.tolist()
+    n_closest = Ddf.idxmin(axis=1).value_counts()
+
+    fig, ax = plt.subplots(1, 2, figsize=(13.5, 0.62 * len(regions) + 2.5),
+                           gridspec_kw={"width_ratios": [2.3, 1]})
+    H = Ddf[order]
+    im = ax[0].imshow(H.values, aspect="auto", cmap="viridis")
+    ax[0].set_xticks(range(len(order))); ax[0].set_xticklabels(order)
+    ax[0].set_yticks(range(len(regions))); ax[0].set_yticklabels(regions)
+    mean_all = np.nanmean(H.values)
+    for ri in range(len(regions)):
+        best = int(np.nanargmin(H.values[ri]))
+        for ci in range(len(order)):
+            v = H.values[ri, ci]
+            ax[0].text(ci, ri, f"{v:.2f}", ha="center", va="center", fontsize=8,
+                       color="white" if v < mean_all else "black",
+                       fontweight="bold" if ci == best else "normal")
+        ax[0].add_patch(plt.Rectangle((best - .5, ri - .5), 1, 1, fill=False,
+                                      edgecolor="red", lw=2.2))
+    ax[0].set_title("Distance from real graph to each family centroid\n"
+                    "(standardized feature space; red box = closest)")
+    fig.colorbar(im, ax=ax[0], shrink=.85, label="Euclidean distance")
+    ax[1].barh(range(len(order)), mean_rank[order].values,
+               color=[_fam_color(f) for f in order])
+    ax[1].set_yticks(range(len(order))); ax[1].set_yticklabels(order); ax[1].invert_yaxis()
+    ax[1].set_xlabel("mean distance rank  (1 = closest to real)")
+    ax[1].set_title("Mean rank across networks"); ax[1].grid(alpha=.25, axis="x")
+    for i, f in enumerate(order):
+        ax[1].text(mean_rank[f], i, f" {mean_rank[f]:.2f}", va="center", fontsize=9)
+    fig.tight_layout()
+    for ext in ("png", "pdf"):
+        fig.savefig(OUT / f"dimred_distance.{ext}", dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    log(f"\ndistance-to-real: closest family by network -> {dict(n_closest)}")
+    log("  mean distance-rank (1=closest): "
+        + ", ".join(f"{f}={mean_rank[f]:.2f}" for f in order))
 
 
 def dimred(records):
@@ -362,20 +537,37 @@ def dimred(records):
 
     keep = _prune_colinear(F, THRESH)
     (OUT / "kept_features.txt").write_text("\n".join(keep))
-    log(f"\nfeatures: {F.shape[1]} candidates -> {len(keep)} non-colinear (|corr|<{THRESH}):")
+    # diagnostics: max pairwise |corr| and max VIF AMONG THE KEPT features
+    from sklearn.preprocessing import StandardScaler
+    Zk = pd.DataFrame(StandardScaler().fit_transform(F[keep].values), columns=keep)
+    kept_corr = Zk.corr().abs()
+    max_pair = (kept_corr.where(~np.eye(len(keep), dtype=bool)).max().max())
+    max_vif = max(_vif(Zk).values())
+    log(f"\nfeatures: {F.shape[1]} candidates -> {len(keep)} non-colinear "
+        f"(|Pearson|<{THRESH} + VIF<{VIF_THRESH}); kept max|corr|={max_pair:.2f} "
+        f"max VIF={max_vif:.2f}:")
     log("  " + ", ".join(keep))
 
-    # colinearity heatmap (candidates)
-    corr = F.corr()
-    fig, ax = plt.subplots(figsize=(11, 9))
-    im = ax.imshow(corr.values, cmap="coolwarm", vmin=-1, vmax=1)
-    ax.set_xticks(range(len(corr))); ax.set_xticklabels(corr.columns, rotation=90, fontsize=7)
-    ax.set_yticks(range(len(corr))); ax.set_yticklabels(corr.columns, fontsize=7)
-    ax.set_title("Candidate feature colinearity (|corr|>%.2f pruned)" % THRESH)
-    fig.colorbar(im, shrink=.8); fig.tight_layout()
-    fig.savefig(OUT / "colinearity.png", dpi=150); plt.close(fig)
+    # colinearity heatmaps: candidates (before) and the kept set (after)
+    fig, axx = plt.subplots(1, 2, figsize=(17, 8))
+    for ax, (C, ttl) in zip(axx, [(F.corr(), f"All {F.shape[1]} candidates"),
+                                  (F[keep].corr(), f"{len(keep)} kept (VIF<{VIF_THRESH})")]):
+        im = ax.imshow(C.values, cmap="coolwarm", vmin=-1, vmax=1)
+        ax.set_xticks(range(len(C))); ax.set_xticklabels(C.columns, rotation=90, fontsize=8)
+        ax.set_yticks(range(len(C))); ax.set_yticklabels(C.columns, fontsize=8)
+        ax.set_title(ttl)
+        for i in range(len(C)):
+            for j in range(len(C)):
+                if i != j and abs(C.values[i, j]) >= 0.5:
+                    ax.text(j, i, f"{C.values[i, j]:.1f}", ha="center", va="center",
+                            fontsize=6, color="black")
+    fig.colorbar(im, ax=axx, shrink=.7, label="Pearson correlation")
+    fig.suptitle("Feature colinearity: candidates vs. pruned set", fontsize=14)
+    fig.savefig(OUT / "colinearity.png", dpi=150, bbox_inches="tight"); plt.close(fig)
 
-    _grid_figure(meta, F, keep)   # one PCA/t-SNE/UMAP per Twitch network (rows), no mixing
+    region_embeds = _grid_figure(meta, F, keep)   # supplementary: all 3 methods x networks
+    _main_figure(region_embeds, MAIN_METHOD)       # main figure: one method, 2 cols, clean
+    _distance_figure(meta, F, keep)                # quantitative: distance-to-real heatmap
     log(f"\nWrote {OUT}/")
 
 

--- a/scripts/dim_red/run_tlg_dimred_twitch.py
+++ b/scripts/dim_red/run_tlg_dimred_twitch.py
@@ -88,6 +88,7 @@ VIF_THRESH = _float("LG_DR_VIF_THRESH", 5.0)      # max variance-inflation facto
 SEED = _int("LG_DR_SEED", 12345)
 PERPLEXITY = _float("LG_DR_TSNE_PERPLEXITY", 30.0)
 MAIN_METHOD = os.environ.get("LG_DR_MAIN_METHOD", "t-SNE")  # method for the main figure
+FOCUS_REGION = os.environ.get("LG_DR_FOCUS_REGION", "")     # network shown in the distance fig
 
 
 def log(*a):
@@ -459,16 +460,19 @@ def _main_figure(region_embeds, method):
     plt.close(fig)
 
 
-def _distance_figure(meta, F, keep):
-    """Quantitative result: per network, Euclidean distance (standardized feature space)
-    from the real graph to each family centroid -> heatmap (closest boxed) + mean-rank bar.
-    Writes distance_to_real.csv and dimred_distance.{png,pdf}; prints the summary."""
+def _distance_figure(meta, F, keep, region_embeds):
+    """Quantitative result + visual: LEFT = heatmap of the distance (standardized feature
+    space) from the real graph to each family centroid (closest boxed); RIGHT = the dim-red
+    embeddings (PCA/t-SNE/UMAP) for one focus network (family density regions + real ★), so
+    the heatmap's numbers and the embedding picture sit side by side. Writes
+    distance_to_real.csv + dimred_distance.{png,pdf}; prints the summary."""
     import matplotlib
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
     from sklearn.preprocessing import StandardScaler
     regions = [r for r in REGIONS if r in set(meta["region"])]
     fams = [f for f in FAMILIES if f in set(meta["family"])]
+    color = {f: _fam_color(f) for f in fams}
     D = np.full((len(regions), len(fams)), np.nan)
     for ri, region in enumerate(regions):
         mask = (meta["region"] == region).values
@@ -488,37 +492,58 @@ def _distance_figure(meta, F, keep):
     order = mean_rank.index.tolist()
     n_closest = Ddf.idxmin(axis=1).value_counts()
 
-    fig, ax = plt.subplots(1, 2, figsize=(13.5, 0.62 * len(regions) + 2.5),
-                           gridspec_kw={"width_ratios": [2.3, 1]})
+    focus = FOCUS_REGION if FOCUS_REGION in region_embeds else regions[0]
+    emb, sub = region_embeds[focus]
+    methods = list(emb)
+
+    fig = plt.figure(figsize=(14, max(7.5, 2.6 * len(methods))))
+    gs = fig.add_gridspec(len(methods), 2, width_ratios=[2.0, 1.35],
+                          wspace=0.16, hspace=0.28)
+    # left: distance heatmap (spans all rows)
+    axh = fig.add_subplot(gs[:, 0])
     H = Ddf[order]
-    im = ax[0].imshow(H.values, aspect="auto", cmap="viridis")
-    ax[0].set_xticks(range(len(order))); ax[0].set_xticklabels(order)
-    ax[0].set_yticks(range(len(regions))); ax[0].set_yticklabels(regions)
+    im = axh.imshow(H.values, aspect="auto", cmap="viridis")
+    axh.set_xticks(range(len(order))); axh.set_xticklabels(order)
+    axh.set_yticks(range(len(regions))); axh.set_yticklabels(regions)
     mean_all = np.nanmean(H.values)
     for ri in range(len(regions)):
         best = int(np.nanargmin(H.values[ri]))
         for ci in range(len(order)):
             v = H.values[ri, ci]
-            ax[0].text(ci, ri, f"{v:.2f}", ha="center", va="center", fontsize=8,
-                       color="white" if v < mean_all else "black",
-                       fontweight="bold" if ci == best else "normal")
-        ax[0].add_patch(plt.Rectangle((best - .5, ri - .5), 1, 1, fill=False,
-                                      edgecolor="red", lw=2.2))
-    ax[0].set_title("Distance from real graph to each family centroid\n"
-                    "(standardized feature space; red box = closest)")
-    fig.colorbar(im, ax=ax[0], shrink=.85, label="Euclidean distance")
-    ax[1].barh(range(len(order)), mean_rank[order].values,
-               color=[_fam_color(f) for f in order])
-    ax[1].set_yticks(range(len(order))); ax[1].set_yticklabels(order); ax[1].invert_yaxis()
-    ax[1].set_xlabel("mean distance rank  (1 = closest to real)")
-    ax[1].set_title("Mean rank across networks"); ax[1].grid(alpha=.25, axis="x")
-    for i, f in enumerate(order):
-        ax[1].text(mean_rank[f], i, f" {mean_rank[f]:.2f}", va="center", fontsize=9)
-    fig.tight_layout()
+            axh.text(ci, ri, f"{v:.2f}", ha="center", va="center", fontsize=8,
+                     color="white" if v < mean_all else "black",
+                     fontweight="bold" if ci == best else "normal")
+        axh.add_patch(plt.Rectangle((best - .5, ri - .5), 1, 1, fill=False,
+                                    edgecolor="red", lw=2.2))
+    axh.add_patch(plt.Rectangle((-.5, regions.index(focus) - .5), len(order), 1, fill=False,
+                                edgecolor="black", lw=1.6, ls=":"))   # focus-row marker
+    axh.set_title("Distance from real graph to each family centroid\n"
+                  "(standardized feature space; red box = closest; dotted = focus network)")
+    fig.colorbar(im, ax=axh, shrink=.85, label="Euclidean distance", pad=0.02)
+    # right: the dim-red embeddings for the focus network (stacked, one per method)
+    for mi, method in enumerate(methods):
+        ax = fig.add_subplot(gs[mi, 1])
+        e = emb[method]; cents = {}
+        for f in fams:
+            m = (sub["family"] == f).values
+            _cov_ellipse(ax, e[m, 0], e[m, 1], color[f]); cents[f] = e[m].mean(0)
+        m = (sub["family"] == "real").values; rp = e[m][0]
+        nearest = min(fams, key=lambda f: np.linalg.norm(rp - cents[f]))
+        ax.plot([rp[0], cents[nearest][0]], [rp[1], cents[nearest][1]], color="black",
+                lw=0.9, ls="--", alpha=0.6, zorder=4)
+        ax.scatter(rp[0], rp[1], s=240, marker="*", color="black", edgecolors="white",
+                   linewidths=1.1, zorder=6)
+        ax.set_title(method, fontsize=11, fontweight="bold")
+        ax.tick_params(labelbottom=False, labelleft=False, length=0); ax.grid(alpha=.18, lw=.5)
+    fig.legend(handles=_legend_handles(fams), loc="lower center", ncol=len(fams) + 1,
+               frameon=False, bbox_to_anchor=(0.5, -0.02))
+    fig.suptitle(f"Distance-to-real (left) and the dim-red embeddings for the {focus} "
+                 f"network (right; family density regions, ★ = real graph)", fontsize=14, y=1.0)
+    fig.tight_layout(rect=[0, 0.04, 1, 0.97])
     for ext in ("png", "pdf"):
         fig.savefig(OUT / f"dimred_distance.{ext}", dpi=300, bbox_inches="tight")
     plt.close(fig)
-    log(f"\ndistance-to-real: closest family by network -> {dict(n_closest)}")
+    log(f"\ndistance-to-real: closest family by network -> {dict(n_closest)}  (focus={focus})")
     log("  mean distance-rank (1=closest): "
         + ", ".join(f"{f}={mean_rank[f]:.2f}" for f in order))
 
@@ -567,7 +592,7 @@ def dimred(records):
 
     region_embeds = _grid_figure(meta, F, keep)   # supplementary: all 3 methods x networks
     _main_figure(region_embeds, MAIN_METHOD)       # main figure: one method, 2 cols, clean
-    _distance_figure(meta, F, keep)                # quantitative: distance-to-real heatmap
+    _distance_figure(meta, F, keep, region_embeds)  # heatmap + the embeddings for one network
     log(f"\nWrote {OUT}/")
 
 

--- a/scripts/experiments/replot_tlg_aic_d.py
+++ b/scripts/experiments/replot_tlg_aic_d.py
@@ -1,0 +1,17 @@
+"""Re-render the AIC d-selection confusion figure from the cached CSV (no rerun).
+
+Usage: replot_tlg_aic_d.py <out_png>
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import pandas as pd
+import run_tlg_aic_d_recovery as R
+
+df = pd.read_csv(R.OUT_DIR / "aic_d_long.csv")
+out = Path(sys.argv[1])
+out.parent.mkdir(parents=True, exist_ok=True)
+R._plot_confusion(df, out)
+print(f"Saved {out}")

--- a/scripts/experiments/replot_tlg_recovery.py
+++ b/scripts/experiments/replot_tlg_recovery.py
@@ -1,0 +1,21 @@
+"""Re-render the parameter-recovery figure from the cached CSV (no experiment rerun).
+
+Loads runs/tlg_recovery/recovery_all.csv and calls the existing plotting function with
+the updated suptitle. Output path is the first CLI argument.
+"""
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("LG_TLG_QUICK", "0")  # full DS=[0,1,2], full NS
+sys.path.insert(0, str(Path(__file__).parent))
+
+import pandas as pd
+import run_tlg_recovery as R
+
+combined = pd.read_csv(R.OUT_DIR / "recovery_all.csv")
+scenarios = list(zip(R.SIGMAS, R.ALPHAS))
+out = Path(sys.argv[1])
+out.parent.mkdir(parents=True, exist_ok=True)
+R.plot_combined_recovery(combined, scenarios, out)
+print(f"Saved {out}")

--- a/scripts/experiments/replot_tlg_roc.py
+++ b/scripts/experiments/replot_tlg_roc.py
@@ -1,0 +1,19 @@
+"""Re-render the ROC figures from the cached roc_long.csv (no experiment rerun).
+
+Usage: replot_tlg_roc.py <out_dir>
+Writes <out_dir>/tlg_roc_effect.png and <out_dir>/tlg_roc_sample.png.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import pandas as pd
+import run_tlg_roc_experiments as R
+
+df = pd.read_csv(R.OUT_DIR / "roc_long.csv")
+outdir = Path(sys.argv[1])
+outdir.mkdir(parents=True, exist_ok=True)
+R._plot(df, "effect", outdir / "tlg_roc_effect.png")
+R._plot(df, "sample", outdir / "tlg_roc_sample.png")
+print(f"Saved tlg_roc_effect.png and tlg_roc_sample.png to {outdir}")

--- a/scripts/experiments/run_tlg_recovery.py
+++ b/scripts/experiments/run_tlg_recovery.py
@@ -188,8 +188,8 @@ def plot_combined_recovery(combined, scenarios, out_path):
     fig.legend(handles=handles, loc="lower center",
                ncol=min(len(scenarios), 5), fontsize=9, frameon=False,
                bbox_to_anchor=(0.5, -0.02))
-    fig.suptitle("TLG parameter recovery — estimates → true value as n grows "
-                 "(colorblind-safe: color+marker = (σ,α) scenario; dashed = truth)")
+    fig.suptitle("LG parameter recovery — estimates → true value as n grows "
+                 "(dashed = truth)")
     fig.tight_layout(rect=[0, 0.03, 1, 1])
     fig.savefig(out_path, dpi=150, bbox_inches="tight")
     plt.close(fig)

--- a/scripts/experiments/run_tlg_roc_experiments.py
+++ b/scripts/experiments/run_tlg_roc_experiments.py
@@ -322,8 +322,8 @@ def _plot(df, sweep, out_path):
     if sweep == "sample":
         fixed_txt = (f" — $|\\Delta\\sigma|={abs(SIGMA2_SAMPLE-SIGMA1):g}$, "
                      f"$|\\Delta\\alpha|={abs(ALPHA2_SAMPLE-ALPHA1):g}$")
-    title = ("TLG ROC: effect size" if sweep == "effect"
-             else "TLG ROC: sample size")
+    title = ("LG ROC: effect size" if sweep == "effect"
+             else "LG ROC: sample size")
     fig.suptitle(f"{title} (null = chance diagonal){fixed_txt}",
                  y=1.01)
     fig.tight_layout()


### PR DESCRIPTION
## What

Adds `scripts/dim_red/run_tlg_dimred_twitch.py` — a dimensionality-reduction experiment that asks *which model family generates graphs structurally closest to the real Twitch networks*.

For each Twitch network (largest CC, BFS-capped to ~1500 — the same subgraph the closed-form/latent experiments use):
1. **Generate n=10 graphs per family** using the closed-form parameter estimation: ER/BA/WS/KR/GRG moment-matched, SBM from Louvain, **TLG by sampling the cached latent degree+community+latent-ASE fit** (reuses the sweep's per-region fit — no expensive re-fit).
2. **Compute ~20 structural features** per graph, then **prune to a non-colinear subset** (greedy |Pearson|<0.9 → ~10: e.g. max/mean k-core, avg degree, avg-neighbor-degree, spectral radius, modularity, transitivity, LCC fraction, spectral gap, triangle density).
3. **Cache every cell** (`cache/<region>_<family>_<rep>.json`: estimated params, features, edges) → fully resumable.
4. **Embed in 2D** with PCA / t-SNE / UMAP.

## Figure

Grid: **rows = the 6 Twitch networks, columns = PCA / t-SNE / UMAP**, each embedding **fit on that network's graphs only**. This was a deliberate design point — embedding all networks together split each family into per-region sub-clusters (the regions differ a lot: real-graph density 0.008→0.026, modularity 0.26→0.41), so per-network embedding gives one clean cluster per family. Per-family covariance ellipses + colorblind-safe color/marker, real graph as a ★; 300-dpi PNG + vector PDF.

**Result:** each family forms a distinct cluster, and in t-SNE/UMAP the real Twitch graph lands on/near the **TLG** cluster in most networks.

## Notes
- Output under `runs/tlg_dimred_twitch/` (gitignored): per-cell cache, `features.csv`, `kept_features.txt`, `colinearity.png`, `embeddings.csv`, `dimred_per_graph.{png,pdf}`.
- `make tlg-dimred-twitch`. Env knobs: `LG_DR_{REGIONS,NREPS,FAMILIES,COLINEAR_THRESH,SEED,TSNE_PERPLEXITY}`.
- Reuses `tlg_latent_gic_common` (loaders, latent-TLG sampler pieces, closed-form baselines); deps sklearn + umap-learn (both already installed).