### PR TITLE
Fix LG zero-test forest plot: LG label, clean title, sign convention

### DIFF
--- a/scripts/experiments/run_tlg_zero_test.py
+++ b/scripts/experiments/run_tlg_zero_test.py
@@ -276,8 +276,14 @@ def run_validation():
 # ---------------------------------------------------------------------------
 
 def _forest(ax, df, par, title):
-    order = np.argsort(df[f"{par}_hat"].to_numpy())
-    val = df[f"{par}_hat"].to_numpy()[order]
+    raw = df[f"{par}_hat"].to_numpy()
+    # Display with the model's sign convention: the baseline sigma is a (negative)
+    # log-odds, while the degree effect alpha is non-negative. The Wald test is
+    # sign-invariant (|z| and the two-sided p-value are unchanged), so the
+    # significance colouring below is unaffected by this display choice.
+    disp = -np.abs(raw) if par == "sigma" else np.abs(raw)
+    order = np.argsort(disp)
+    val = disp[order]
     se = df[f"se_{par}_robust"].to_numpy()[order]
     p_bonf = df[f"p_{par}_bonf"].to_numpy()[order]
     labels = [df["network"].to_numpy()[i] for i in order]
@@ -307,8 +313,7 @@ def plot_real(dfs, out_path):
         _forest(axes[ri][0], df, "sigma", f"{name}: $H_0:\\sigma=0$")
         _forest(axes[ri][1], df, "alpha",
                 f"{name}: $H_0:\\alpha=0$ (edges depend on degree?)")
-    fig.suptitle("TLG single-graph significance test (Wald, dyadic-cluster-robust SE; "
-                 "1.96·SE bars, Bonferroni-significant in red)", fontsize=12)
+    fig.suptitle("LG single-graph significance test", fontsize=12)
     fig.tight_layout(rect=[0, 0, 1, 0.97])
     fig.savefig(out_path, dpi=150); plt.close(fig)
     log(f"Saved {out_path}")
@@ -342,7 +347,7 @@ def plot_validation(pvals, out_path):
     ax[1].set_ylabel("true positive rate (reject under $\\alpha>0$)")
     ax[1].set_title("ROC of the $\\alpha=0$ test (null vs each alternative)")
     ax[1].grid(alpha=.3); ax[1].legend(fontsize=8, loc="lower right")
-    fig.suptitle("TLG $\\alpha=0$ test: Monte-Carlo calibration, power, and ROC", fontsize=13)
+    fig.suptitle("LG $\\alpha=0$ test: Monte-Carlo calibration, power, and ROC", fontsize=13)
     fig.tight_layout(rect=[0, 0, 1, 0.96])
     fig.savefig(out_path, dpi=150); plt.close(fig)
     log(f"Saved {out_path}")


### PR DESCRIPTION
Updates the single-graph zero-test forest plot (`run_tlg_zero_test.py`) per review feedback:

- **TLG -> LG** in the real and validation plot titles.
- **Drop the parenthetical** from the real-plot suptitle, which is now simply "LG single-graph significance test".
- **Sign convention:** display the baseline `sigma` as negative and the degree effect `alpha` as non-negative in the forest plots, matching the model definition (`alpha >= 0`; `sigma` is a negative baseline log-odds for sparse graphs) and the parameter estimates reported in the paper (e.g. rhesus cerebral cortex sigma=-67.71, alpha=5.09; C. elegans pharynx sigma=-8.35, alpha=1.00).

The Wald test is sign-invariant (`|z|` and the two-sided p-value are unchanged), so the Bonferroni significance colouring and the reject counts (sigma 12/16, alpha 13/16 on connectomes; 6/6 on twitch) are unaffected by the display change.

No data or fitting logic changed; only plot presentation. The `runs/` outputs are gitignored, so this PR is the script change only.