### PR TITLE
Retitle latent identifiability figure: TLG -> LG, drop 'latent-' and model note

### DIFF
--- a/scripts/experiments/run_tlg_latent_identifiability.py
+++ b/scripts/experiments/run_tlg_latent_identifiability.py
@@ -287,8 +287,8 @@ def plot_identifiability(combined, scenarios, out_path):
                for s in scenarios]
     fig.legend(handles=handles, loc="lower center", ncol=1, fontsize=9, frameon=False,
                bbox_to_anchor=(0.5, -0.04))
-    fig.suptitle("Unified latent-TLG identifiability — all five coefficients recover by "
-                 "MLE as n grows (dashed = truth; add+remove model)", fontsize=13)
+    fig.suptitle("Unified LG identifiability — all five coefficients recover by "
+                 "MLE as n grows (dashed = truth)", fontsize=13)
     fig.tight_layout(rect=[0, 0.04, 1, 1])
     fig.savefig(out_path, dpi=150, bbox_inches="tight")
     plt.close(fig)


### PR DESCRIPTION
## What

Changes the suptitle of `identifiability.png` (`scripts/experiments/run_tlg_latent_identifiability.py`):

`Unified latent-TLG identifiability — ... (dashed = truth; add+remove model)`
->
`Unified LG identifiability — ... (dashed = truth)`

i.e. **TLG -> LG**, **drop the 'latent-' qualifier**, and **drop the 'add+removal model' note**. The net diff is the two title lines.

## Notes

- **No simulation rerun.** The figure was regenerated directly from the cached `recovery_all.csv` (75 rows, 3 scenarios) in the same output folder — only the title text changes; all curves/data are identical.
- `runs/tlg_latent_identifiability/` is gitignored, so this PR is the script change only.