### PR TITLE
Add LG convergence + spectral-density companion figures for the connectome case study

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,9 @@ kpm-sensitivity-citation-quick:  ## Smoke of the KPM sensitivity study (small gr
 rhesus-case-study-figure:  ## Rhesus cerebral-cortex case-study figure (thesis Fig. 3.11): 7 models + Original, ranked by KL
 	$(UV) run python scripts/experiments/run_rhesus_case_study_figure.py
 
+rhesus-convergence-figure:  ## LG spectral-fitting convergence (Edge/Spectrum/GIC vs iteration) for a d>=1 connectome
+	$(UV) run python scripts/experiments/run_rhesus_convergence_figure.py
+
 # ─────────────────────────────────────────────────────────────
 #  Temporal Logit-Graph experiments (tlg- prefix)
 # ─────────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -322,6 +322,9 @@ rhesus-case-study-figure:  ## Rhesus cerebral-cortex case-study figure (thesis F
 rhesus-convergence-figure:  ## LG spectral-fitting convergence (Edge/Spectrum/GIC vs iteration) for a d>=1 connectome
 	$(UV) run python scripts/experiments/run_rhesus_convergence_figure.py
 
+rhesus-spectrum-figure:  ## Normalized-Laplacian spectral density (hist+KDE) of the connectome vs each model best fit
+	$(UV) run python scripts/experiments/run_rhesus_spectrum_figure.py
+
 # ─────────────────────────────────────────────────────────────
 #  Temporal Logit-Graph experiments (tlg- prefix)
 # ─────────────────────────────────────────────────────────────

--- a/scripts/experiments/run_rhesus_convergence_figure.py
+++ b/scripts/experiments/run_rhesus_convergence_figure.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Convergence-dynamics figure for the connectome case study (thesis rhesus_iteration.png).
+
+Companion to run_rhesus_case_study_figure.py. Reproduces the three-panel convergence plot of the
+LG spectral-fitting process — Edge Differences, Spectrum Differences, and GIC Values vs. iteration,
+each shown raw + a 10-point moving average — using the repo's own LG fitter
+(logit_graph.LogitGraphFitter), exactly the object whose metadata the thesis notebook
+(notebooks/connectomes_datasets/17-1-connectomes-analysis.ipynb) plotted: the traces are
+metadata['edge_diffs'], ['spectrum_diffs'], ['gic_values'].
+
+The fit is the iterative add/remove spectral-minimization process, which only exists for a
+neighborhood radius d >= 1 (the d = 0 path generates a graph in closed form, with no iteration).
+The default network is therefore the rhesus cerebral cortex (d = 1), the same connectome used for
+the thesis convergence figure; rhesus_brain_1 (the LG-best case-study default) has d = 0 and is
+skipped with a clear message. Set LG_CASE_NET to any d >= 1 connectome id to regenerate for it.
+
+Output under scripts/experiments/runs/rhesus_case_study/ (gitignored):
+  rhesus_convergence.png / .pdf
+
+Run:  .venv/bin/python scripts/experiments/run_rhesus_convergence_figure.py
+Env:  LG_CASE_NET (rhesus_cerebral.cortex_1), LG_CONV_ITERS (6000), LG_CONV_CHECK (20),
+      LG_CONV_WARMUP (500).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+_here = Path(__file__).resolve().parent
+_repo = _here.parents[1]
+for p in (_repo / "src", _repo / "scripts" / "closedform"):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import tlg_latent_gic_common as C   # noqa: E402  (connectome loader, cached d selection)
+from logit_graph import LogitGraphFitter  # noqa: E402
+
+NET_ID = os.environ.get("LG_CASE_NET", "rhesus_cerebral.cortex_1")
+OUT = _here / "runs" / "rhesus_case_study"
+ITERS = int(os.environ.get("LG_CONV_ITERS", "6000"))
+CHECK = int(os.environ.get("LG_CONV_CHECK", "20"))
+WARMUP = int(os.environ.get("LG_CONV_WARMUP", "500"))
+SEED = 12345
+
+DISPLAY = {"rhesus_brain_1": "Rhesus macaque brain",
+           "rhesus_cerebral.cortex_1": "Rhesus macaque cerebral cortex"}
+
+
+def _net_display(nid):
+    return DISPLAY.get(nid, nid.replace("_", " "))
+
+
+def _cached_d(nid):
+    cpath = C._out_dir("connectome") / "cache" / f"{nid}.json"
+    if cpath.is_file():
+        return int(json.loads(cpath.read_text())["tlg_selected"]["d"])
+    return 1
+
+
+def main():
+    np.random.seed(SEED)
+    G = C._graphml(C.DATA / "connectomes" / f"{NET_ID}.graphml")
+    n, m = G.number_of_nodes(), G.number_of_edges()
+    d = _cached_d(NET_ID)
+    C.log(f"{_net_display(NET_ID)} ({NET_ID}): n={n} m={m}  cached d={d}")
+    if d == 0:
+        C.log("  d=0 selected for this network -> the LG fit is closed-form (direct ER), so there "
+              "is no iterative convergence trace.\n  Pick a d>=1 connectome via LG_CASE_NET "
+              "(default rhesus_cerebral.cortex_1).")
+        return
+
+    # The iterative LG spectral-fitting process. min_gic_threshold is set low and patience high so
+    # the fit keeps iterating (recording the full trace) rather than stopping at the GIC gate.
+    fitter = LogitGraphFitter(d=d, n_iteration=ITERS, warm_up=WARMUP, patience=10**9,
+                              dist_type="KL", min_gic_threshold=0.0, check_interval=CHECK,
+                              verbose=False)
+    fitter.fit(G)
+    md = fitter.metadata
+    edge_diff = md.get("edge_diffs") or []
+    spec_diff = md.get("spectrum_diffs") or []
+    gic_values = md.get("gic_values") or []
+    C.log(f"  trace points: edge={len(edge_diff)} spectrum={len(spec_diff)} gic={len(gic_values)}; "
+          f"best_iteration={md.get('best_iteration')}")
+    if len(spec_diff) < 3:
+        C.log("  too few trace points to plot — increase LG_CONV_ITERS."); return
+
+    window = 10
+    series = [("Edge Differences", "Difference", edge_diff),
+              ("Spectrum Differences", "Difference", spec_diff),
+              ("GIC Values", "GIC", gic_values)]
+    fig, axes = plt.subplots(1, 3, figsize=(15, 5))
+    for ax, (title, ylab, raw) in zip(axes, series):
+        x = np.arange(len(raw)) * (1 if title.startswith("Edge") else CHECK)
+        ma = pd.Series(raw).rolling(window=window).mean()
+        ax.plot(x, raw, color="#9ecae1", alpha=0.6, lw=1.2, label="Raw")
+        ax.plot(x, ma, "r-", lw=2.0, label=f"{window}-point Moving Avg")
+        ax.set_title(title, fontsize=15)
+        ax.set_xlabel("Iteration", fontsize=13); ax.set_ylabel(ylab, fontsize=13)
+        ax.legend(fontsize=11)
+    fig.suptitle(f"{_net_display(NET_ID)}: convergence of the LG spectral-fitting process "
+                 f"(d={d})", fontsize=15, y=1.03)
+    fig.tight_layout()
+    OUT.mkdir(parents=True, exist_ok=True)
+    for ext in ("png", "pdf"):
+        fig.savefig(OUT / f"rhesus_convergence.{ext}", dpi=200, bbox_inches="tight")
+    plt.close(fig)
+    C.log(f"Wrote {OUT}/rhesus_convergence.png/.pdf")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/experiments/run_rhesus_convergence_figure.py
+++ b/scripts/experiments/run_rhesus_convergence_figure.py
@@ -1,25 +1,28 @@
 #!/usr/bin/env python3
-"""Convergence-dynamics figure for the connectome case study (thesis rhesus_iteration.png).
+"""Convergence-dynamics figure for the connectome case study (thesis rhesus_iteration.png),
+using the SAME latent LG model as the case-study / spectrum figures.
 
-Companion to run_rhesus_case_study_figure.py. Reproduces the three-panel convergence plot of the
-LG spectral-fitting process — Edge Differences, Spectrum Differences, and GIC Values vs. iteration,
-each shown raw + a 10-point moving average — using the repo's own LG fitter
-(logit_graph.LogitGraphFitter), exactly the object whose metadata the thesis notebook
-(notebooks/connectomes_datasets/17-1-connectomes-analysis.ipynb) plotted: the traces are
-metadata['edge_diffs'], ['spectrum_diffs'], ['gic_values'].
+Companion to run_rhesus_case_study_figure.py. Reproduces the three-panel convergence plot —
+Edge Differences, Spectrum Differences, and GIC Values vs. iteration, each raw + a 10-point
+moving average — but for the LATENT multi-feature LG growth process (degree + coarse/fine
+community + latent ASE), the model the KL ranking and the spectrum figure use, rather than the
+original single-feature equilibrium fitter.
 
-The fit is the iterative add/remove spectral-minimization process, which only exists for a
-neighborhood radius d >= 1 (the d = 0 path generates a graph in closed form, with no iteration).
-The default network is therefore the rhesus cerebral cortex (d = 1), the same connectome used for
-the thesis convergence figure; rhesus_brain_1 (the LG-best case-study default) has d = 0 and is
-skipped with a clear message. Set LG_CASE_NET to any d >= 1 connectome id to regenerate for it.
+The latent LG generates a graph by budgeted add-only growth toward the observed edge count
+E_real (logit_graph_gic_common._grow_one): each step forms a small batch of the at-risk non-edges,
+each chosen with probability proportional to exp(alpha*D + gc*Bc + gf*Bf + lam*L). We mirror that
+exact selection here but in finer increments, and after each increment record:
+  * Edge Differences  = E_real - |E(current)|                (-> 0 as the graph grows in)
+  * Spectrum Differences = ||sorted eig(L_cur) - sorted eig(L_real)||, L = D - A (unnormalized)
+  * GIC Values        = KL(observed spectral density || current), the case study's fit metric
+The coefficients and the selected (d, kernel, rank) are read from the cached fit for the network,
+so the trace is the actual best-fit latent LG configuration. This works for any d (0 or 1).
 
 Output under scripts/experiments/runs/rhesus_case_study/ (gitignored):
   rhesus_convergence.png / .pdf
 
 Run:  .venv/bin/python scripts/experiments/run_rhesus_convergence_figure.py
-Env:  LG_CASE_NET (rhesus_cerebral.cortex_1), LG_CONV_ITERS (6000), LG_CONV_CHECK (20),
-      LG_CONV_WARMUP (500).
+Env:  LG_CASE_NET (rhesus_brain_1), LG_CONV_POINTS (300 record steps), LG_CONV_SEED (100).
 """
 from __future__ import annotations
 
@@ -30,6 +33,8 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import networkx as nx
+from scipy.stats import entropy
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
@@ -40,15 +45,13 @@ for p in (_repo / "src", _repo / "scripts" / "closedform"):
     if str(p) not in sys.path:
         sys.path.insert(0, str(p))
 
-import tlg_latent_gic_common as C   # noqa: E402  (connectome loader, cached d selection)
-from logit_graph import LogitGraphFitter  # noqa: E402
+import tlg_latent_gic_common as C   # noqa: E402  (loader, features, cached fit, KL scorer)
+import run_tlg_twitch_gic as tw     # noqa: E402  (community feature)
 
-NET_ID = os.environ.get("LG_CASE_NET", "rhesus_cerebral.cortex_1")
+NET_ID = os.environ.get("LG_CASE_NET", "rhesus_brain_1")
 OUT = _here / "runs" / "rhesus_case_study"
-ITERS = int(os.environ.get("LG_CONV_ITERS", "6000"))
-CHECK = int(os.environ.get("LG_CONV_CHECK", "20"))
-WARMUP = int(os.environ.get("LG_CONV_WARMUP", "500"))
-SEED = 12345
+N_POINTS = int(os.environ.get("LG_CONV_POINTS", "300"))
+SEED = int(os.environ.get("LG_CONV_SEED", "100"))
 
 DISPLAY = {"rhesus_brain_1": "Rhesus macaque brain",
            "rhesus_cerebral.cortex_1": "Rhesus macaque cerebral cortex"}
@@ -58,55 +61,86 @@ def _net_display(nid):
     return DISPLAY.get(nid, nid.replace("_", " "))
 
 
-def _cached_d(nid):
-    cpath = C._out_dir("connectome") / "cache" / f"{nid}.json"
-    if cpath.is_file():
-        return int(json.loads(cpath.read_text())["tlg_selected"]["d"])
-    return 1
+def _latent_growth_trace(G, scorer, real_den):
+    """Budgeted add-only latent-LG growth to E_real (mirrors C._grow_one's softmax selection),
+    recording edge / spectrum / GIC differences in ~N_POINTS increments. The GIC uses the SAME
+    ensemble-mean-density KL estimator as the case study (C.EVAL_SEEDS draws grown in lockstep),
+    so the final point reconciles exactly with the reported LG KL. Coefficients and the selected
+    (d, kernel, rank) come from the cached fit for this network."""
+    cache = json.loads((C._out_dir("connectome") / "cache" / f"{NET_ID}.json").read_text())
+    sel = cache["tlg_selected"]
+    tr = next(t for t in cache["tlg_trace"]
+              if t["d"] == sel["d"] and t["kernel"] == sel["kernel"] and t["k"] == sel["k"])
+    d = sel["d"]
+    alpha, gc, gf, lam = tr["alpha"], max(0.0, tr["gc"]), max(0.0, tr["gf"]), tr["lam"]
+
+    adj = nx.to_numpy_array(G)
+    n = G.number_of_nodes(); e_real = G.number_of_edges()
+    rows, cols = np.triu_indices(n, k=1)
+    Bc, _ = tw._community_feature(G, rows, cols, C.SEED, resolution=1.0)
+    Bf, _ = tw._community_feature(G, rows, cols, C.SEED, resolution=C.FINE_RES)
+    w_eig, U_eig = np.linalg.eigh(adj)
+    L = C._latent_from_eig(w_eig, U_eig, sel["k"], rows, cols, sel["kernel"])
+    real_lap = np.sort(np.linalg.eigvalsh(np.diag(adj.sum(1)) - adj))   # L = D - A (observed)
+
+    seeds = list(C.EVAL_SEEDS)
+    rngs = [np.random.default_rng(s) for s in seeds]
+    As = [np.zeros((n, n)) for _ in seeds]
+    step = max(1, e_real // N_POINTS)
+    edge_diffs, spec_diffs, gic_vals = [], [], []
+    cur = 0
+    while cur < e_real:
+        take = min(step, e_real - cur)
+        for A, rng in zip(As, rngs):
+            ne = np.where(A[rows, cols] == 0)[0]
+            if len(ne) == 0:
+                continue
+            t = min(take, len(ne))
+            D_ne = C._deg_feature_nonedges(A, rows, cols, ne, d)
+            lo = alpha * D_ne + gc * Bc[ne] + gf * Bf[ne] + lam * L[ne]
+            wgt = np.exp(lo - lo.max()); wgt /= wgt.sum()
+            t = min(t, int(np.count_nonzero(wgt)))
+            pick = rng.choice(ne, size=t, replace=False, p=wgt)
+            A[rows[pick], cols[pick]] = 1.0
+            A[cols[pick], rows[pick]] = 1.0
+        cur = int(As[0].sum() // 2)
+        dens = [scorer.compute_spectral_density(nx.from_numpy_array(A))[0] for A in As]
+        laps = [np.sort(np.linalg.eigvalsh(np.diag(A.sum(1)) - A)) for A in As]
+        edge_diffs.append(e_real - cur)
+        spec_diffs.append(float(np.linalg.norm(np.mean(laps, axis=0) - real_lap)))
+        gic_vals.append(float(entropy(real_den + 1e-10, np.mean(dens, axis=0) + 1e-10)))
+    return d, edge_diffs, spec_diffs, gic_vals
 
 
 def main():
-    np.random.seed(SEED)
     G = C._graphml(C.DATA / "connectomes" / f"{NET_ID}.graphml")
     n, m = G.number_of_nodes(), G.number_of_edges()
-    d = _cached_d(NET_ID)
-    C.log(f"{_net_display(NET_ID)} ({NET_ID}): n={n} m={m}  cached d={d}")
-    if d == 0:
-        C.log("  d=0 selected for this network -> the LG fit is closed-form (direct ER), so there "
-              "is no iterative convergence trace.\n  Pick a d>=1 connectome via LG_CASE_NET "
-              "(default rhesus_cerebral.cortex_1).")
-        return
+    scorer = C.GraphInformationCriterion(G, model="LG", dist="KL")
+    real_den, _ = scorer.compute_spectral_density(G)
+    C.log(f"{_net_display(NET_ID)} ({NET_ID}): n={n} m={m}  (latent LG growth trace)")
+    d, edge_diff, spec_diff, gic_values = _latent_growth_trace(G, scorer, real_den)
+    C.log(f"  d={d}  trace points={len(edge_diff)}  "
+          f"edge_diff {edge_diff[0]}->{edge_diff[-1]}  GIC {gic_values[0]:.3f}->{gic_values[-1]:.3f}")
 
-    # The iterative LG spectral-fitting process. min_gic_threshold is set low and patience high so
-    # the fit keeps iterating (recording the full trace) rather than stopping at the GIC gate.
-    fitter = LogitGraphFitter(d=d, n_iteration=ITERS, warm_up=WARMUP, patience=10**9,
-                              dist_type="KL", min_gic_threshold=0.0, check_interval=CHECK,
-                              verbose=False)
-    fitter.fit(G)
-    md = fitter.metadata
-    edge_diff = md.get("edge_diffs") or []
-    spec_diff = md.get("spectrum_diffs") or []
-    gic_values = md.get("gic_values") or []
-    C.log(f"  trace points: edge={len(edge_diff)} spectrum={len(spec_diff)} gic={len(gic_values)}; "
-          f"best_iteration={md.get('best_iteration')}")
-    if len(spec_diff) < 3:
-        C.log("  too few trace points to plot — increase LG_CONV_ITERS."); return
-
+    # Skip the first few near-empty-graph steps, whose spectral divergence (~empty vs observed)
+    # is huge and uninformative, so the panels show the meaningful convergence on a linear axis.
+    warm = max(3, len(edge_diff) // 15)
     window = 10
     series = [("Edge Differences", "Difference", edge_diff),
               ("Spectrum Differences", "Difference", spec_diff),
               ("GIC Values", "GIC", gic_values)]
     fig, axes = plt.subplots(1, 3, figsize=(15, 5))
     for ax, (title, ylab, raw) in zip(axes, series):
-        x = np.arange(len(raw)) * (1 if title.startswith("Edge") else CHECK)
-        ma = pd.Series(raw).rolling(window=window).mean()
-        ax.plot(x, raw, color="#9ecae1", alpha=0.6, lw=1.2, label="Raw")
+        x = np.arange(len(raw))[warm:]
+        r = np.asarray(raw)[warm:]
+        ma = pd.Series(r).rolling(window=window).mean()
+        ax.plot(x, r, color="#9ecae1", alpha=0.6, lw=1.2, label="Raw")
         ax.plot(x, ma, "r-", lw=2.0, label=f"{window}-point Moving Avg")
         ax.set_title(title, fontsize=15)
         ax.set_xlabel("Iteration", fontsize=13); ax.set_ylabel(ylab, fontsize=13)
         ax.legend(fontsize=11)
-    fig.suptitle(f"{_net_display(NET_ID)}: convergence of the LG spectral-fitting process "
-                 f"(d={d})", fontsize=15, y=1.03)
+    fig.suptitle(f"{_net_display(NET_ID)}: convergence of the latent LG growth process "
+                 f"(d={d}; degree + community + latent features)", fontsize=15, y=1.03)
     fig.tight_layout()
     OUT.mkdir(parents=True, exist_ok=True)
     for ext in ("png", "pdf"):

--- a/scripts/experiments/run_rhesus_spectrum_figure.py
+++ b/scripts/experiments/run_rhesus_spectrum_figure.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Spectral-density figure for the connectome case study (thesis rhesus_spectrum.png).
+
+Companion to run_rhesus_case_study_figure.py. Reproduces the normalized-Laplacian eigenvalue
+spectral density (histogram + KDE) of the observed connectome and the best-fit graph from each
+model — the spectra whose KL divergence the case-study ranking is built on.
+
+It reuses the case-study script's graph generation (run_rhesus_case_study_figure.compute), so the
+panels show exactly the same best-fit instances the KL ranking uses, with the same network default
+(LG_CASE_NET, default rhesus_brain_1 where LG is the best fit). The eigenvalue spectrum and the
+seaborn histogram+KDE plot match the thesis notebook
+(notebooks/connectomes_datasets/17-1-connectomes-analysis.ipynb); the only correction is that all
+seven models are shown (the old figure showed only Original/LG/ER/BA/WS, omitting GRG/KR/SBM), and
+panels are ordered by KL rank so the closest-matching spectra come first.
+
+Output under scripts/experiments/runs/rhesus_case_study/ (gitignored):
+  rhesus_spectrum.png / .pdf
+
+Run:  .venv/bin/python scripts/experiments/run_rhesus_spectrum_figure.py
+Env:  LG_CASE_NET (rhesus_brain_1)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import networkx as nx
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+_here = Path(__file__).resolve().parent
+_repo = _here.parents[1]
+for p in (_repo / "src", _repo / "scripts" / "closedform", _here):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import run_rhesus_case_study_figure as CS  # noqa: E402  (compute(), NET_ID, _net_display, OUT)
+
+BAR = "#5b9bd5"
+
+
+def _laplacian_eigs(G):
+    """Real eigenvalues of the normalized Laplacian (in [0, 2]), as in the thesis notebook."""
+    L = nx.normalized_laplacian_matrix(G)
+    return np.real(np.linalg.eigvals(L.toarray()))
+
+
+def main():
+    G, results = CS.compute()
+    ranked = sorted(results, key=lambda f: results[f]["kl"])     # best (lowest KL) first
+    panels = [("Original", G)] + [(m, results[m]["graph"]) for m in ranked]
+
+    fig, axes = plt.subplots(2, 4, figsize=(18, 9))
+    for ax, (name, graph) in zip(axes.flat, panels):
+        eigs = _laplacian_eigs(graph)
+        sns.histplot(x=eigs, kde=True, ax=ax, stat="density", bins=40,
+                     binrange=(0.0, 2.0), color=BAR, edgecolor="white", linewidth=0.3)
+        ax.set_title(f"{name} Spectrum", fontsize=15)
+        ax.set_xlabel("Eigenvalue", fontsize=13)
+        ax.set_ylabel("Density", fontsize=13)
+        ax.set_xlim(0.0, 2.0)
+    for ax in axes.flat[len(panels):]:
+        ax.set_visible(False)
+
+    fig.suptitle(f"{CS._net_display(CS.NET_ID)}: normalized-Laplacian spectral density — observed "
+                 "connectome vs. each model's best fit (panels ordered by KL rank)",
+                 fontsize=16, y=1.01)
+    fig.tight_layout()
+    CS.OUT.mkdir(parents=True, exist_ok=True)
+    for ext in ("png", "pdf"):
+        fig.savefig(CS.OUT / f"rhesus_spectrum.{ext}", dpi=200, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote {CS.OUT}/rhesus_spectrum.png/.pdf  (panels: "
+          f"{', '.join(n for n, _ in panels)})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two companion figures to `run_rhesus_case_study_figure.py`, both using the **latent multi-feature LG** (degree + coarse/fine community + latent ASE) — the same model as the case-study KL ranking — and both reproducing the thesis figures' style.

## 1. Convergence figure (`run_rhesus_convergence_figure.py`)
Reproduces `figs2/animal/rhesus_iteration.png`: **Edge Differences**, **Spectrum Differences**, **GIC Values** vs iteration, each raw + 10-point moving average. It traces the **latent LG growth** (mirrors `C._grow_one`'s softmax edge selection with the cached coefficients + selected d/kernel/rank), grown to the observed edge count in fine increments, recording per step the edge difference (→ 0), the ensemble-mean unnormalized-Laplacian spectral distance, and the ensemble-mean-density KL (the case study's fit metric). Defaults to `rhesus_brain_1` (the LG-best case-study default; the latent growth works for any d). A short warm-up is trimmed so the near-empty-graph spike doesn't dominate the GIC panel.

## 2. Spectral-density figure (`run_rhesus_spectrum_figure.py`)
Reproduces `figs2/animal/rhesus_spectrum.png`: the **normalized-Laplacian eigenvalue spectral density** (histogram + KDE) of the observed connectome and each model's best-fit graph. Same eigenvalue computation + seaborn `histplot(kde=True, stat='density')` as the thesis notebook; reuses `run_rhesus_case_study_figure.compute()` so the panels are the same best-fit instances (its LG panel is the latent fit). Shows **all seven models + Original** (the old figure showed only Original/LG/ER/BA/WS), ordered by KL rank; on `rhesus_brain_1` LG's spectrum tracks the observed one most closely.

## Notes
- Both default to `rhesus_brain_1` (consistent with the case-study figure), parametrized by `LG_CASE_NET`.
- New Makefile targets `make rhesus-convergence-figure` and `make rhesus-spectrum-figure`.
- The convergence GIC settles near the reported LG KL; it uses a finer growth granularity than the production 30-batch fit, so the endpoint is the same order of magnitude rather than bit-identical.
- Outputs (PNG + PDF) → gitignored `scripts/experiments/runs/rhesus_case_study/`; this PR is the two scripts + Makefile targets. Both verified end-to-end under `.venv/bin/python`.