### PR TITLE
Add ReadTheDocs documentation (MkDocs + Material + mkdocstrings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ notebooks/changes_article/
 
 # local research notes
 FINDINGS.md
+# mkdocs build output
+site/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Read the Docs build configuration (https://docs.readthedocs.io/en/stable/config-file/v2.html).
+# The API reference is extracted statically from src/ by griffe/mkdocstrings, so the
+# build only needs the docs tooling — not the package's heavy runtime deps (numba, umap-learn).
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@
 [![Python](https://img.shields.io/pypi/pyversions/logit-graph?style=flat-square&logo=python&logoColor=white)](https://pypi.org/project/logit-graph/)
 [![License: MIT](https://img.shields.io/github/license/mbottoni/logit-graph?style=flat-square)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/mbottoni/logit-graph/ci.yml?branch=main&style=flat-square&label=tests)](https://github.com/mbottoni/logit-graph/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/readthedocs/logit-graph?style=flat-square&logo=readthedocs&logoColor=white)](https://logit-graph.readthedocs.io/)
 [![Downloads](https://img.shields.io/pypi/dm/logit-graph?style=flat-square)](https://pypi.org/project/logit-graph/)
 
 [Installation](#installation) ·
 [Quickstart](#quickstart-60-seconds) ·
 [Examples](#examples) ·
+[Docs](https://logit-graph.readthedocs.io/) ·
 [API](docs/API.md) ·
 [Changelog](CHANGELOG.md) ·
 [Contributing](CONTRIBUTING.md) ·

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,7 @@
 # API Reference
 
-Detailed reference for the main `logit_graph` exports. For a quick start, see the [README](../README.md).
+Detailed reference for the main `logit_graph` exports. For a quick start, see the [Home page](index.md);
+for the full docstring-generated reference, see the [API Reference](reference.md).
 
 The **paper-consistent** pipeline is:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,47 @@
+# Logit Graph
+
+**Fit, simulate, and compare logit graph models against ER / WS / BA using spectral GIC.**
+
+`logit-graph` is a probabilistic, paper-consistent random-graph model with Layer-2
+estimation and a scikit-learn-style API. It lets you:
+
+| | |
+|---|---|
+| **Estimate** | Pick the neighborhood depth `d̂` by AIC and the intercept `σ̂` from a real graph |
+| **Generate** | Sample graphs whose normalized-Laplacian spectrum matches the data (GIC-guided Gibbs) |
+| **Compare** | Rank LG against Erdős–Rényi, Watts–Strogatz, and Barabási–Albert on the same spectral GIC |
+
+## Installation
+
+```bash
+pip install "logit-graph>=0.1.3"
+```
+
+## Quickstart
+
+The paper-consistent pipeline is
+`simulate_graph` → `select_d_ensemble` → `estimate_sigma_from_graph` → `GraphModelComparator`:
+
+```python
+from logit_graph import simulate_graph, select_d_ensemble, estimate_sigma_from_graph
+
+# Generate a graph at a known (n, d, sigma)
+adj = simulate_graph(n=200, d=1, sigma=-4.0, n_iter=30_000,
+                     feature_mode="incremental", target_density=0.10, seed=42)
+
+# Recover the neighborhood depth by AIC, then the intercept
+d_hat, aic_stats = select_d_ensemble(graphs=[adj], d_candidates=[0, 1, 2, 3])
+sigma_hat = estimate_sigma_from_graph(adj, d=d_hat, feature_mode="incremental")
+```
+
+## Where to next
+
+- **[API Guide](API.md)** — task-oriented walkthrough of the main entry points with examples.
+- **[API Reference](reference.md)** — full reference generated from the source docstrings.
+- **[Connectomes case study](connectomes.md)** — applying LG to real brain networks.
+
+## Model in one line
+
+Edge probability `P(i–j) = sigmoid(σ · (deg_d(i) + deg_d(j)))`; models are ranked by
+`GIC = 2 · spectral_distance(original, fitted) + 2 · |θ|` (lower is better), where the
+spectral distance defaults to the KL divergence between normalized-Laplacian spectral densities.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,48 @@
+# API Reference
+
+Auto-generated from the source docstrings. For a task-oriented walkthrough with examples,
+see the [API Guide](API.md).
+
+All symbols below are importable directly from the top-level `logit_graph` package, e.g.
+`from logit_graph import simulate_graph`.
+
+## Paper-consistent sampler & estimator
+
+::: logit_graph.simulate_graph
+::: logit_graph.select_d_ensemble
+::: logit_graph.estimate_sigma_from_graph
+
+## High-level API (scikit-learn style)
+
+::: logit_graph.LogitGraphFitter
+::: logit_graph.LogitGraphSimulation
+::: logit_graph.GraphModelComparator
+::: logit_graph.estimate_sigma_only
+::: logit_graph.estimate_sigma_many
+::: logit_graph.calculate_graph_attributes
+
+## Core model & estimator
+
+::: logit_graph.GraphModel
+::: logit_graph.LogitRegEstimator
+
+## Features
+
+::: logit_graph.build_pair_dataset
+::: logit_graph.pair_feature
+::: logit_graph.pair_feature_layer2
+::: logit_graph.incremental_h
+::: logit_graph.recommended_iterations
+
+## Temporal / growth Logit-Graph
+
+::: logit_graph.grow_graph
+::: logit_graph.GrowthResult
+::: logit_graph.growth_design_from_snapshots
+::: logit_graph.fit_growth_params
+::: logit_graph.fit_growth_from_result
+
+## Experiment configuration
+
+::: logit_graph.AICSweepConfig
+::: logit_graph.SigmaSweepConfig

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+# Docs-only tooling for the Read the Docs build. The package itself is NOT installed:
+# mkdocstrings reads docstrings statically from src/ via griffe, so the heavy runtime
+# dependencies (numba, umap-learn, statsmodels, ...) are not needed to build the docs.
+mkdocs-material>=9.5
+mkdocstrings[python]>=0.26
+black>=24  # lets mkdocstrings format rendered signatures

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,65 @@
+site_name: Logit Graph
+site_description: Probabilistic logit-based graph model and utilities
+site_url: https://logit-graph.readthedocs.io/
+repo_url: https://github.com/mbottoni/logit-graph
+repo_name: mbottoni/logit-graph
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - content.code.copy
+    - search.suggest
+    - toc.follow
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            show_root_heading: true
+            show_root_full_path: false
+            show_source: true
+            show_signature_annotations: true
+            separate_signature: true
+            merge_init_into_class: true
+            members_order: source
+            heading_level: 3
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+
+nav:
+  - Home: index.md
+  - API Guide: API.md
+  - API Reference: reference.md
+  - Connectomes case study: connectomes.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,13 @@ progress = [
 torch = [
     "torch>=2.0"
 ]
+docs = [
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.26"
+]
 
 [project.urls]
-Homepage = "https://github.com/maruanottoni/logit-graph"
-Repository = "https://github.com/maruanottoni/logit-graph"
-Issues = "https://github.com/maruanottoni/logit-graph/issues"
+Homepage = "https://github.com/mbottoni/logit-graph"
+Repository = "https://github.com/mbottoni/logit-graph"
+Documentation = "https://logit-graph.readthedocs.io/"
+Issues = "https://github.com/mbottoni/logit-graph/issues"


### PR DESCRIPTION
## What

Sets up a documentation site buildable on Read the Docs, using **MkDocs + Material + mkdocstrings**.

### New files
- `mkdocs.yml` — Material theme + `mkdocstrings` (Python handler, `paths: [src]`).
- `.readthedocs.yaml` — RTD v2 build config (Ubuntu 24.04, Python 3.12, MkDocs).
- `docs/requirements.txt` — docs-only tooling (mkdocs-material, mkdocstrings[python], black).
- `docs/index.md` — landing page + quickstart.
- `docs/reference.md` — API reference auto-generated from docstrings via `::: logit_graph.X`.

### Edits
- `pyproject.toml` — adds a `[docs]` extra and fixes stale `maruanottoni` → `mbottoni` repo URLs (+ a `Documentation` URL).
- `docs/API.md` — fixes a dead `../README.md` link (kept as the curated, example-driven API guide).
- `README.md` — Read the Docs badge + Docs link.
- `.gitignore` — ignores the mkdocs `site/` output.

The existing `docs/*.md` (API guide, connectomes case study) are reused as-is in the nav.

## Design notes

- **Lean, fast builds.** mkdocstrings reads docstrings **statically** from `src/` via griffe, so the RTD build installs only the docs tooling — **not** the package's heavy runtime deps (numba, umap-learn, statsmodels). Verified the full API reference still renders (symbols, signatures, docstrings) without importing the package.
- **Reused the cleaned docstrings.** The recently trimmed ≤3-line docstrings render as clean one-line summaries in the API reference.
- **Case-insensitive-FS safe.** The generated page is `docs/reference.md`, not `docs/api.md`, to avoid colliding with the existing `docs/API.md` on a case-insensitive filesystem (macOS).

## Verification

`mkdocs build --strict` passes (no warnings); the reference page renders all public `__all__` symbols with signatures and docstrings.

## Manual step (yours)

Publishing is a one-time action on readthedocs.org: **Import** the `mbottoni/logit-graph` repo (and connect GitHub if the repo is private). Everything here is set up so the first build is green. The README badge/links assume the project slug `logit-graph`.