### PR TITLE
Add multi-feature (unified) temporal Logit-Graph + document the model family

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -131,10 +131,17 @@ After `fit(G)`: `fitter.fitted_graph`, `fitter.metadata`.
 
 ## Model summary
 
-**Edge probability:** `P(i–j) = sigmoid(σ · (deg_d(i) + deg_d(j)))`
+Logistic Random Graph (LG) model, Ottoni–Takahashi–Fujita (2026).
 
-**GIC:** `GIC = 2 · spectral_distance(original, fitted) + 2 · |θ|`
+**Edge probability (Eq. 3.1):** `p_ij = logistic(σ + α·[g(S_i) + g(S_j)])`, with `g(s) = log(1 + s)`
+and `S_i = Σ_{l ∈ N_d(i)} k_l` the neighborhood degree sum over the `d`-hop ball. `σ` is the baseline
+connection propensity; `α ≥ 0` is the strength of the neighborhood degree effect.
 
-**Baselines:** ER, WS, BA, optionally GRG.
+**Extension (§3.7):** append pairwise features — `logit p_ij = σ + Σₖ θₖ·φₖ(i,j)`.
+
+**GIC:** `GIC = 2 · KL(observed ‖ generated) + 2 · |θ|` (lower = better); `KL` is the spectral KL
+divergence between normalized-Laplacian spectral densities and is the un-penalized goodness-of-fit.
+
+**Baselines:** ER, WS, BA, optionally GRG / KR / SBM.
 
 **Spectral distances:** KL (default), L1, L2.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,21 @@
 # Logit Graph
 
-**Fit, simulate, and compare logit graph models against ER / WS / BA using spectral GIC.**
+**Fit, simulate, and compare the Logistic Random Graph (LG) model against ER / WS / BA using spectral GIC.**
 
-`logit-graph` is a probabilistic, paper-consistent random-graph model with Layer-2
-estimation and a scikit-learn-style API. It lets you:
+`logit-graph` is the Python package for the **Logistic Random Graph (LG) model** — a logistic
+random-graph model with neighborhood degree effects — with maximum-likelihood estimation,
+AIC-based model selection, and a scikit-learn-style API. It lets you:
 
 | | |
 |---|---|
-| **Estimate** | Pick the neighborhood depth `d̂` by AIC and the intercept `σ̂` from a real graph |
-| **Generate** | Sample graphs whose normalized-Laplacian spectrum matches the data (GIC-guided Gibbs) |
+| **Estimate** | Pick the neighborhood radius `d̂` by AIC and the parameters `σ̂` (baseline) and `α̂` (degree effect) from a real graph |
+| **Generate** | Run the LG iterative generation algorithm so the normalized-Laplacian spectrum matches the data |
 | **Compare** | Rank LG against Erdős–Rényi, Watts–Strogatz, and Barabási–Albert on the same spectral GIC |
+
+!!! note "Reference"
+    This package accompanies Ottoni, Takahashi & Fujita, *A Logistic Random Graph Model with
+    Neighborhood Degree Effects* (IMA Journal of Complex Networks, 2026), and the corresponding
+    master's thesis. Notation and model names below follow the paper.
 
 ## Installation
 
@@ -40,8 +46,26 @@ sigma_hat = estimate_sigma_from_graph(adj, d=d_hat, feature_mode="incremental")
 - **[API Reference](reference.md)** — full reference generated from the source docstrings.
 - **[Connectomes case study](connectomes.md)** — applying LG to real brain networks.
 
-## Model in one line
+## The model (paper notation)
 
-Edge probability `P(i–j) = sigmoid(σ · (deg_d(i) + deg_d(j)))`; models are ranked by
-`GIC = 2 · spectral_distance(original, fitted) + 2 · |θ|` (lower is better), where the
-spectral distance defaults to the KL divergence between normalized-Laplacian spectral densities.
+Edge probability via the logistic link (Eq. 3.1):
+
+`p_ij = logistic(η_ij)`,  `η_ij = σ + α·[g(S_i) + g(S_j)]`,  `g(s) = log(1 + s)`
+
+where `S_i = Σ_{l ∈ N_d(i)} k_l` is the **neighborhood degree sum** over the `d`-hop ball
+`N_d(i) = {l : dist(i,l) ≤ d}`, **σ** is the baseline connection propensity (baseline log-odds,
+typically negative), and **α ≥ 0** is the strength of the **neighborhood degree effect**.
+
+The **radius `d`** controls how far the degree feature reaches: `d=0` uses each node's own degree
+only (`N_0(i)={i}`, so `S_i = k_i`); `d=1` adds the neighbors' degrees; larger `d` aggregates over a
+wider ball. `d` is selected from the data by AIC (`select_d_ensemble`). The iterative generation algorithm
+draws each pair from its predetermined value on the lagged graph `G(t-1)` (Eq. 3.5), which is also
+what makes maximum-likelihood estimation of `(σ, α)` consistent.
+
+**Extension (§3.7).** Any pairwise features can be appended: `logit p_ij = σ + Σₖ θₖ·φₖ(i,j)`. The
+*unified five-feature LG model* of the thesis adds coarse/fine community indicators (`γc`, `γf`) and a
+latent-proximity feature (`λ`) to the degree term.
+
+Models are ranked by `GIC = 2·KL + 2·|θ|` (lower is better), where `KL` is the Kullback–Leibler
+divergence between the normalized-Laplacian spectral densities of the observed and generated graphs
+and `|θ|` is the number of free parameters; the un-penalized `KL` is reported as the goodness-of-fit.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,22 +6,28 @@ see the [API Guide](API.md).
 All symbols below are importable directly from the top-level `logit_graph` package, e.g.
 `from logit_graph import simulate_graph`.
 
-## The model family
+## The model — Logistic Random Graph (LG)
 
-Every model here scores edges with a logistic link; they differ in what enters the linear predictor.
+There is a single model, the **Logistic Random Graph (LG)** of Ottoni, Takahashi & Fujita (2026);
+the entries below are its computational forms and the general-pairwise-features extension (§3.7).
+All score an edge with a logistic link and differ only in what enters the linear predictor `η_ij`.
 
-| Model | Edge log-odds | Packaged as |
-|-------|---------------|-------------|
-| **Equilibrium LG** | `σ` + degree feature (Gibbs at stationarity) | `simulate_graph`, `GraphModel` |
-| **Temporal LG (TLG)** | `σ + α·D(t-1)` — degree from the predetermined snapshot | [Temporal LG](#temporal-growth-logit-graph) |
-| **Multi-feature TLG** | `σ + α·D(t-1) + Σ βₖ·Fₖ` — degree **plus** fixed exogenous dyad covariates | [Multi-feature TLG](#multi-feature-unified-temporal-logit-graph) |
+| Form | Edge log-odds `η_ij` | Packaged as |
+|------|----------------------|-------------|
+| **Equilibrium sampler** | `σ + α·[g(S_i)+g(S_j)]` at stationarity (Gibbs) | `simulate_graph`, `GraphModel` |
+| **Iterative generation** | same, with `S` evaluated on the lagged graph `G(t-1)` (Eq. 3.5) | [LG generation & estimation](#lg-iterative-generation-estimation) |
+| **General pairwise features (§3.7)** | `σ + Σₖ θₖ·φₖ(i,j)` — degree term **plus** extra features | [Unified LG](#unified-lg-general-pairwise-features) |
 
-- **`σ` (intercept)** — baseline edge log-odds (controls density).
-- **`α` (degree slope)** — how a dyad's degree feature `D` shifts its edge probability (hubs / preferential attachment).
-- **`Fₖ` (extra covariates)** — fixed, exogenous per-dyad features such as same-community indicators
-  (`community_feature`) or latent-embedding proximity (`latent_feature`). Because every `Fₖ` and the
-  lagged `D` are predetermined, the pooled dyad design is an ordinary logistic regression whose MLE
-  recovers `(σ, α, β₁…βₖ)` consistently — the property that makes the multi-feature model identifiable.
+- **`σ`** — baseline connection propensity (baseline log-odds; typically negative).
+- **`α ≥ 0`** — strength of the neighborhood degree effect on `g(S_i)+g(S_j)`, `g(s)=log(1+s)`,
+  `S_i = Σ_{l∈N_d(i)} k_l` the neighborhood degree sum over the `d`-hop ball.
+- **`d`** — the neighborhood radius (hops). `d=0` uses each node's own degree only (`S_i = k_i`);
+  `d=1` adds the neighbors' degrees; larger `d` reaches further. Selected from data by AIC.
+- **`φₖ` (extra features)** — appended columns: exogenous / pair-local ones (e.g. block membership via
+  `community_feature`) are directly estimable; globally-coupled ones (e.g. latent proximity via
+  `latent_feature`, or the degree term itself) are made consistent by the **predetermined-predictor
+  (temporal)** form that reads them off `G(t-1)`. The *unified five-feature LG model* of the thesis is the
+  instance with degree + coarse/fine community (`γc`, `γf`) + latent proximity (`λ`).
 
 ## Paper-consistent sampler & estimator
 
@@ -51,10 +57,11 @@ Every model here scores edges with a logistic link; they differ in what enters t
 ::: logit_graph.incremental_h
 ::: logit_graph.recommended_iterations
 
-## Temporal / growth Logit-Graph
+## LG: iterative generation & estimation
 
-The degree-only temporal model: `logit P[edge_ij at t] = σ + α·D(t-1)`, with `D` read from the
-predetermined previous snapshot so the pooled dyad design is an ordinary logistic regression.
+The LG iterative generation algorithm and its estimator: `logit Pr[A_ij(t)=1 | G(t-1)] = σ + α·D(t-1)`
+(Eq. 3.5), with the degree term `D = g(S_i)+g(S_j)` read from the predetermined previous graph so the
+pooled dyad design is an ordinary logistic regression and the MLE of `(σ, α)` is consistent.
 
 ::: logit_graph.grow_graph
 ::: logit_graph.GrowthResult
@@ -62,12 +69,12 @@ predetermined previous snapshot so the pooled dyad design is an ordinary logisti
 ::: logit_graph.fit_growth_params
 ::: logit_graph.fit_growth_from_result
 
-## Multi-feature (unified) Temporal Logit-Graph
+## Unified LG: general pairwise features
 
-The TLG extended with fixed exogenous dyad covariates:
-`logit P[edge_ij at t] = σ + α·D(t-1) + Σ βₖ·Fₖ`. `grow_graph_multi` / `fit_multi_params` mirror the
-degree-only API but carry arbitrary extra features; `community_feature` and `latent_feature` build the
-canonical same-community and latent-embedding covariates from an observed graph.
+The §3.7 extension `logit p_ij = σ + Σₖ θₖ·φₖ(i,j)`: the degree term plus arbitrary appended pairwise
+features. `grow_graph_multi` / `fit_multi_params` mirror the degree-only API but carry the extra features;
+`community_feature` (block membership) and `latent_feature` (latent proximity) build the canonical
+covariates of the thesis's unified five-feature LG model from an observed graph.
 
 ::: logit_graph.grow_graph_multi
 ::: logit_graph.MultiGrowthResult

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,6 +6,23 @@ see the [API Guide](API.md).
 All symbols below are importable directly from the top-level `logit_graph` package, e.g.
 `from logit_graph import simulate_graph`.
 
+## The model family
+
+Every model here scores edges with a logistic link; they differ in what enters the linear predictor.
+
+| Model | Edge log-odds | Packaged as |
+|-------|---------------|-------------|
+| **Equilibrium LG** | `σ` + degree feature (Gibbs at stationarity) | `simulate_graph`, `GraphModel` |
+| **Temporal LG (TLG)** | `σ + α·D(t-1)` — degree from the predetermined snapshot | [Temporal LG](#temporal-growth-logit-graph) |
+| **Multi-feature TLG** | `σ + α·D(t-1) + Σ βₖ·Fₖ` — degree **plus** fixed exogenous dyad covariates | [Multi-feature TLG](#multi-feature-unified-temporal-logit-graph) |
+
+- **`σ` (intercept)** — baseline edge log-odds (controls density).
+- **`α` (degree slope)** — how a dyad's degree feature `D` shifts its edge probability (hubs / preferential attachment).
+- **`Fₖ` (extra covariates)** — fixed, exogenous per-dyad features such as same-community indicators
+  (`community_feature`) or latent-embedding proximity (`latent_feature`). Because every `Fₖ` and the
+  lagged `D` are predetermined, the pooled dyad design is an ordinary logistic regression whose MLE
+  recovers `(σ, α, β₁…βₖ)` consistently — the property that makes the multi-feature model identifiable.
+
 ## Paper-consistent sampler & estimator
 
 ::: logit_graph.simulate_graph
@@ -36,11 +53,28 @@ All symbols below are importable directly from the top-level `logit_graph` packa
 
 ## Temporal / growth Logit-Graph
 
+The degree-only temporal model: `logit P[edge_ij at t] = σ + α·D(t-1)`, with `D` read from the
+predetermined previous snapshot so the pooled dyad design is an ordinary logistic regression.
+
 ::: logit_graph.grow_graph
 ::: logit_graph.GrowthResult
 ::: logit_graph.growth_design_from_snapshots
 ::: logit_graph.fit_growth_params
 ::: logit_graph.fit_growth_from_result
+
+## Multi-feature (unified) Temporal Logit-Graph
+
+The TLG extended with fixed exogenous dyad covariates:
+`logit P[edge_ij at t] = σ + α·D(t-1) + Σ βₖ·Fₖ`. `grow_graph_multi` / `fit_multi_params` mirror the
+degree-only API but carry arbitrary extra features; `community_feature` and `latent_feature` build the
+canonical same-community and latent-embedding covariates from an observed graph.
+
+::: logit_graph.grow_graph_multi
+::: logit_graph.MultiGrowthResult
+::: logit_graph.multi_design_from_snapshots
+::: logit_graph.fit_multi_params
+::: logit_graph.community_feature
+::: logit_graph.latent_feature
 
 ## Experiment configuration
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,9 @@ theme:
     - search.suggest
     - toc.follow
 
+watch:
+  - src
+
 plugins:
   - search
   - mkdocstrings:

--- a/src/logit_graph/__init__.py
+++ b/src/logit_graph/__init__.py
@@ -41,6 +41,15 @@ from .temporal import (
     grow_graph,
     growth_design_from_snapshots,
 )
+# Multi-feature (unified) temporal LG: degree + arbitrary fixed exogenous dyad covariates.
+from .temporal_multi import (
+    MultiGrowthResult,
+    community_feature,
+    fit_multi_params,
+    grow_graph_multi,
+    latent_feature,
+    multi_design_from_snapshots,
+)
 
 __all__ = [
     # Core model
@@ -74,4 +83,11 @@ __all__ = [
     "growth_design_from_snapshots",
     "fit_growth_params",
     "fit_growth_from_result",
+    # Multi-feature (unified) temporal Logit-Graph
+    "grow_graph_multi",
+    "MultiGrowthResult",
+    "multi_design_from_snapshots",
+    "fit_multi_params",
+    "community_feature",
+    "latent_feature",
 ]

--- a/src/logit_graph/temporal_multi.py
+++ b/src/logit_graph/temporal_multi.py
@@ -1,7 +1,6 @@
-"""Multi-feature (unified) Temporal Logit-Graph: the degree-only temporal model extended with
-fixed exogenous dyad covariates, logit P[edge_ij at t] = sigma + alpha*D(t-1) + sum_k beta_k*F_k.
-Every F_k is predetermined, so the pooled dyad design is an ordinary logistic regression whose
-MLE recovers (sigma, alpha, beta_1..beta_k) consistently — no degeneracy."""
+"""Unified Logistic Random Graph (LG) model — the general-pairwise-features extension (paper Sec 3.7):
+logit p_ij = sigma + alpha*D(t-1) + sum_k theta_k*phi_k(i,j). Predetermined predictors make the pooled
+dyad design an ordinary logistic regression whose MLE recovers (sigma, alpha, theta_1..theta_k) consistently."""
 from __future__ import annotations
 
 import warnings
@@ -103,11 +102,9 @@ def grow_graph_multi(
     record_design: bool = True,
     store_snapshots: bool = True,
 ) -> MultiGrowthResult:
-    """Grow a multi-feature temporal Logit-Graph from a sparse ER seed. ``features`` is an
-    (n*(n-1)/2, k) array of FIXED exogenous dyad covariates (upper-triangle order) with
-    coefficients ``coefs``; each step draws dyads from expit(sigma + alpha*D + features @ coefs),
-    D read from the previous snapshot. allow_removal (default) resamples every dyad (ergodic
-    chain); allow_removal=False grows add-only. Returns the pooled design and outcomes."""
+    """Generate from the unified LG (general pairwise features) by growth from a sparse ER seed:
+    ``features`` (n*(n-1)/2, k) are fixed pairwise covariates phi_k with coefficients ``coefs``, and each
+    step draws dyads from expit(sigma + alpha*D + features @ coefs), D from G(t-1) (allow_removal=ergodic)."""
     features = np.atleast_2d(np.asarray(features, dtype=np.float64))
     if features.shape[0] != n * (n - 1) // 2:
         features = features.T

--- a/src/logit_graph/temporal_multi.py
+++ b/src/logit_graph/temporal_multi.py
@@ -1,0 +1,248 @@
+"""Multi-feature (unified) Temporal Logit-Graph: the degree-only temporal model extended with
+fixed exogenous dyad covariates, logit P[edge_ij at t] = sigma + alpha*D(t-1) + sum_k beta_k*F_k.
+Every F_k is predetermined, so the pooled dyad design is an ordinary logistic regression whose
+MLE recovers (sigma, alpha, beta_1..beta_k) consistently — no degeneracy."""
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.special import expit
+import statsmodels.api as sm
+
+from .lg_features import FeatureMode, build_pair_dataset
+
+# The feature carrying alpha (the degree slope), read from the previous snapshot.
+DEGREE_MODE: FeatureMode = "bounded"
+
+
+@dataclass
+class MultiGrowthResult:
+    """Output of :func:`grow_graph_multi`: final adjacency ``adj`` (n x n, 0/1, symmetric),
+    pooled design ``X`` (m, 1+k) = [D, F_1..F_k] / outcomes ``y``, the ``feature_names`` for the
+    extra covariates, the ``snapshots`` G(0..n_steps) (empty if not stored), and ``params``."""
+    adj: np.ndarray
+    X: np.ndarray
+    y: np.ndarray
+    feature_names: list
+    snapshots: list
+    params: dict
+
+
+def _degree_feature(adj, d, degree_mode):
+    """Degree feature (D) + current-edge labels over all upper-triangle pairs, in row-major
+    order (matching np.triu_indices(n, 1))."""
+    D, labels = build_pair_dataset(adj, d=d, mode=degree_mode, layer2=True)
+    return np.asarray(D, dtype=np.float64), np.asarray(labels, dtype=np.int8)
+
+
+# ---------------------------------------------------------------------------
+# Exogenous dyad-feature builders (how to construct F_k on a real graph)
+# ---------------------------------------------------------------------------
+
+def _as_adj(graph):
+    """Accept a numpy adjacency or a networkx graph, returning a dense 0/1 ndarray."""
+    if isinstance(graph, np.ndarray):
+        return graph
+    import networkx as nx
+    return nx.to_numpy_array(graph)
+
+
+def community_feature(graph, *, resolution: float = 1.0, seed: int | None = None) -> np.ndarray:
+    """Same-community indicator over upper-triangle dyads from a fixed Louvain partition of the
+    graph at the given resolution (higher resolution -> finer communities). An exogenous node
+    covariate, like SBM uses, so it stays identifiable. Returns a (n*(n-1)/2,) float array."""
+    import networkx as nx
+    A = _as_adj(graph)
+    n = A.shape[0]
+    rows, cols = np.triu_indices(n, k=1)
+    part = nx.community.louvain_communities(nx.from_numpy_array(A), seed=seed, resolution=resolution)
+    blk = np.empty(n, dtype=int)
+    for i, com in enumerate(part):
+        for v in com:
+            blk[v] = i
+    return (blk[rows] == blk[cols]).astype(np.float64)
+
+
+def latent_feature(graph, k: int = 4, *, kind: str = "dot") -> np.ndarray:
+    """Latent proximity over upper-triangle dyads from a rank-k adjacency spectral embedding z
+    (eigvecs scaled by sqrt|eigval|). kind="dot": z_i . z_j (RDPG inner product); kind="dist":
+    -||z_i - z_j|| (Hoff latent-space distance). Standardized; returns a (n*(n-1)/2,) array."""
+    A = _as_adj(graph)
+    n = A.shape[0]
+    rows, cols = np.triu_indices(n, k=1)
+    w, U = np.linalg.eigh(A)
+    idx = np.argsort(-np.abs(w))[:k]
+    z = U[:, idx] * np.sqrt(np.abs(w[idx]))
+    if kind == "dist":
+        L = -np.sqrt(((z[rows] - z[cols]) ** 2).sum(1))
+    else:
+        L = (z[rows] * z[cols]).sum(1)
+    return (L - L.mean()) / (L.std() + 1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+def grow_graph_multi(
+    n: int,
+    d: int,
+    sigma: float,
+    alpha: float,
+    features: np.ndarray,
+    coefs,
+    *,
+    n_steps: int,
+    feature_names: list | None = None,
+    degree_mode: FeatureMode = DEGREE_MODE,
+    allow_removal: bool = True,
+    seed: int | None = None,
+    p0: float = 0.02,
+    record_design: bool = True,
+    store_snapshots: bool = True,
+) -> MultiGrowthResult:
+    """Grow a multi-feature temporal Logit-Graph from a sparse ER seed. ``features`` is an
+    (n*(n-1)/2, k) array of FIXED exogenous dyad covariates (upper-triangle order) with
+    coefficients ``coefs``; each step draws dyads from expit(sigma + alpha*D + features @ coefs),
+    D read from the previous snapshot. allow_removal (default) resamples every dyad (ergodic
+    chain); allow_removal=False grows add-only. Returns the pooled design and outcomes."""
+    features = np.atleast_2d(np.asarray(features, dtype=np.float64))
+    if features.shape[0] != n * (n - 1) // 2:
+        features = features.T
+    coefs = np.asarray(coefs, dtype=np.float64).ravel()
+    k = features.shape[1]
+    if coefs.shape[0] != k:
+        raise ValueError(f"coefs has length {coefs.shape[0]} but features has {k} columns")
+    if feature_names is None:
+        feature_names = [f"f{j}" for j in range(k)]
+    fixed_lo = features @ coefs
+
+    rng = np.random.default_rng(seed)
+    rows, cols = np.triu_indices(n, k=1)
+    adj = np.zeros((n, n), dtype=np.float64)
+    seed_mask = rng.random(rows.shape[0]) < p0
+    adj[rows[seed_mask], cols[seed_mask]] = 1.0
+    adj[cols[seed_mask], rows[seed_mask]] = 1.0
+
+    snapshots = [adj.copy()] if store_snapshots else []
+    Xs: list[np.ndarray] = []
+    ys: list[np.ndarray] = []
+
+    for _ in range(n_steps):
+        D, labels = _degree_feature(adj, d, degree_mode)
+        p = expit(sigma + alpha * D + fixed_lo)
+        draw = rng.random(p.shape[0]) < p
+        design = np.column_stack([D, features])
+        if allow_removal:
+            if record_design:
+                Xs.append(design)
+                ys.append(draw.astype(np.int8))
+            adj[:] = 0.0
+            adj[rows[draw], cols[draw]] = 1.0
+            adj[cols[draw], rows[draw]] = 1.0
+        else:
+            at_risk = labels == 0
+            form = at_risk & draw
+            if record_design:
+                Xs.append(design[at_risk])
+                ys.append(form[at_risk].astype(np.int8))
+            adj[rows[form], cols[form]] = 1.0
+            adj[cols[form], rows[form]] = 1.0
+        if store_snapshots:
+            snapshots.append(adj.copy())
+
+    X = np.vstack(Xs) if Xs else np.empty((0, 1 + k), dtype=np.float64)
+    y = np.concatenate(ys) if ys else np.empty(0, dtype=np.int8)
+    params = dict(n=n, d=d, sigma=sigma, alpha=alpha, coefs=coefs.tolist(),
+                  feature_names=list(feature_names), n_steps=n_steps,
+                  degree_mode=degree_mode, allow_removal=allow_removal, p0=p0)
+    return MultiGrowthResult(adj=adj, X=X, y=y, feature_names=list(feature_names),
+                             snapshots=snapshots, params=params)
+
+
+# ---------------------------------------------------------------------------
+# Estimation
+# ---------------------------------------------------------------------------
+
+def multi_design_from_snapshots(
+    snapshots: list,
+    d: int,
+    features: np.ndarray,
+    *,
+    degree_mode: FeatureMode = DEGREE_MODE,
+    allow_removal: bool = True,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build the pooled [D, F_1..F_k] design from observed snapshots: D from G(t-1), the extra
+    fixed ``features`` repeated each step, outcome from G(t). With allow_removal the design is
+    over all dyads (else the at-risk non-edges). Reproduces grow_graph_multi's recorded design."""
+    features = np.atleast_2d(np.asarray(features, dtype=np.float64))
+    Xs: list[np.ndarray] = []
+    ys: list[np.ndarray] = []
+    for t in range(len(snapshots) - 1):
+        prev = np.asarray(snapshots[t])
+        nxt = np.asarray(snapshots[t + 1])
+        n = prev.shape[0]
+        if features.shape[0] != n * (n - 1) // 2:
+            features = features.T
+        rows, cols = np.triu_indices(n, k=1)
+        D, labels_prev = _degree_feature(prev, d, degree_mode)
+        state = (nxt[rows, cols] > 0)
+        design = np.column_stack([D, features])
+        if allow_removal:
+            Xs.append(design)
+            ys.append(state.astype(np.int8))
+        else:
+            at_risk = labels_prev == 0
+            Xs.append(design[at_risk])
+            ys.append(state[at_risk].astype(np.int8))
+    k = features.shape[1]
+    X = np.vstack(Xs) if Xs else np.empty((0, 1 + k), dtype=np.float64)
+    y = np.concatenate(ys) if ys else np.empty(0, dtype=np.int8)
+    return X, y
+
+
+def fit_multi_params(X: np.ndarray, labels: np.ndarray, feature_names: list | None = None) -> dict:
+    """Fit logit(P) = sigma + alpha*D + sum_k beta_k*F_k by pooled logistic regression — the exact,
+    consistent MLE for the multi-feature temporal model. Returns sigma, alpha, the per-feature
+    coefficients and their SEs, the log-likelihood, AIC, and n_params (solver fallbacks for robustness)."""
+    y = np.asarray(labels, dtype=int)
+    X = np.asarray(X, dtype=np.float64)
+    k = X.shape[1] - 1
+    if feature_names is None:
+        feature_names = [f"f{j}" for j in range(k)]
+    Xc = sm.add_constant(X, has_constant="add")
+    res = None
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for method in ("newton", "bfgs", "lbfgs"):
+            try:
+                r = sm.Logit(y, Xc).fit(method=method, disp=0, maxiter=300)
+                if np.isfinite(r.llf):
+                    res = r
+                    break
+            except Exception:
+                continue
+        if res is None:
+            res = sm.Logit(y, Xc).fit_regularized(method="l1", alpha=1e-4, disp=0)
+
+    b = np.asarray(res.params, dtype=np.float64)
+    try:
+        se = np.asarray(res.bse, dtype=np.float64)
+    except Exception:
+        se = np.full(b.shape[0], np.nan)
+    ll = float(res.llf)
+    n_params = 2 + k
+    out = {
+        "sigma": float(b[0]),
+        "alpha": float(b[1]),
+        "se_sigma": float(se[0]),
+        "se_alpha": float(se[1]),
+        "coefs": {feature_names[j]: float(b[2 + j]) for j in range(k)},
+        "se_coefs": {feature_names[j]: float(se[2 + j]) for j in range(k)},
+        "ll": ll,
+        "aic": 2.0 * n_params - 2.0 * ll,
+        "n_params": n_params,
+    }
+    return out

--- a/tests/test_temporal_multi.py
+++ b/tests/test_temporal_multi.py
@@ -1,0 +1,82 @@
+"""Tests for the multi-feature (unified) temporal Logit-Graph: degree + fixed exogenous covariates."""
+import networkx as nx
+import numpy as np
+
+from logit_graph.temporal_multi import (
+    community_feature,
+    fit_multi_params,
+    grow_graph_multi,
+    latent_feature,
+    multi_design_from_snapshots,
+)
+
+NAMES = ["coarse", "fine", "latent"]
+
+
+def _synthetic_features(n, seed):
+    """Two same-community indicators + a latent inner-product feature, fixed over the trajectory."""
+    rng = np.random.default_rng(seed)
+    rows, cols = np.triu_indices(n, k=1)
+    coarse, fine = rng.integers(0, 4, n), rng.integers(0, 16, n)
+    z = rng.normal(size=(n, 4))
+    Bc = (coarse[rows] == coarse[cols]).astype(float)
+    Bf = (fine[rows] == fine[cols]).astype(float)
+    L = (z[rows] * z[cols]).sum(1)
+    L = (L - L.mean()) / (L.std() + 1e-9)
+    return np.column_stack([Bc, Bf, L])
+
+
+def _fit_at(n, truth, seed):
+    F = _synthetic_features(n, seed)
+    res = grow_graph_multi(n, 0, truth["sigma"], truth["alpha"], F,
+                           [truth["coarse"], truth["fine"], truth["latent"]],
+                           n_steps=6, feature_names=NAMES, allow_removal=True, seed=seed)
+    return fit_multi_params(res.X, res.y, NAMES)
+
+
+def test_recovers_all_five_coefficients():
+    """Generate at a known (sigma, alpha, gc, gf, lam) and recover every coefficient in a loose band."""
+    truth = dict(sigma=-2.0, alpha=0.05, coarse=0.8, fine=0.5, latent=0.4)
+    ests = [_fit_at(220, truth, seed=100 + r) for r in range(6)]
+    sigma = np.mean([e["sigma"] for e in ests])
+    alpha = np.mean([e["alpha"] for e in ests])
+    gc = np.mean([e["coefs"]["coarse"] for e in ests])
+    gf = np.mean([e["coefs"]["fine"] for e in ests])
+    lam = np.mean([e["coefs"]["latent"] for e in ests])
+    assert abs(sigma - truth["sigma"]) < 0.2
+    assert abs(alpha - truth["alpha"]) < 0.02
+    assert abs(gc - truth["coarse"]) < 0.15
+    assert abs(gf - truth["fine"]) < 0.15
+    assert abs(lam - truth["latent"]) < 0.15
+    assert ests[0]["n_params"] == 5  # sigma, alpha + 3 features
+
+
+def test_alpha_consistency_shrinks_with_n():
+    """The spread of alpha_hat should shrink as n grows (consistency of the pooled MLE)."""
+    truth = dict(sigma=-2.0, alpha=0.05, coarse=0.8, fine=0.5, latent=0.4)
+    sd_small = np.std([_fit_at(80, truth, 200 + r)["alpha"] for r in range(6)], ddof=1)
+    sd_large = np.std([_fit_at(240, truth, 300 + r)["alpha"] for r in range(6)], ddof=1)
+    assert sd_large < sd_small
+
+
+def test_design_matches_snapshot_rebuild():
+    """multi_design_from_snapshots reproduces grow_graph_multi's recorded [D, F...] design."""
+    F = _synthetic_features(120, 7)
+    res = grow_graph_multi(120, 0, -2.0, 0.05, F, [0.8, 0.5, 0.4],
+                           n_steps=4, feature_names=NAMES, allow_removal=True, seed=7)
+    X2, y2 = multi_design_from_snapshots(res.snapshots, 0, F, allow_removal=True)
+    assert res.X.shape[1] == 4  # D + 3 features
+    assert np.allclose(res.X, X2)
+    assert np.array_equal(res.y, y2)
+
+
+def test_feature_builders_shape_and_exogeneity():
+    """community_feature / latent_feature return one value per upper-triangle dyad, fixed for a graph."""
+    G = nx.gnp_random_graph(60, 0.1, seed=3)
+    m = 60 * 59 // 2
+    Bc = community_feature(G, seed=0)
+    L = latent_feature(G, k=4, kind="dot")
+    assert Bc.shape == (m,) and L.shape == (m,)
+    assert set(np.unique(Bc)).issubset({0.0, 1.0})       # same-community indicator
+    assert np.allclose(community_feature(G, seed=0), Bc)  # deterministic / exogenous
+    assert abs(L.mean()) < 1e-6 and abs(L.std() - 1.0) < 1e-3  # standardized


### PR DESCRIPTION
Stacked on **#91** (the docs setup) — base is `docs/readthedocs-mkdocs` so the diff is just this feature. After #91 merges, GitHub retargets this to `main`.

## Why

The API reference needs to cover the full model family: **σ + α** (base), **TLG** (temporal), and the **multi-feature extension** (`σ + α·D + γc·Bc + γf·Bf + λ·L`). The first two were already packaged in `temporal.py`; the multi-feature model existed **only** as experiment-script code (`run_tlg_latent_identifiability.py`, `tlg_latent_gic_common.py`) and was therefore not importable or documentable. This builds it into the package.

## New module — `src/logit_graph/temporal_multi.py`

Mirrors `temporal.py`'s API but carries arbitrary fixed exogenous dyad covariates:

- `grow_graph_multi(n, d, sigma, alpha, features, coefs, ...)` — generate; `logit P = σ + α·D(t-1) + features @ coefs`. Supports the add+remove ergodic chain (default) and add-only growth.
- `multi_design_from_snapshots(...)` / `fit_multi_params(X, y, names)` — build the pooled `[D, F...]` design and recover `(σ, α, β₁…βₖ)` by ordinary logistic regression (the exact, consistent MLE), with SEs, AIC, `n_params`.
- `community_feature(graph, ...)` / `latent_feature(graph, k, kind)` — the canonical same-community (Louvain) and latent-embedding (ASE) covariate builders, so the unified model is usable end-to-end on a real graph.
- `MultiGrowthResult` dataclass.

All six are exported from `logit_graph` and added to `__all__`. `temporal.py` is untouched.

## Verification

- **Recovery validated**: generate at known `(σ=-2, α=0.05, γc=0.8, γf=0.5, λ=0.4)`, recover all five — e.g. at n=320: `σ -1.99, α 0.0485, γc 0.79, γf 0.51, λ 0.40`. α's sd shrinks `0.0095 → 0.0035 → 0.0022` as n grows (consistency).
- `tests/test_temporal_multi.py` (4 tests): 5-coefficient recovery, α-consistency, design-from-snapshots reproduction, feature-builder shape/exogeneity. **Pass.**
- Full suite green (same xfails as `main`); `import logit_graph` exports OK.

## Docs

`docs/reference.md` gains a **"The model family"** section (a table mapping each model to its log-odds and packaged symbols, with σ/α/Fₖ explained) and a **"Multi-feature (unified) Temporal Logit-Graph"** autodoc section. `mkdocs.yml` now `watch:`es `src/` so docstring edits hot-reload. `mkdocs build --strict` passes; all new symbols render.