### PR TITLE
Rename Layer-2 → leave-one-out and align remaining naming with the paper/thesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 [Issues](https://github.com/mbottoni/logit-graph/issues) ·
 [Releases](https://github.com/mbottoni/logit-graph/releases)
 
-*Scikit-learn-style API · Layer-2 offset logit · reproducible GIC (`random_state`) · on PyPI as `logit-graph`*
+*Scikit-learn-style API · leave-one-out (full conditional) offset logit · reproducible GIC (`random_state`) · on PyPI as `logit-graph`*
 
 </div>
 
@@ -219,7 +219,7 @@ recover them.
 | `make lg-sigma-convergence` | Fig 2 — σ̂ converges to the true σ as `n` grows. |
 | `make lg-roc-paper` | Figs 3–4 — ANOVA-on-σ̂ ROC curves vs effect size and `n`. |
 | `make lg-aic-paper-fast` | AIC `d`-selection sweep — recovers the true neighborhood radius `d` across `n`. |
-| `make lg-convergence-diagnostics` | MCMC convergence diagnostics for the Layer-2 Gibbs sampler. |
+| `make lg-convergence-diagnostics` | MCMC convergence diagnostics for the leave-one-out (full conditional) Gibbs sampler. |
 
 ### Model selection on real networks (spectral GIC)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -25,7 +25,7 @@ adj = simulate_graph(
 
 | Parameter | Description |
 |-----------|-------------|
-| `n`, `d`, `sigma` | Graph size, feature depth, logit intercept |
+| `n`, `d`, `sigma` | Graph size, neighborhood radius, baseline σ (connection propensity) |
 | `n_iter` | Gibbs iterations (`d≥1`) or ignored (`d=0`, direct ER) |
 | `feature_mode` | `"incremental"` (paper mode), `"bounded"`, or `"full"` |
 | `target_density` | Used when calibrating `β` if `sigma` is omitted |
@@ -35,7 +35,7 @@ adj = simulate_graph(
 
 ## `select_d_ensemble`
 
-Pick `d̂` by AIC over candidate depths using the Layer-2 offset logit.
+Pick the neighborhood radius `d̂` by AIC over candidate radii using the leave-one-out (full conditional) offset logit.
 
 ```python
 from logit_graph import select_d_ensemble
@@ -102,7 +102,7 @@ Sklearn-style fitter at a **fixed** `d`: estimate `σ` and search for a graph mi
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `d` | `0` | Neighborhood depth for degree-sum features |
+| `d` | `0` | Neighborhood radius for the degree-sum feature (`d=0` = own degree) |
 | `n_iteration` | `10000` | Max edge-swap / Gibbs iterations |
 | `warm_up` | `500` | Burn-in before GIC tracking |
 | `patience` | `2000` | Early-stop patience |
@@ -120,10 +120,10 @@ After `fit(G)`: `fitter.fitted_graph`, `fitter.metadata`.
 | Symbol | Role |
 |--------|------|
 | `LogitGraphSimulation` | Lower-level multi-run LG simulation |
-| `LogitRegEstimator` | Layer-2 offset logit on pair features |
+| `LogitRegEstimator` | Leave-one-out (full conditional) offset logit on pair features |
 | `calculate_graph_attributes` | Density, clustering, diameter, assortativity |
 | `recommended_iterations` | Suggested Gibbs length vs `n` |
-| `build_pair_dataset`, `pair_feature`, `pair_feature_layer2` | Feature construction |
+| `build_pair_dataset`, `pair_feature`, `pair_feature_layer2` | Feature construction (`pair_feature_layer2` / `layer2=True` = the leave-one-out / full conditional feature) |
 | `GraphModel` | Core Gibbs / edge-swap engine |
 | `AICSweepConfig`, `SigmaSweepConfig`, `PRESETS` | Experiment presets (`logit_graph.experiments`) |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ from logit_graph import simulate_graph, select_d_ensemble, estimate_sigma_from_g
 adj = simulate_graph(n=200, d=1, sigma=-4.0, n_iter=30_000,
                      feature_mode="incremental", target_density=0.10, seed=42)
 
-# Recover the neighborhood depth by AIC, then the intercept
+# Recover the neighborhood radius d by AIC, then the baseline sigma
 d_hat, aic_stats = select_d_ensemble(graphs=[adj], d_candidates=[0, 1, 2, 3])
 sigma_hat = estimate_sigma_from_graph(adj, d=d_hat, feature_mode="incremental")
 ```

--- a/src/logit_graph/__init__.py
+++ b/src/logit_graph/__init__.py
@@ -1,5 +1,5 @@
-"""Logit Graph: paper-consistent random-graph model with Layer-2 estimation.
-Default exports are paper-consistent (Layer-2, incremental feature, beta=1 offset logit,
+"""Logit Graph: the Logistic Random Graph (LG) model with leave-one-out (full conditional) estimation.
+Default exports are paper-consistent (leave-one-out features, incremental feature, beta=1 offset logit,
 d=0 direct-ER, warm-started Gibbs); legacy estimator classes stay importable for repro."""
 
 from .graph import GraphModel
@@ -83,7 +83,7 @@ __all__ = [
     "growth_design_from_snapshots",
     "fit_growth_params",
     "fit_growth_from_result",
-    # Multi-feature (unified) temporal Logit-Graph
+    # Unified (multi-feature) LG: general pairwise features (paper Sec 3.7)
     "grow_graph_multi",
     "MultiGrowthResult",
     "multi_design_from_snapshots",

--- a/src/logit_graph/experiments/sweeps.py
+++ b/src/logit_graph/experiments/sweeps.py
@@ -449,7 +449,7 @@ def simulate_graph(
     adaptive_min_iter: int = 20_000,
 ) -> np.ndarray | tuple[np.ndarray, dict[str, float]]:
     """Generate a graph at fixed sigma. d=0 uses a direct ER sample at p=expit(sigma)
-    (exact equilibrium, no degree feedback); d>=1 runs Layer-2 Gibbs with the feature
+    (exact equilibrium, no degree feedback); d>=1 runs leave-one-out Gibbs with the feature
     coefficient fixed at beta=1 (matching the paper offset estimator)."""
     if d == 0:
         if sigma is None:

--- a/src/logit_graph/graph.py
+++ b/src/logit_graph/graph.py
@@ -135,7 +135,7 @@ class GraphModel:
         return float(self._degrees[vertex])
 
     def _layer2_feature(self, i: int, j: int) -> float:
-        """Layer-2 pair feature via in-place neighbor-list toggle."""
+        """leave-one-out pair feature via in-place neighbor-list toggle."""
         return pair_feature_layer2_nbrs(
             self._nbrs, i, j, self.d, mode=self.feature_mode,
         )
@@ -207,7 +207,7 @@ class GraphModel:
         self._adj_only = False
 
     def _add_remove_edge_legacy(self) -> None:
-        """Dense-matrix-copy layer-2 path (reference for equivalence tests)."""
+        """Dense-matrix-copy leave-one-out path (reference for equivalence tests)."""
         i = int(self._rng.integers(0, self.n))
         j = int(self._rng.integers(0, self.n - 1))
         if j >= i:

--- a/src/logit_graph/lg_features.py
+++ b/src/logit_graph/lg_features.py
@@ -1,5 +1,5 @@
-"""Neighborhood features for the logistic random graph model. Supports Layer-2
-conditioning (features on the graph with pair (i, j) removed) and the several
+"""Neighborhood features for the Logistic Random Graph (LG) model. Supports the leave-one-out
+(full conditional) feature — evaluated on the graph with pair (i, j) removed — and the several
 feature modes used in the paper experiments."""
 from __future__ import annotations
 
@@ -121,7 +121,7 @@ def pair_feature_layer2(
     mode: FeatureMode = "bounded",
     alpha_gwesp: float = ALPHA_GWESP_DEFAULT,
 ) -> float:
-    """Layer-2 feature: computed on the graph with edge (i,j) removed."""
+    """Leave-one-out (full conditional) feature: computed on the graph with edge (i,j) removed."""
     adj = _adj_from_input(graph).copy()
     had = adj[i, j] > 0
     if had:

--- a/src/logit_graph/lg_features_fast.py
+++ b/src/logit_graph/lg_features_fast.py
@@ -357,7 +357,7 @@ def _sum_ball_degree_skip_rows(
 def _precompute_vertex_ball_sums_skip_rows(
     rows: list, n: int, d: int, mode_code: int,
 ) -> np.ndarray:
-    """Ball-degree sums per vertex for paper_raw / bounded (Layer-2 via -1 fixup)."""
+    """Ball-degree sums per vertex for paper_raw / bounded (leave-one-out via -1 fixup)."""
     sums = np.empty(n, dtype=np.float64)
     for v in range(n):
         raw = _sum_ball_degree_skip_rows(rows, v, d, n, False, -1, -1)
@@ -420,7 +420,7 @@ def build_multi_d_pair_dataset_skip_rows(
     mode_code: int,
     alpha_gwesp: float,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Layer-2 offsets for several ``d`` in one pass over upper-triangle pairs."""
+    """leave-one-out offsets for several ``d`` in one pass over upper-triangle pairs."""
     nd = d_values.shape[0]
     m = n * (n - 1) // 2
     offsets = np.empty((nd, m), dtype=np.float64)
@@ -511,7 +511,7 @@ def build_pair_dataset_skip_rows(
     mode_code: int,
     alpha_gwesp: float,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Layer-2 offsets and edge labels for all upper-triangle pairs."""
+    """leave-one-out offsets and edge labels for all upper-triangle pairs."""
     d_values = np.array([d], dtype=np.int32)
     offsets_2d, labels = build_multi_d_pair_dataset_skip_rows(
         rows, n, d_values, mode_code, alpha_gwesp,
@@ -1085,7 +1085,7 @@ def build_pair_dataset_from_rows(
     mode: FeatureMode = "incremental",
     alpha_gwesp: float = ALPHA_GWESP_DEFAULT,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Layer-2 pair dataset from CSR rows (no dense adjacency conversion)."""
+    """leave-one-out pair dataset from CSR rows (no dense adjacency conversion)."""
     n = len(rows)
     offsets, labels = build_pair_dataset_skip_rows(
         rows, n, d, MODE_TO_CODE[mode], alpha_gwesp,
@@ -1101,7 +1101,7 @@ def build_pair_dataset_fast(
     *,
     rows: Optional[list] = None,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Fast Layer-2 pair dataset via Numba CSR (matches ``build_pair_dataset``)."""
+    """Fast leave-one-out pair dataset via Numba CSR (matches ``build_pair_dataset``)."""
     if rows is None:
         adj = np.asarray(graph, dtype=float)
         rows = rows_from_adj(adj)
@@ -1116,7 +1116,7 @@ def build_multi_d_pair_datasets_fast(
     *,
     rows: Optional[list] = None,
 ) -> tuple[np.ndarray, dict[int, np.ndarray]]:
-    """Fast multi-``d`` Layer-2 pair datasets sharing one CSR + label pass."""
+    """Fast multi-``d`` leave-one-out pair datasets sharing one CSR + label pass."""
     if rows is None:
         adj = np.asarray(graph, dtype=float)
         rows = rows_from_adj(adj)

--- a/src/logit_graph/logit_estimator.py
+++ b/src/logit_graph/logit_estimator.py
@@ -23,15 +23,15 @@ max_val = np.nan
 eps = 1e-5
 
 class NegativeLogLikelihoodLoss(torch.nn.Module if torch is not None else object):
-    """DEPRECATED: paper-raw (alpha*S_i + beta*S_j + sigma) loss without Layer-2
+    """DEPRECATED: paper-raw (alpha*S_i + beta*S_j + sigma) loss without leave-one-out
     conditioning, kept only to reproduce the original notebooks. New code should use
-    :class:`LogitRegEstimator` (Layer-2 aware, with compute_aic / select_d)."""
+    :class:`LogitRegEstimator` (leave-one-out aware, with compute_aic / select_d)."""
 
     def __init__(self, graph: np.ndarray, d: int) -> None:
         super(NegativeLogLikelihoodLoss, self).__init__()
         warnings.warn(
             "NegativeLogLikelihoodLoss is deprecated; use LogitRegEstimator "
-            "(Layer-2 offset logit) for consistent results.",
+            "(leave-one-out offset logit) for consistent results.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -70,14 +70,14 @@ class NegativeLogLikelihoodLoss(torch.nn.Module if torch is not None else object
         return -likelihood  # Return negative likelihood
 
 class MLEGraphModelEstimator:
-    """DEPRECATED: paper-raw MLE without Layer-2 conditioning — the original
+    """DEPRECATED: paper-raw MLE without leave-one-out conditioning — the original
     ``alpha*S_i + beta*S_j + sigma`` form with no edge-removal correction (biased on
-    Layer-2 Gibbs graphs). New code should use :class:`LogitRegEstimator` instead."""
+    leave-one-out Gibbs graphs). New code should use :class:`LogitRegEstimator` instead."""
 
     def __init__(self, graph: np.ndarray, d: int) -> None:
         warnings.warn(
             "MLEGraphModelEstimator is deprecated; use LogitRegEstimator "
-            "(Layer-2 offset logit) for consistent results.",
+            "(leave-one-out offset logit) for consistent results.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/logit_graph/simulation.py
+++ b/src/logit_graph/simulation.py
@@ -57,8 +57,8 @@ def estimate_sigma_only(
     l1_wt: float = 1,
     alpha: float = 0,
 ) -> tuple[float, Any]:
-    """Estimate sigma via Layer-2 offset logit (paper formulation), using
-    :func:`build_pair_dataset` (layer2=True) so it stays consistent with generation.
+    """Estimate sigma via the leave-one-out (full conditional) offset logit (paper formulation),
+    using :func:`build_pair_dataset` (layer2=True) so it stays consistent with generation.
     Returns ``(sigma_hat, fit_result)``; legacy max_edges/max_non_edges/l1_wt/alpha unused."""
     del l1_wt, alpha  # accepted for backwards compatibility, unused
 
@@ -93,7 +93,7 @@ def estimate_sigma_many(
     l1_wt: float = 1,
     alpha: float = 0,
 ) -> list[float]:
-    """Repeat Layer-2 sigma estimation ``n_repeats`` times with different seeds, returning
+    """Repeat the leave-one-out sigma estimation ``n_repeats`` times with different seeds, returning
     a list of ``sigma_hat``. Variability comes from random pair sampling when ``max_pairs``
     is set; with ``max_pairs=None`` on a small graph every repetition is identical."""
     del l1_wt, alpha


### PR DESCRIPTION
Follow-up to the paper-consistency pass: the repo's **"Layer-2"** jargon is the paper/thesis term **leave-one-out (full conditional)** — features evaluated on `G_{-(ij)}`, the graph with edge (i,j) removed (paper §3.4, Eq. 3.3; thesis §2.4). This renames the **terminology in all user-facing prose, docstrings, and docs**, plus a couple of adjacent term fixes.

## Layer-2 → leave-one-out (full conditional)

- Docstrings of exported / reference-rendered symbols: `lg_features` (module + `pair_feature_layer2`), `simulate_graph`, `estimate_sigma_only`, `estimate_sigma_many`, `LogitRegEstimator` + deprecated estimators, package `__init__` docstring, and internal `GraphModel` / numba-helper docstrings.
- Deprecation **warning messages** updated to say "leave-one-out offset logit".
- Docs (`index.md`, `API.md`) and `README.md` prose.

## Other paper-naming fixes found in the audit

- **σ**: "intercept" → **baseline σ (connection propensity)** (paper's term).
- **d**: "neighborhood/feature depth" → **neighborhood radius** (incl. `d=0` = own degree).
- Confirmed **already consistent**: model name (LG / Logistic Random Graph), α = "neighborhood degree effect", baselines ER/BA/WS/KR/GRG/SBM, GIC = 2·KL + 2·|θ|. No "TLG"/"Temporal Logit-Graph"/"Logit Graph model" left in the docs.

## Scope note — code identifiers kept

The **public API symbols** `layer2=True` and `pair_feature_layer2` are **unchanged** (renaming them is a breaking change to the published PyPI package). They're now documented as "the leave-one-out / full conditional feature". If you want true code-level consistency, I can add `leave_one_out` parameter/function aliases with a deprecation path in a separate PR — say the word.

## Verification

- AST guard confirms the bulk source edits are **docstring-only** (no logic change).
- `mkdocs build --strict` passes; **zero** "Layer-2" left in the rendered reference prose.
- Full test suite green (exit 0); package imports.