### PR TITLE
Release 0.2.0 + PyPI trusted-publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish to PyPI
+
+# Tag-triggered release: push a tag like v0.2.0 to build and publish to PyPI via
+# trusted publishing (OIDC) — no API token is stored. The PyPI project must have a
+# trusted publisher configured for this repo, workflow file (publish.yml), and the
+# "pypi" environment before the first run.
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify the tag matches the package version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "tag=$tag  pyproject=$pkg"
+          test "$tag" = "$pkg" || { echo "::error::Tag v$tag does not match pyproject version $pkg"; exit 1; }
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Check metadata
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/logit-graph/
+    permissions:
+      id-token: write  # required for trusted publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-15
+
 ### Added
+- Temporal / growth **Logistic Random Graph (LG)** model: `grow_graph`, `fit_growth_params`,
+  `fit_growth_from_result`, `growth_design_from_snapshots`, `GrowthResult` — generation and
+  consistent leave-one-out (full conditional) estimation of (σ, α).
+- **Unified (multi-feature) LG** — the general-pairwise-features extension (paper §3.7):
+  `grow_graph_multi`, `fit_multi_params`, `multi_design_from_snapshots`, `MultiGrowthResult`,
+  plus the `community_feature` (block membership) and `latent_feature` (latent proximity) builders.
+- Dyadic-cluster-robust standard errors (`robust_se`) and a Stochastic Block Model baseline (`sbm`).
+- MkDocs + Material documentation site with a mkdocstrings API reference, ready for Read the Docs.
+- Tag-triggered PyPI release workflow via GitHub Actions trusted publishing (OIDC, no stored token).
 - Platform batch notebooks with step logging and per-network fit reports (`notebooks/refactors/`).
+
+### Changed
+- Documentation and docstrings aligned with the paper/thesis: the model is the **Logistic Random
+  Graph (LG)** model, Eq. 3.1 notation, and **leave-one-out (full conditional)** terminology
+  (replacing the internal "Layer-2" jargon).
+- Trimmed comments and docstrings across `src/` and `scripts/` to ≤3 lines.
+- Fixed stale repository URLs in `pyproject.toml`.
 
 ## [0.1.4] - 2026-05-26
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "logit-graph"
-version = "0.1.4"
-description = "Probabilistic logit-based graph model and utilities"
+version = "0.2.0"
+description = "Logistic Random Graph (LG) model: generation, leave-one-out estimation, and spectral GIC comparison"
 readme = "README.md"
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
Prepares the **0.2.0** release. Merge this, configure the PyPI trusted publisher (steps below), then the `v0.2.0` tag publishes automatically.

## Changes
- **Version** `0.1.4 → 0.2.0` (minor: new public API since v0.1.4 — 11 new exported symbols across `temporal`, `temporal_multi`, `robust_se`, `sbm`).
- **CHANGELOG** 0.2.0 section (temporal LG, unified multi-feature LG / §3.7, robust SE, SBM baseline, MkDocs/RTD docs, leave-one-out naming).
- **`.github/workflows/publish.yml`** — tag-triggered (`v*`) release via PyPI **trusted publishing** (OIDC, no stored token): builds sdist+wheel, verifies the tag matches `pyproject` version, runs `twine check`, then publishes from the `pypi` environment.

## Verified locally
- `uv build` → `logit_graph-0.2.0` sdist + wheel; `twine check` **PASSED**; new modules (`temporal`, `temporal_multi`) present in the wheel.

## One-time PyPI setup you must do before tagging
On https://pypi.org/manage/project/logit-graph/settings/publishing/ add a **Trusted Publisher**:
- Owner: `mbottoni` · Repository: `logit-graph`
- Workflow filename: `publish.yml`
- Environment name: `pypi`

After that's saved and this PR is merged, the `v0.2.0` tag triggers the publish.